### PR TITLE
feat: Add Financial Reports (Issue #12)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,11 @@ import EditProductService from './pages/EditProductService';
 import Vendors from './pages/Vendors';
 import NewVendor from './pages/NewVendor';
 import EditVendor from './pages/EditVendor';
+import Reports from './pages/Reports';
+import ProfitAndLoss from './pages/reports/ProfitAndLoss';
+import BalanceSheet from './pages/reports/BalanceSheet';
+import TrialBalance from './pages/reports/TrialBalance';
+import ARAgingSummary from './pages/reports/ARAgingSummary';
 import ChatInterface from './components/ChatInterface';
 
 const queryClient = new QueryClient();
@@ -54,6 +59,11 @@ function App() {
             <Route path="reconciliations" element={<BankReconciliations />} />
             <Route path="reconciliations/new" element={<NewReconciliation />} />
             <Route path="reconciliations/:id" element={<NewReconciliation />} />
+            <Route path="reports" element={<Reports />} />
+            <Route path="reports/profit-loss" element={<ProfitAndLoss />} />
+            <Route path="reports/balance-sheet" element={<BalanceSheet />} />
+            <Route path="reports/trial-balance" element={<TrialBalance />} />
+            <Route path="reports/ar-aging" element={<ARAgingSummary />} />
             <Route path="settings" element={<div>Settings Page</div>} />
           </Route>
         </Routes>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useLocation } from 'react-router-dom';
-import { LayoutDashboard, FileText, BookOpen, Settings, Menu, Building2, Upload, CheckCircle, Database, Users, Package, Scale, Truck } from 'lucide-react';
+import { LayoutDashboard, FileText, BookOpen, Settings, Menu, Building2, Upload, CheckCircle, Database, Users, Package, Scale, Truck, BarChart3 } from 'lucide-react';
 import { useState } from 'react';
 import clsx from 'clsx';
 
@@ -19,6 +19,7 @@ export default function Layout() {
     { name: 'Review', href: '/review', icon: CheckCircle },
     { name: 'Transactions', href: '/transactions', icon: Database },
     { name: 'Reconciliation', href: '/reconciliations', icon: Scale },
+    { name: 'Reports', href: '/reports', icon: BarChart3 },
     { name: 'Settings', href: '/settings', icon: Settings },
   ];
 
@@ -35,7 +36,7 @@ export default function Layout() {
         <nav className="p-4 space-y-1">
           {navigation.map((item) => {
             const Icon = item.icon;
-            const isActive = location.pathname === item.href;
+            const isActive = location.pathname === item.href || (item.href !== '/' && location.pathname.startsWith(item.href));
             return (
               <Link
                 key={item.name}

--- a/client/src/components/reports/DateRangePicker.tsx
+++ b/client/src/components/reports/DateRangePicker.tsx
@@ -1,0 +1,176 @@
+import { useState, useRef, useEffect } from 'react';
+import { Calendar, ChevronDown } from 'lucide-react';
+
+interface DateRangePickerProps {
+  startDate: string;
+  endDate: string;
+  onStartDateChange: (date: string) => void;
+  onEndDateChange: (date: string) => void;
+}
+
+type PresetKey = 'thisMonth' | 'lastMonth' | 'thisQuarter' | 'lastQuarter' | 'thisYear' | 'lastYear' | 'custom';
+
+const presets: { key: PresetKey; label: string }[] = [
+  { key: 'thisMonth', label: 'This Month' },
+  { key: 'lastMonth', label: 'Last Month' },
+  { key: 'thisQuarter', label: 'This Quarter' },
+  { key: 'lastQuarter', label: 'Last Quarter' },
+  { key: 'thisYear', label: 'This Year' },
+  { key: 'lastYear', label: 'Last Year' },
+  { key: 'custom', label: 'Custom Range' },
+];
+
+function getPresetDates(preset: PresetKey): { start: string; end: string } | null {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const quarter = Math.floor(month / 3);
+
+  const formatDate = (d: Date) => d.toISOString().split('T')[0];
+
+  switch (preset) {
+    case 'thisMonth':
+      return {
+        start: formatDate(new Date(year, month, 1)),
+        end: formatDate(new Date(year, month + 1, 0)),
+      };
+    case 'lastMonth':
+      return {
+        start: formatDate(new Date(year, month - 1, 1)),
+        end: formatDate(new Date(year, month, 0)),
+      };
+    case 'thisQuarter':
+      return {
+        start: formatDate(new Date(year, quarter * 3, 1)),
+        end: formatDate(new Date(year, quarter * 3 + 3, 0)),
+      };
+    case 'lastQuarter':
+      return {
+        start: formatDate(new Date(year, (quarter - 1) * 3, 1)),
+        end: formatDate(new Date(year, quarter * 3, 0)),
+      };
+    case 'thisYear':
+      return {
+        start: formatDate(new Date(year, 0, 1)),
+        end: formatDate(new Date(year, 11, 31)),
+      };
+    case 'lastYear':
+      return {
+        start: formatDate(new Date(year - 1, 0, 1)),
+        end: formatDate(new Date(year - 1, 11, 31)),
+      };
+    default:
+      return null;
+  }
+}
+
+export default function DateRangePicker({
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+}: DateRangePickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedPreset, setSelectedPreset] = useState<PresetKey>('custom');
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handlePresetSelect = (preset: PresetKey) => {
+    setSelectedPreset(preset);
+    const dates = getPresetDates(preset);
+    if (dates) {
+      onStartDateChange(dates.start);
+      onEndDateChange(dates.end);
+    }
+    if (preset !== 'custom') {
+      setIsOpen(false);
+    }
+  };
+
+  const formatDisplayDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="relative print:hidden" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+      >
+        <Calendar className="h-4 w-4 text-gray-400" />
+        <span>
+          {formatDisplayDate(startDate)} - {formatDisplayDate(endDate)}
+        </span>
+        <ChevronDown className="h-4 w-4 text-gray-400" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-10 mt-2 w-80 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
+          <div className="p-4">
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              {presets.map((preset) => (
+                <button
+                  key={preset.key}
+                  onClick={() => handlePresetSelect(preset.key)}
+                  className={`px-3 py-2 text-sm rounded-md ${
+                    selectedPreset === preset.key
+                      ? 'bg-indigo-100 text-indigo-700 font-medium'
+                      : 'text-gray-700 hover:bg-gray-100'
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="border-t border-gray-200 pt-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1">
+                    Start Date
+                  </label>
+                  <input
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => {
+                      onStartDateChange(e.target.value);
+                      setSelectedPreset('custom');
+                    }}
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1">
+                    End Date
+                  </label>
+                  <input
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => {
+                      onEndDateChange(e.target.value);
+                      setSelectedPreset('custom');
+                    }}
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/reports/ReportHeader.tsx
+++ b/client/src/components/reports/ReportHeader.tsx
@@ -1,0 +1,55 @@
+import { Printer, Download } from 'lucide-react';
+
+interface ReportHeaderProps {
+  title: string;
+  subtitle?: string;
+  dateRange?: string;
+  onExportCSV?: () => void;
+}
+
+export default function ReportHeader({
+  title,
+  subtitle,
+  dateRange,
+  onExportCSV,
+}: ReportHeaderProps) {
+  const handlePrint = () => {
+    window.print();
+  };
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 print:text-xl">{title}</h1>
+          {subtitle && (
+            <p className="mt-1 text-sm text-gray-500 print:text-xs">{subtitle}</p>
+          )}
+          {dateRange && (
+            <p className="mt-1 text-sm font-medium text-gray-700 print:text-xs">
+              {dateRange}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2 print:hidden">
+          <button
+            onClick={handlePrint}
+            className="inline-flex items-center gap-1.5 px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            <Printer className="h-4 w-4" />
+            Print
+          </button>
+          {onExportCSV && (
+            <button
+              onClick={onExportCSV}
+              className="inline-flex items-center gap-1.5 px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              <Download className="h-4 w-4" />
+              Export CSV
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/reports/ReportTable.tsx
+++ b/client/src/components/reports/ReportTable.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from 'react';
+
+export interface ReportColumn {
+  key: string;
+  header: string;
+  align?: 'left' | 'right' | 'center';
+  className?: string;
+  format?: (value: any, row: any) => ReactNode;
+}
+
+export interface ReportRow {
+  [key: string]: any;
+  isHeader?: boolean;
+  isTotal?: boolean;
+  isSubtotal?: boolean;
+  indent?: number;
+}
+
+interface ReportTableProps {
+  columns: ReportColumn[];
+  data: ReportRow[];
+}
+
+export function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+export function exportToCSV(filename: string, columns: ReportColumn[], data: ReportRow[]) {
+  const headers = columns.map((col) => col.header);
+  const rows = data.map((row) =>
+    columns.map((col) => {
+      const value = row[col.key];
+      if (value === undefined || value === null) return '';
+      if (typeof value === 'number') return value.toString();
+      return `"${String(value).replace(/"/g, '""')}"`;
+    })
+  );
+
+  const csvContent = [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `${filename}.csv`;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
+export default function ReportTable({ columns, data }: ReportTableProps) {
+  const getAlignment = (align?: 'left' | 'right' | 'center') => {
+    switch (align) {
+      case 'right':
+        return 'text-right';
+      case 'center':
+        return 'text-center';
+      default:
+        return 'text-left';
+    }
+  };
+
+  const getRowClasses = (row: ReportRow) => {
+    const classes: string[] = [];
+    if (row.isHeader) {
+      classes.push('bg-gray-50 font-semibold text-gray-900');
+    } else if (row.isTotal) {
+      classes.push('bg-gray-100 font-bold text-gray-900 border-t-2 border-gray-300');
+    } else if (row.isSubtotal) {
+      classes.push('font-semibold text-gray-800 border-t border-gray-200');
+    }
+    return classes.join(' ');
+  };
+
+  const getCellClasses = (row: ReportRow, column: ReportColumn) => {
+    const classes: string[] = [
+      'px-4 py-2 print:px-2 print:py-1 print:text-xs',
+      getAlignment(column.align),
+    ];
+    if (row.indent && column.key === columns[0].key) {
+      classes.push(`pl-${4 + row.indent * 4}`);
+    }
+    if (column.className) {
+      classes.push(column.className);
+    }
+    return classes.join(' ');
+  };
+
+  return (
+    <table className="min-w-full divide-y divide-gray-200">
+      <thead className="bg-gray-50 print:bg-white">
+        <tr>
+          {columns.map((column) => (
+            <th
+              key={column.key}
+              className={`px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider print:px-2 print:py-1 ${getAlignment(
+                column.align
+              )}`}
+            >
+              {column.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="bg-white divide-y divide-gray-200">
+        {data.map((row, rowIndex) => (
+          <tr key={rowIndex} className={getRowClasses(row)}>
+            {columns.map((column) => (
+              <td key={column.key} className={getCellClasses(row, column)}>
+                {column.format
+                  ? column.format(row[column.key], row)
+                  : row[column.key] ?? ''}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/client/src/components/reports/index.ts
+++ b/client/src/components/reports/index.ts
@@ -1,0 +1,4 @@
+export { default as DateRangePicker } from './DateRangePicker';
+export { default as ReportHeader } from './ReportHeader';
+export { default as ReportTable, formatCurrency, exportToCSV } from './ReportTable';
+export type { ReportColumn, ReportRow } from './ReportTable';

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -1,0 +1,66 @@
+import { Link } from 'react-router-dom';
+import { TrendingUp, Scale, List, Clock } from 'lucide-react';
+
+const reports = [
+  {
+    name: 'Profit & Loss',
+    description: 'Income statement showing revenues, expenses, and net income over a period',
+    href: '/reports/profit-loss',
+    icon: TrendingUp,
+    color: 'bg-green-100 text-green-600',
+  },
+  {
+    name: 'Balance Sheet',
+    description: 'Statement of financial position showing assets, liabilities, and equity',
+    href: '/reports/balance-sheet',
+    icon: Scale,
+    color: 'bg-blue-100 text-blue-600',
+  },
+  {
+    name: 'Trial Balance',
+    description: 'List of all accounts with their debit and credit balances',
+    href: '/reports/trial-balance',
+    icon: List,
+    color: 'bg-purple-100 text-purple-600',
+  },
+  {
+    name: 'AR Aging Summary',
+    description: 'Outstanding customer invoices organized by age',
+    href: '/reports/ar-aging',
+    icon: Clock,
+    color: 'bg-orange-100 text-orange-600',
+  },
+];
+
+export default function Reports() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Financial Reports</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Generate and view financial reports for your business
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {reports.map((report) => (
+          <Link
+            key={report.name}
+            to={report.href}
+            className="block p-6 bg-white rounded-lg shadow hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-start gap-4">
+              <div className={`p-3 rounded-lg ${report.color}`}>
+                <report.icon className="h-6 w-6" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">{report.name}</h2>
+                <p className="mt-1 text-sm text-gray-500">{report.description}</p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/ARAgingSummary.tsx
+++ b/client/src/pages/reports/ARAgingSummary.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { ReportHeader, ReportTable, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Customer { Id: string; Name: string; }
+interface Invoice { Id: string; InvoiceNumber: string; CustomerId: string; IssueDate: string; DueDate: string; TotalAmount: number; Status: string; }
+interface AgingBucket { current: number; days1to30: number; days31to60: number; days61to90: number; days90plus: number; total: number; }
+
+function createEmptyBucket(): AgingBucket { return { current: 0, days1to30: 0, days31to60: 0, days61to90: 0, days90plus: 0, total: 0 }; }
+
+export default function ARAgingSummary() {
+  const { data: customers, isLoading: loadingCustomers } = useQuery({ queryKey: ['customers'], queryFn: async () => { const r = await fetch('/api/customers'); const d = await r.json(); return d.value as Customer[]; } });
+  const { data: invoices, isLoading: loadingInvoices } = useQuery({ queryKey: ['invoices'], queryFn: async () => { const r = await fetch('/api/invoices'); const d = await r.json(); return d.value as Invoice[]; } });
+
+  const reportData = useMemo(() => {
+    if (!customers || !invoices) return { customerAging: [], totals: createEmptyBucket() };
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const outstandingInvoices = invoices.filter(inv => inv.Status !== 'Paid' && inv.Status !== 'Cancelled' && inv.Status !== 'Voided');
+    const customerMap = new Map(customers.map(c => [c.Id, c]));
+    const customerAging = new Map<string, { customer: Customer; aging: AgingBucket }>();
+    outstandingInvoices.forEach(invoice => { const customer = customerMap.get(invoice.CustomerId); if (!customer) return; const dueDate = new Date(invoice.DueDate); const daysPastDue = Math.floor((today.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24)); let existing = customerAging.get(invoice.CustomerId); if (!existing) { existing = { customer, aging: createEmptyBucket() }; customerAging.set(invoice.CustomerId, existing); } const amount = invoice.TotalAmount; if (daysPastDue <= 0) existing.aging.current += amount; else if (daysPastDue <= 30) existing.aging.days1to30 += amount; else if (daysPastDue <= 60) existing.aging.days31to60 += amount; else if (daysPastDue <= 90) existing.aging.days61to90 += amount; else existing.aging.days90plus += amount; existing.aging.total += amount; });
+    const result = Array.from(customerAging.values()).filter(item => item.aging.total > 0).sort((a, b) => a.customer.Name.localeCompare(b.customer.Name));
+    const totals = createEmptyBucket(); result.forEach(({ aging }) => { totals.current += aging.current; totals.days1to30 += aging.days1to30; totals.days31to60 += aging.days31to60; totals.days61to90 += aging.days61to90; totals.days90plus += aging.days90plus; totals.total += aging.total; });
+    return { customerAging: result, totals };
+  }, [customers, invoices]);
+
+  const columns: ReportColumn[] = [{ key: 'customer', header: 'Customer', align: 'left' }, { key: 'current', header: 'Current', align: 'right', format: (value) => value ? formatCurrency(value) : '-' }, { key: 'days1to30', header: '1-30 Days', align: 'right', format: (value) => value ? formatCurrency(value) : '-' }, { key: 'days31to60', header: '31-60 Days', align: 'right', format: (value) => value ? formatCurrency(value) : '-' }, { key: 'days61to90', header: '61-90 Days', align: 'right', format: (value) => value ? formatCurrency(value) : '-' }, { key: 'days90plus', header: '90+ Days', align: 'right', format: (value) => value ? formatCurrency(value) : '-' }, { key: 'total', header: 'Total', align: 'right', format: (value) => formatCurrency(value) }];
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = reportData.customerAging.map(({ customer, aging }) => ({ customer: customer.Name, current: aging.current || undefined, days1to30: aging.days1to30 || undefined, days31to60: aging.days31to60 || undefined, days61to90: aging.days61to90 || undefined, days90plus: aging.days90plus || undefined, total: aging.total }));
+    rows.push({ customer: 'Total', current: reportData.totals.current || undefined, days1to30: reportData.totals.days1to30 || undefined, days31to60: reportData.totals.days31to60 || undefined, days61to90: reportData.totals.days61to90 || undefined, days90plus: reportData.totals.days90plus || undefined, total: reportData.totals.total, isTotal: true });
+    return rows;
+  }, [reportData]);
+
+  const handleExportCSV = () => { const today = new Date().toISOString().split('T')[0]; exportToCSV(`ar-aging-summary-${today}`, columns, tableData); };
+  if (loadingCustomers || loadingInvoices) return <div className="max-w-6xl mx-auto"><div className="p-4">Loading AR Aging data...</div></div>;
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-4 print:hidden"><Link to="/reports" className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"><ArrowLeft className="h-4 w-4 mr-1" />Back to Reports</Link></div>
+      <ReportHeader title="Accounts Receivable Aging Summary" subtitle="Outstanding invoices by age" dateRange={`As of ${new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`} onExportCSV={handleExportCSV} />
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-4 mb-6 print:hidden">
+        <div className="bg-white rounded-lg shadow p-4"><div className="text-xs text-gray-500 uppercase">Current</div><div className="text-lg font-semibold text-gray-900">{formatCurrency(reportData.totals.current)}</div></div>
+        <div className="bg-white rounded-lg shadow p-4"><div className="text-xs text-gray-500 uppercase">1-30 Days</div><div className="text-lg font-semibold text-yellow-600">{formatCurrency(reportData.totals.days1to30)}</div></div>
+        <div className="bg-white rounded-lg shadow p-4"><div className="text-xs text-gray-500 uppercase">31-60 Days</div><div className="text-lg font-semibold text-orange-600">{formatCurrency(reportData.totals.days31to60)}</div></div>
+        <div className="bg-white rounded-lg shadow p-4"><div className="text-xs text-gray-500 uppercase">61-90 Days</div><div className="text-lg font-semibold text-red-500">{formatCurrency(reportData.totals.days61to90)}</div></div>
+        <div className="bg-white rounded-lg shadow p-4"><div className="text-xs text-gray-500 uppercase">90+ Days</div><div className="text-lg font-semibold text-red-700">{formatCurrency(reportData.totals.days90plus)}</div></div>
+        <div className="bg-indigo-50 rounded-lg shadow p-4"><div className="text-xs text-indigo-600 uppercase font-medium">Total AR</div><div className="text-lg font-bold text-indigo-700">{formatCurrency(reportData.totals.total)}</div></div>
+      </div>
+      <div className="bg-white shadow rounded-lg overflow-hidden">{reportData.customerAging.length === 0 ? <div className="p-8 text-center text-gray-500"><p>No outstanding invoices found.</p></div> : <ReportTable columns={columns} data={tableData} />}</div>
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs"><p>Generated on {new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</p></div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/BalanceSheet.tsx
+++ b/client/src/pages/reports/BalanceSheet.tsx
@@ -1,0 +1,61 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { ReportHeader, ReportTable, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Account { Id: string; Name: string; Type: string; Subtype: string | null; }
+interface JournalEntry { Id: string; TransactionDate: string; }
+interface JournalEntryLine { Id: string; JournalEntryId: string; AccountId: string; Debit: number; Credit: number; }
+
+export default function BalanceSheet() {
+  const today = new Date();
+  const [asOfDate, setAsOfDate] = useState(today.toISOString().split('T')[0]);
+
+  const { data: accounts } = useQuery({ queryKey: ['accounts'], queryFn: async () => { const r = await fetch('/api/accounts'); const d = await r.json(); return d.value as Account[]; } });
+  const { data: journalEntries } = useQuery({ queryKey: ['journal-entries'], queryFn: async () => { const r = await fetch('/api/journalentries'); const d = await r.json(); return d.value as JournalEntry[]; } });
+  const { data: lines } = useQuery({ queryKey: ['journal-entry-lines'], queryFn: async () => { const r = await fetch('/api/journalentrylines'); const d = await r.json(); return d.value as JournalEntryLine[]; } });
+
+  const reportData = useMemo(() => {
+    if (!accounts || !journalEntries || !lines) return { assetAccounts: [], liabilityAccounts: [], equityAccounts: [], totalAssets: 0, totalLiabilities: 0, totalEquity: 0, retainedEarnings: 0 };
+    const accountMap = new Map(accounts.map(a => [a.Id, a]));
+    const entryDateMap = new Map(journalEntries.map(e => [e.Id, new Date(e.TransactionDate)]));
+    const end = new Date(asOfDate); end.setHours(23, 59, 59, 999);
+    const filteredLines = lines.filter(line => { const date = entryDateMap.get(line.JournalEntryId); return date && date <= end; });
+    const accountTotals = new Map<string, number>(); let retainedEarnings = 0;
+    filteredLines.forEach(line => { const account = accountMap.get(line.AccountId); if (!account) return; const current = accountTotals.get(line.AccountId) || 0; switch (account.Type) { case 'Asset': accountTotals.set(line.AccountId, current + (line.Debit - line.Credit)); break; case 'Liability': accountTotals.set(line.AccountId, current + (line.Credit - line.Debit)); break; case 'Equity': accountTotals.set(line.AccountId, current + (line.Credit - line.Debit)); break; case 'Revenue': retainedEarnings += line.Credit - line.Debit; break; case 'Expense': retainedEarnings -= line.Debit - line.Credit; break; } });
+    const assetAccounts: { account: Account; balance: number }[] = []; const liabilityAccounts: { account: Account; balance: number }[] = []; const equityAccounts: { account: Account; balance: number }[] = [];
+    accountTotals.forEach((balance, accountId) => { const account = accountMap.get(accountId); if (!account || balance === 0) return; switch (account.Type) { case 'Asset': assetAccounts.push({ account, balance }); break; case 'Liability': liabilityAccounts.push({ account, balance }); break; case 'Equity': equityAccounts.push({ account, balance }); break; } });
+    assetAccounts.sort((a, b) => a.account.Name.localeCompare(b.account.Name)); liabilityAccounts.sort((a, b) => a.account.Name.localeCompare(b.account.Name)); equityAccounts.sort((a, b) => a.account.Name.localeCompare(b.account.Name));
+    return { assetAccounts, liabilityAccounts, equityAccounts, totalAssets: assetAccounts.reduce((sum, a) => sum + a.balance, 0), totalLiabilities: liabilityAccounts.reduce((sum, a) => sum + a.balance, 0), totalEquity: equityAccounts.reduce((sum, a) => sum + a.balance, 0) + retainedEarnings, retainedEarnings };
+  }, [accounts, journalEntries, lines, asOfDate]);
+
+  const columns: ReportColumn[] = [{ key: 'name', header: 'Account', align: 'left' }, { key: 'amount', header: 'Amount', align: 'right', format: (value) => value !== undefined ? formatCurrency(value) : '' }];
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = [{ name: 'ASSETS', amount: undefined, isHeader: true }];
+    reportData.assetAccounts.forEach(({ account, balance }) => rows.push({ name: account.Name, amount: balance, indent: 1 }));
+    rows.push({ name: 'Total Assets', amount: reportData.totalAssets, isSubtotal: true }, { name: '', amount: undefined }, { name: 'LIABILITIES', amount: undefined, isHeader: true });
+    reportData.liabilityAccounts.forEach(({ account, balance }) => rows.push({ name: account.Name, amount: balance, indent: 1 }));
+    rows.push({ name: 'Total Liabilities', amount: reportData.totalLiabilities, isSubtotal: true }, { name: '', amount: undefined }, { name: 'EQUITY', amount: undefined, isHeader: true });
+    reportData.equityAccounts.forEach(({ account, balance }) => rows.push({ name: account.Name, amount: balance, indent: 1 }));
+    if (reportData.retainedEarnings !== 0) rows.push({ name: 'Retained Earnings', amount: reportData.retainedEarnings, indent: 1 });
+    rows.push({ name: 'Total Equity', amount: reportData.totalEquity, isSubtotal: true }, { name: '', amount: undefined }, { name: 'Total Liabilities & Equity', amount: reportData.totalLiabilities + reportData.totalEquity, isTotal: true });
+    return rows;
+  }, [reportData]);
+
+  const handleExportCSV = () => exportToCSV(`balance-sheet-${asOfDate}`, columns, tableData.filter(row => row.name));
+  const formatAsOfDate = () => `As of ${new Date(asOfDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`;
+  const isBalanced = Math.abs(reportData.totalAssets - (reportData.totalLiabilities + reportData.totalEquity)) < 0.01;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-4 print:hidden"><Link to="/reports" className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"><ArrowLeft className="h-4 w-4 mr-1" />Back to Reports</Link></div>
+      <ReportHeader title="Balance Sheet" subtitle="Statement of Financial Position" dateRange={formatAsOfDate()} onExportCSV={handleExportCSV} />
+      <div className="mb-6 print:hidden"><div className="flex items-center gap-4"><label className="text-sm font-medium text-gray-700">As of Date:</label><input type="date" value={asOfDate} onChange={(e) => setAsOfDate(e.target.value)} className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" /></div></div>
+      <div className="bg-white shadow rounded-lg overflow-hidden"><ReportTable columns={columns} data={tableData} /></div>
+      {!isBalanced && <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-md"><p className="text-sm text-yellow-800"><strong>Warning:</strong> The balance sheet is out of balance. Assets ({formatCurrency(reportData.totalAssets)}) do not equal Liabilities + Equity ({formatCurrency(reportData.totalLiabilities + reportData.totalEquity)}).</p></div>}
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs"><p>Generated on {new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</p></div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/ProfitAndLoss.tsx
+++ b/client/src/pages/reports/ProfitAndLoss.tsx
@@ -1,0 +1,58 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { DateRangePicker, ReportHeader, ReportTable, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Account { Id: string; Name: string; Type: string; Subtype: string | null; }
+interface JournalEntry { Id: string; TransactionDate: string; }
+interface JournalEntryLine { Id: string; JournalEntryId: string; AccountId: string; Debit: number; Credit: number; }
+
+export default function ProfitAndLoss() {
+  const today = new Date();
+  const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const [startDate, setStartDate] = useState(firstDayOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(today.toISOString().split('T')[0]);
+
+  const { data: accounts } = useQuery({ queryKey: ['accounts'], queryFn: async () => { const r = await fetch('/api/accounts'); const d = await r.json(); return d.value as Account[]; } });
+  const { data: journalEntries } = useQuery({ queryKey: ['journal-entries'], queryFn: async () => { const r = await fetch('/api/journalentries'); const d = await r.json(); return d.value as JournalEntry[]; } });
+  const { data: lines } = useQuery({ queryKey: ['journal-entry-lines'], queryFn: async () => { const r = await fetch('/api/journalentrylines'); const d = await r.json(); return d.value as JournalEntryLine[]; } });
+
+  const reportData = useMemo(() => {
+    if (!accounts || !journalEntries || !lines) return { revenueAccounts: [], expenseAccounts: [], totalRevenue: 0, totalExpenses: 0 };
+    const accountMap = new Map(accounts.map(a => [a.Id, a]));
+    const entryDateMap = new Map(journalEntries.map(e => [e.Id, new Date(e.TransactionDate)]));
+    const start = new Date(startDate); const end = new Date(endDate); end.setHours(23, 59, 59, 999);
+    const filteredLines = lines.filter(line => { const date = entryDateMap.get(line.JournalEntryId); return date && date >= start && date <= end; });
+    const accountTotals = new Map<string, number>();
+    filteredLines.forEach(line => { const account = accountMap.get(line.AccountId); if (!account) return; const current = accountTotals.get(line.AccountId) || 0; if (account.Type === 'Revenue') accountTotals.set(line.AccountId, current + (line.Credit - line.Debit)); else if (account.Type === 'Expense') accountTotals.set(line.AccountId, current + (line.Debit - line.Credit)); });
+    const revenueAccounts: { account: Account; balance: number }[] = []; const expenseAccounts: { account: Account; balance: number }[] = [];
+    accountTotals.forEach((balance, accountId) => { const account = accountMap.get(accountId); if (!account || balance === 0) return; if (account.Type === 'Revenue') revenueAccounts.push({ account, balance }); else if (account.Type === 'Expense') expenseAccounts.push({ account, balance }); });
+    revenueAccounts.sort((a, b) => a.account.Name.localeCompare(b.account.Name)); expenseAccounts.sort((a, b) => a.account.Name.localeCompare(b.account.Name));
+    return { revenueAccounts, expenseAccounts, totalRevenue: revenueAccounts.reduce((sum, a) => sum + a.balance, 0), totalExpenses: expenseAccounts.reduce((sum, a) => sum + a.balance, 0) };
+  }, [accounts, journalEntries, lines, startDate, endDate]);
+
+  const columns: ReportColumn[] = [{ key: 'name', header: 'Account', align: 'left' }, { key: 'amount', header: 'Amount', align: 'right', format: (value) => value !== undefined ? formatCurrency(value) : '' }];
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = [{ name: 'Revenue', amount: undefined, isHeader: true }];
+    reportData.revenueAccounts.forEach(({ account, balance }) => rows.push({ name: account.Name, amount: balance, indent: 1 }));
+    rows.push({ name: 'Total Revenue', amount: reportData.totalRevenue, isSubtotal: true }, { name: '', amount: undefined }, { name: 'Expenses', amount: undefined, isHeader: true });
+    reportData.expenseAccounts.forEach(({ account, balance }) => rows.push({ name: account.Name, amount: balance, indent: 1 }));
+    rows.push({ name: 'Total Expenses', amount: reportData.totalExpenses, isSubtotal: true }, { name: '', amount: undefined }, { name: 'Net Income', amount: reportData.totalRevenue - reportData.totalExpenses, isTotal: true });
+    return rows;
+  }, [reportData]);
+
+  const handleExportCSV = () => exportToCSV(`profit-loss-${startDate}-to-${endDate}`, columns, tableData.filter(row => row.name));
+  const formatDateRange = () => `${new Date(startDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })} - ${new Date(endDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-4 print:hidden"><Link to="/reports" className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"><ArrowLeft className="h-4 w-4 mr-1" />Back to Reports</Link></div>
+      <ReportHeader title="Profit & Loss Statement" subtitle="Income Statement" dateRange={formatDateRange()} onExportCSV={handleExportCSV} />
+      <div className="mb-6"><DateRangePicker startDate={startDate} endDate={endDate} onStartDateChange={setStartDate} onEndDateChange={setEndDate} /></div>
+      <div className="bg-white shadow rounded-lg overflow-hidden"><ReportTable columns={columns} data={tableData} /></div>
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs"><p>Generated on {new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</p></div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/TrialBalance.tsx
+++ b/client/src/pages/reports/TrialBalance.tsx
@@ -1,0 +1,56 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, CheckCircle, AlertTriangle } from 'lucide-react';
+import { ReportHeader, ReportTable, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Account { Id: string; Name: string; Type: string; Subtype: string | null; }
+interface JournalEntry { Id: string; TransactionDate: string; }
+interface JournalEntryLine { Id: string; JournalEntryId: string; AccountId: string; Debit: number; Credit: number; }
+
+export default function TrialBalance() {
+  const today = new Date();
+  const [asOfDate, setAsOfDate] = useState(today.toISOString().split('T')[0]);
+
+  const { data: accounts } = useQuery({ queryKey: ['accounts'], queryFn: async () => { const r = await fetch('/api/accounts'); const d = await r.json(); return d.value as Account[]; } });
+  const { data: journalEntries } = useQuery({ queryKey: ['journal-entries'], queryFn: async () => { const r = await fetch('/api/journalentries'); const d = await r.json(); return d.value as JournalEntry[]; } });
+  const { data: lines } = useQuery({ queryKey: ['journal-entry-lines'], queryFn: async () => { const r = await fetch('/api/journalentrylines'); const d = await r.json(); return d.value as JournalEntryLine[]; } });
+
+  const reportData = useMemo(() => {
+    if (!accounts || !journalEntries || !lines) return { accountBalances: [], totalDebits: 0, totalCredits: 0 };
+    const accountMap = new Map(accounts.map(a => [a.Id, a]));
+    const entryDateMap = new Map(journalEntries.map(e => [e.Id, new Date(e.TransactionDate)]));
+    const end = new Date(asOfDate); end.setHours(23, 59, 59, 999);
+    const filteredLines = lines.filter(line => { const date = entryDateMap.get(line.JournalEntryId); return date && date <= end; });
+    const accountTotals = new Map<string, { debits: number; credits: number }>();
+    filteredLines.forEach(line => { const current = accountTotals.get(line.AccountId) || { debits: 0, credits: 0 }; accountTotals.set(line.AccountId, { debits: current.debits + line.Debit, credits: current.credits + line.Credit }); });
+    const accountBalances: { account: Account; debit: number; credit: number }[] = [];
+    accountTotals.forEach(({ debits, credits }, accountId) => { const account = accountMap.get(accountId); if (!account) return; const netBalance = debits - credits; const isNormallyDebit = ['Asset', 'Expense'].includes(account.Type); let debit = 0, credit = 0; if (isNormallyDebit) { if (netBalance >= 0) debit = netBalance; else credit = -netBalance; } else { if (netBalance <= 0) credit = -netBalance; else debit = netBalance; } if (debit !== 0 || credit !== 0) accountBalances.push({ account, debit, credit }); });
+    const typeOrder = ['Asset', 'Liability', 'Equity', 'Revenue', 'Expense'];
+    accountBalances.sort((a, b) => { const typeCompare = typeOrder.indexOf(a.account.Type) - typeOrder.indexOf(b.account.Type); if (typeCompare !== 0) return typeCompare; return a.account.Name.localeCompare(b.account.Name); });
+    return { accountBalances, totalDebits: accountBalances.reduce((sum, a) => sum + a.debit, 0), totalCredits: accountBalances.reduce((sum, a) => sum + a.credit, 0) };
+  }, [accounts, journalEntries, lines, asOfDate]);
+
+  const columns: ReportColumn[] = [{ key: 'accountNumber', header: 'Account #', align: 'left' }, { key: 'name', header: 'Account Name', align: 'left' }, { key: 'type', header: 'Type', align: 'left' }, { key: 'debit', header: 'Debit', align: 'right', format: (value) => value ? formatCurrency(value) : '' }, { key: 'credit', header: 'Credit', align: 'right', format: (value) => value ? formatCurrency(value) : '' }];
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = reportData.accountBalances.map(({ account, debit, credit }) => ({ accountNumber: account.Id.slice(0, 8), name: account.Name, type: account.Type, debit: debit || undefined, credit: credit || undefined }));
+    rows.push({ accountNumber: '', name: 'Totals', type: '', debit: reportData.totalDebits, credit: reportData.totalCredits, isTotal: true });
+    return rows;
+  }, [reportData]);
+
+  const handleExportCSV = () => exportToCSV(`trial-balance-${asOfDate}`, columns, tableData);
+  const formatAsOfDate = () => `As of ${new Date(asOfDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`;
+  const isBalanced = Math.abs(reportData.totalDebits - reportData.totalCredits) < 0.01;
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-4 print:hidden"><Link to="/reports" className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"><ArrowLeft className="h-4 w-4 mr-1" />Back to Reports</Link></div>
+      <ReportHeader title="Trial Balance" dateRange={formatAsOfDate()} onExportCSV={handleExportCSV} />
+      <div className="mb-6 print:hidden"><div className="flex items-center gap-4"><label className="text-sm font-medium text-gray-700">As of Date:</label><input type="date" value={asOfDate} onChange={(e) => setAsOfDate(e.target.value)} className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" /></div></div>
+      <div className={`mb-6 p-4 rounded-lg flex items-center gap-3 ${isBalanced ? 'bg-green-50 border border-green-200' : 'bg-red-50 border border-red-200'}`}>{isBalanced ? (<><CheckCircle className="h-5 w-5 text-green-600" /><span className="text-green-800 font-medium">Trial Balance is in balance</span></>) : (<><AlertTriangle className="h-5 w-5 text-red-600" /><span className="text-red-800 font-medium">Trial Balance is OUT OF BALANCE by {formatCurrency(Math.abs(reportData.totalDebits - reportData.totalCredits))}</span></>)}</div>
+      <div className="bg-white shadow rounded-lg overflow-hidden"><ReportTable columns={columns} data={tableData} /></div>
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs"><p>Generated on {new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</p></div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/index.ts
+++ b/client/src/pages/reports/index.ts
@@ -1,0 +1,4 @@
+export { default as ProfitAndLoss } from './ProfitAndLoss';
+export { default as BalanceSheet } from './BalanceSheet';
+export { default as TrialBalance } from './TrialBalance';
+export { default as ARAgingSummary } from './ARAgingSummary';


### PR DESCRIPTION
## Summary
- Implements 4 financial reports: Profit & Loss, Balance Sheet, Trial Balance, and AR Aging Summary
- Creates reusable report components: DateRangePicker, ReportHeader, ReportTable
- Adds Reports index page with navigation cards
- All reports support print-friendly layout and CSV export

## Features
- **Profit & Loss Statement**: Income statement with date range filtering and preset periods
- **Balance Sheet**: Statement of financial position with as-of-date selection and balance verification
- **Trial Balance**: Account listing with debit/credit balances and balance status indicator
- **AR Aging Summary**: Outstanding invoices grouped by customer with aging buckets (Current, 1-30, 31-60, 61-90, 90+ days)

## Test plan
- [ ] Navigate to Reports from sidebar
- [ ] Verify all 4 report cards are displayed
- [ ] Test Profit & Loss with different date ranges
- [ ] Test Balance Sheet with different as-of dates
- [ ] Test Trial Balance shows correct balance status
- [ ] Test AR Aging shows customers with outstanding invoices
- [ ] Verify Print functionality works on all reports
- [ ] Verify CSV export works on all reports

Closes #12

:robot: Generated with [Claude Code](https://claude.com/claude-code)