### PR TITLE
fix: Correct API endpoints and OData GUID filter syntax

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -167,7 +167,7 @@ export const timeEntriesApi = {
   },
 
   getByProject: async (projectId: string): Promise<TimeEntry[]> => {
-    const response = await api.get(`/timeentries?$filter=ProjectId eq '${projectId}'`);
+    const response = await api.get(`/timeentries?$filter=ProjectId eq ${projectId}`);
     return response.data.value;
   },
 

--- a/client/src/lib/validation.ts
+++ b/client/src/lib/validation.ts
@@ -31,14 +31,14 @@ export function validateUUID(id: string | undefined | null, fieldName: string = 
 
 /**
  * Safely formats a GUID for OData filter queries
- * Validates the GUID and wraps it in quotes
+ * Validates the GUID and returns it without quotes (DAB does not use quotes for GUIDs)
  * @param id - The GUID to format
  * @param fieldName - The name of the field for the error message
- * @returns The quoted GUID string for use in OData filters
+ * @returns The GUID string for use in OData filters (unquoted)
  */
 export function formatGuidForOData(id: string | undefined | null, fieldName: string = 'ID'): string {
   const validatedId = validateUUID(id, fieldName);
-  return `'${validatedId}'`;
+  return validatedId;
 }
 
 /**

--- a/client/src/pages/BankTransactions.tsx
+++ b/client/src/pages/BankTransactions.tsx
@@ -61,7 +61,7 @@ export default function BankTransactions() {
 
   // Fetch transactions with pagination
   const { data: transactionsResponse, isLoading } = useQuery({
-    queryKey: ['bank-transactions', statusFilter, page, pageSize],
+    queryKey: ['banktransactions', statusFilter, page, pageSize],
     queryFn: async () => {
       const filters = [];
       if (statusFilter !== 'all') {
@@ -130,7 +130,7 @@ export default function BankTransactions() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
       setShowModal(false);
       resetForm();
     }
@@ -148,7 +148,7 @@ export default function BankTransactions() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
       setShowModal(false);
       setEditingTransaction(null);
       resetForm();
@@ -165,7 +165,7 @@ export default function BankTransactions() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
     }
   });
 

--- a/client/src/pages/Banking.tsx
+++ b/client/src/pages/Banking.tsx
@@ -15,9 +15,9 @@ interface BankTransaction {
 export default function Banking() {
   const queryClient = useQueryClient();
   const { data: transactions, isLoading } = useQuery({
-    queryKey: ['bank-transactions'],
+    queryKey: ['banktransactions'],
     queryFn: async () => {
-      const response = await api.get<{ value: BankTransaction[] }>('/bank-transactions');
+      const response = await api.get<{ value: BankTransaction[] }>('/banktransactions');
       return response.data.value;
     },
   });
@@ -53,11 +53,11 @@ export default function Banking() {
       ];
 
       for (const tx of dummyTransactions) {
-        await api.post('/bank-transactions', tx);
+        await api.post('/banktransactions', tx);
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
     },
   });
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -91,7 +91,7 @@ export default function Dashboard() {
 
   // Fetch Bank Transactions for Pending Actions
   const { data: bankTransactions } = useQuery({
-    queryKey: ['bank-transactions'],
+    queryKey: ['banktransactions'],
     queryFn: async () => {
       const response = await fetch('/api/banktransactions');
       if (!response.ok) throw new Error('Failed to fetch bank transactions');

--- a/client/src/pages/EditBill.tsx
+++ b/client/src/pages/EditBill.tsx
@@ -48,10 +48,10 @@ export default function EditBill() {
       if (!isIdValid) {
         throw new Error('Invalid bill ID format');
       }
-      // Fix SQL injection: Quote GUID values in OData filter
+      // Use unquoted GUIDs in OData filter for DAB
       const [billResponse, linesResponse] = await Promise.all([
-        api.get<{ value: Bill[] }>(`/bills?$filter=Id eq '${id}'`),
-        api.get<{ value: BillLine[] }>(`/billlines?$filter=BillId eq '${id}'`)
+        api.get<{ value: Bill[] }>(`/bills?$filter=Id eq ${id}`),
+        api.get<{ value: BillLine[] }>(`/billlines?$filter=BillId eq ${id}`)
       ]);
 
       const billData = billResponse.data.value[0];
@@ -74,8 +74,8 @@ export default function EditBill() {
       await api.patch(`/bills/Id/${id}`, billData);
 
       // 2. Handle Lines Reconciliation
-      // Fix SQL injection: Quote GUID value in OData filter
-      const currentLinesResponse = await api.get<{ value: BillLine[] }>(`/billlines?$filter=BillId eq '${id}'`);
+      // Use unquoted GUIDs in OData filter for DAB
+      const currentLinesResponse = await api.get<{ value: BillLine[] }>(`/billlines?$filter=BillId eq ${id}`);
       const currentLines = currentLinesResponse.data.value;
       const currentLineIds = new Set(currentLines.map(l => l.Id));
 

--- a/client/src/pages/NewReconciliation.tsx
+++ b/client/src/pages/NewReconciliation.tsx
@@ -99,7 +99,7 @@ export default function NewReconciliation() {
     queryKey: ['reconciliation-items', id],
     queryFn: async () => {
       if (!id) return [];
-      const response = await fetch(`/api/reconciliationitems?$filter=ReconciliationId eq '${id}'`);
+      const response = await fetch(`/api/reconciliationitems?$filter=ReconciliationId eq ${id}`);
       if (!response.ok) throw new Error('Failed to fetch items');
       return (await response.json()).value as ReconciliationItem[];
     },
@@ -126,10 +126,10 @@ export default function NewReconciliation() {
 
   // Fetch bank transactions for the selected account
   const { data: transactionsData } = useQuery({
-    queryKey: ['bank-transactions', selectedAccountId],
+    queryKey: ['banktransactions', selectedAccountId],
     queryFn: async () => {
       if (!selectedAccountId) return [];
-      const response = await fetch(`/api/banktransactions?$filter=SourceAccountId eq '${selectedAccountId}' and Status eq 'Approved'&$orderby=TransactionDate`);
+      const response = await fetch(`/api/banktransactions?$filter=SourceAccountId eq ${selectedAccountId} and Status eq 'Approved'&$orderby=TransactionDate`);
       if (!response.ok) throw new Error('Failed to fetch transactions');
       return (await response.json()).value as BankTransaction[];
     },
@@ -141,7 +141,7 @@ export default function NewReconciliation() {
     queryKey: ['journal-lines', selectedAccountId],
     queryFn: async () => {
       if (!selectedAccountId) return [];
-      const response = await fetch(`/api/journalentrylines?$filter=AccountId eq '${selectedAccountId}'&$orderby=CreatedAt`);
+      const response = await fetch(`/api/journalentrylines?$filter=AccountId eq ${selectedAccountId}&$orderby=CreatedAt`);
       if (!response.ok) throw new Error('Failed to fetch journal lines');
       return (await response.json()).value as JournalEntryLine[];
     },
@@ -236,7 +236,7 @@ export default function NewReconciliation() {
 
       // Check if item already exists
       const existingResponse = await fetch(
-        `/api/reconciliationitems?$filter=ReconciliationId eq '${reconciliationId}' and TransactionId eq '${item.transactionId}'`
+        `/api/reconciliationitems?$filter=ReconciliationId eq ${reconciliationId} and TransactionId eq ${item.transactionId}`
       );
       if (!existingResponse.ok) {
         throw new Error('Failed to fetch existing reconciliation items');

--- a/client/src/pages/RecurringTransactions.tsx
+++ b/client/src/pages/RecurringTransactions.tsx
@@ -132,7 +132,7 @@ export default function RecurringTransactions() {
     queryFn: async () => {
       if (!selectedTemplate) return [];
       const response = await api.get<{ value: RecurringSchedule[] }>(
-        `/recurringschedules?$filter=RecurringTemplateId eq '${selectedTemplate.Id}'&$orderby=ScheduledDate desc`
+        `/recurringschedules?$filter=RecurringTemplateId eq ${selectedTemplate.Id}&$orderby=ScheduledDate desc`
       );
       return response.data.value;
     },

--- a/client/src/pages/ReviewTransactions.tsx
+++ b/client/src/pages/ReviewTransactions.tsx
@@ -42,7 +42,7 @@ export default function ReviewTransactions() {
 
   // Fetch transactions
   const { data: transactionsData, isLoading } = useQuery({
-    queryKey: ['bank-transactions', statusFilter],
+    queryKey: ['banktransactions', statusFilter],
     queryFn: async () => {
       const url = statusFilter === 'all' 
         ? '/api/banktransactions'
@@ -89,7 +89,7 @@ export default function ReviewTransactions() {
       return response.json();
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
       setEditingId(null);
       setSelectedIds(new Set());
     }
@@ -115,7 +115,7 @@ export default function ReviewTransactions() {
       );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
       setSelectedIds(new Set());
     }
   });
@@ -223,7 +223,7 @@ export default function ReviewTransactions() {
       return response.json();
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['banktransactions'] });
       alert(`Successfully posted ${data.count} transactions to the journal!`);
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary
- Changed `/api/bank-transactions` to `/api/banktransactions` to match the DAB endpoint naming
- Removed single quotes from GUID values in OData filters (DAB does not use quotes for GUIDs)
- Updated `formatGuidForOData` helper function to return unquoted GUIDs
- Fixed query keys to use consistent naming (`banktransactions` instead of `bank-transactions`)

## Files Changed
- `client/src/lib/validation.ts` - Updated `formatGuidForOData` to not wrap GUIDs in quotes
- `client/src/lib/api.ts` - Fixed GUID filter in `getByProject`
- `client/src/pages/Banking.tsx` - Fixed endpoint and query key
- `client/src/pages/BankTransactions.tsx` - Fixed query keys
- `client/src/pages/Dashboard.tsx` - Fixed query key
- `client/src/pages/EditBill.tsx` - Removed quotes from GUID filters
- `client/src/pages/NewReconciliation.tsx` - Removed quotes from GUID filters, fixed query key
- `client/src/pages/RecurringTransactions.tsx` - Removed quotes from GUID filter
- `client/src/pages/ReviewTransactions.tsx` - Fixed query keys

Fixes #53

## Test plan
- [ ] Verify Banking page loads transactions without 404 errors
- [ ] Verify Bank Transactions page loads and filters work
- [ ] Verify Edit Bill page loads bill data without 400 errors
- [ ] Verify Reconciliation pages load transactions correctly
- [ ] Verify Recurring Transactions schedule history loads correctly

Generated with [Claude Code](https://claude.com/claude-code)