### PR TITLE
feat: MUI DataGrid with server-side paging, sorting, filtering

### DIFF
--- a/client/src/components/ServerDataGrid.tsx
+++ b/client/src/components/ServerDataGrid.tsx
@@ -63,8 +63,6 @@ interface ServerDataGridProps<T extends GridValidRowModel> {
   disableRowSelectionOnClick?: boolean;
   // Custom empty state message
   emptyMessage?: string;
-  // Key to trigger refresh
-  refreshKey?: number;
 }
 
 interface GraphQLResponse<T> {
@@ -95,7 +93,6 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
   checkboxSelection = false,
   disableRowSelectionOnClick = true,
   emptyMessage = 'No data found.',
-  refreshKey,
 }: ServerDataGridProps<T>) {
   const navigate = useNavigate();
 
@@ -245,7 +242,7 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
   // Fetch data when dependencies change
   useEffect(() => {
     fetchData();
-  }, [fetchData, refreshKey]);
+  }, [fetchData]);
 
   // Handle pagination changes
   const handlePaginationModelChange = useCallback((newModel: GridPaginationModel) => {

--- a/client/src/pages/Estimates.tsx
+++ b/client/src/pages/Estimates.tsx
@@ -103,7 +103,7 @@ export default function Estimates() {
     onSuccess: (invoice) => {
       queryClient.invalidateQueries({ queryKey: ['estimates'] });
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
-      setRefreshKey(prev => prev + 1);
+      setRefreshKey(k => k + 1);
       showToast('Estimate converted to invoice successfully', 'success');
       navigate(`/invoices/${invoice.Id}/edit`);
     },
@@ -132,7 +132,11 @@ export default function Estimates() {
   const columns: GridColDef[] = [
     { field: 'EstimateNumber', headerName: 'Estimate #', width: 130, filterable: true },
     { field: 'IssueDate', headerName: 'Date', width: 120, filterable: true },
-    { field: 'ExpirationDate', headerName: 'Expiration', width: 120, filterable: true,
+    {
+      field: 'ExpirationDate',
+      headerName: 'Expiration',
+      width: 120,
+      filterable: true,
       renderCell: (params) => params.value || '-'
     },
     {
@@ -146,7 +150,7 @@ export default function Estimates() {
     {
       field: 'Status',
       headerName: 'Status',
-      width: 110,
+      width: 120,
       filterable: true,
       renderCell: (params) => (
         <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${statusColors[params.value] || 'bg-gray-100 text-gray-800'}`}>
@@ -161,7 +165,7 @@ export default function Estimates() {
       sortable: false,
       filterable: false,
       renderCell: (params) => (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center space-x-2">
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -174,7 +178,10 @@ export default function Estimates() {
           {(params.row.Status === 'Accepted' || params.row.Status === 'Sent' || params.row.Status === 'Draft') &&
             !params.row.ConvertedToInvoiceId && (
               <button
-                onClick={(e) => handleConvertClick(e, params.row as Estimate)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleConvertClick(params.row as Estimate);
+                }}
                 disabled={convertToInvoiceMutation.isPending}
                 className="text-green-600 hover:text-green-900 inline-flex items-center"
               >
@@ -213,13 +220,13 @@ export default function Estimates() {
       </div>
 
       <ServerDataGrid<Estimate>
+        key={refreshKey}
         entityName="estimates"
         queryFields="Id EstimateNumber CustomerId IssueDate ExpirationDate TotalAmount Status ConvertedToInvoiceId Notes"
         columns={columns}
         editPath="/estimates/{id}/edit"
         initialPageSize={25}
         emptyMessage="No estimates found."
-        refreshKey={refreshKey}
       />
 
       <ConfirmModal

--- a/client/src/pages/ProductsServices.tsx
+++ b/client/src/pages/ProductsServices.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Plus, Package, Wrench, Box } from 'lucide-react';
+import { Plus, Wrench, Box, Package } from 'lucide-react';
 import { GridColDef } from '@mui/x-data-grid';
 import ServerDataGrid from '../components/ServerDataGrid';
 
@@ -11,22 +11,10 @@ interface ProductService {
   Description: string | null;
   SalesPrice: number | null;
   PurchaseCost: number | null;
-  IncomeAccountId: string | null;
-  ExpenseAccountId: string | null;
-  InventoryAssetAccountId: string | null;
   Category: string | null;
   Taxable: boolean;
   Status: 'Active' | 'Inactive';
 }
-
-const getTypeIcon = (type: string) => {
-  switch (type) {
-    case 'Service': return <Wrench className="w-4 h-4 text-blue-500" />;
-    case 'Inventory': return <Box className="w-4 h-4 text-green-500" />;
-    case 'NonInventory': return <Package className="w-4 h-4 text-orange-500" />;
-    default: return <Package className="w-4 h-4 text-gray-500" />;
-  }
-};
 
 const formatCurrency = (value: number | null) => {
   if (value === null || value === undefined) return '-';
@@ -40,20 +28,24 @@ export default function ProductsServices() {
       headerName: 'Name',
       width: 200,
       filterable: true,
-      renderCell: (params) => (
-        <div className="flex items-center">
-          {getTypeIcon(params.row.Type)}
-          <span className="ml-2">{params.value}</span>
-        </div>
-      ),
+      renderCell: (params) => {
+        const IconComponent = params.row.Type === 'Service' ? Wrench :
+          params.row.Type === 'Inventory' ? Box : Package;
+        const iconColor = params.row.Type === 'Service' ? 'text-blue-500' :
+          params.row.Type === 'Inventory' ? 'text-green-500' : 'text-orange-500';
+        return (
+          <div className="flex items-center">
+            <IconComponent className={`w-4 h-4 mr-2 ${iconColor}`} />
+            <span className="text-sm font-medium text-gray-900">{params.value}</span>
+          </div>
+        );
+      }
     },
-    { field: 'SKU', headerName: 'SKU', width: 120, filterable: true,
-      renderCell: (params) => params.value || '-'
-    },
+    { field: 'SKU', headerName: 'SKU', width: 120, filterable: true, renderCell: (params) => params.value || '-' },
     {
       field: 'Type',
       headerName: 'Type',
-      width: 120,
+      width: 130,
       filterable: true,
       renderCell: (params) => {
         const styles: Record<string, string> = {
@@ -71,17 +63,17 @@ export default function ProductsServices() {
             {labels[params.value] || params.value}
           </span>
         );
-      },
+      }
     },
-    { field: 'Category', headerName: 'Category', width: 130, filterable: true,
-      renderCell: (params) => params.value || '-'
-    },
+    { field: 'Category', headerName: 'Category', width: 130, filterable: true, renderCell: (params) => params.value || '-' },
     {
       field: 'SalesPrice',
       headerName: 'Sales Price',
       width: 120,
       type: 'number',
       filterable: true,
+      align: 'right',
+      headerAlign: 'right',
       renderCell: (params) => formatCurrency(params.value),
     },
     {

--- a/client/src/pages/Projects.tsx
+++ b/client/src/pages/Projects.tsx
@@ -15,29 +15,20 @@ interface Project {
   EndDate?: string;
   BudgetedHours?: number;
   BudgetedAmount?: number;
-  CreatedAt: string;
-  UpdatedAt: string;
 }
-
-const formatCurrency = (amount?: number) => {
-  if (amount === undefined || amount === null) return '-';
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-  }).format(amount);
-};
 
 const getStatusBadgeClass = (status: string) => {
   switch (status) {
-    case 'Active':
-      return 'bg-green-100 text-green-800';
-    case 'Completed':
-      return 'bg-blue-100 text-blue-800';
-    case 'OnHold':
-      return 'bg-yellow-100 text-yellow-800';
-    default:
-      return 'bg-gray-100 text-gray-800';
+    case 'Active': return 'bg-green-100 text-green-800';
+    case 'Completed': return 'bg-blue-100 text-blue-800';
+    case 'OnHold': return 'bg-yellow-100 text-yellow-800';
+    default: return 'bg-gray-100 text-gray-800';
   }
+};
+
+const formatCurrency = (amount?: number) => {
+  if (amount === undefined || amount === null) return '-';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
 };
 
 export default function Projects() {
@@ -56,24 +47,24 @@ export default function Projects() {
       filterable: true,
       renderCell: (params) => (
         <div>
-          <div className="font-medium">{params.value}</div>
+          <div className="text-sm font-medium text-gray-900">{params.value}</div>
           {params.row.Description && (
             <div className="text-sm text-gray-500 truncate max-w-xs">{params.row.Description}</div>
           )}
         </div>
-      ),
+      )
     },
     {
       field: 'CustomerId',
       headerName: 'Customer',
-      width: 180,
+      width: 150,
       filterable: true,
-      renderCell: (params) => customersMap.get(params.value) || 'Unknown',
+      renderCell: (params) => customersMap.get(params.value) || 'Unknown'
     },
     {
       field: 'Status',
       headerName: 'Status',
-      width: 110,
+      width: 120,
       filterable: true,
       renderCell: (params) => (
         <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusBadgeClass(params.value)}`}>
@@ -83,25 +74,31 @@ export default function Projects() {
     },
     {
       field: 'StartDate',
-      headerName: 'Start Date',
-      width: 120,
-      filterable: true,
-      renderCell: (params) => params.value ? new Date(params.value).toLocaleDateString() : '-',
-    },
-    {
-      field: 'EndDate',
-      headerName: 'End Date',
-      width: 120,
-      filterable: true,
-      renderCell: (params) => params.value ? new Date(params.value).toLocaleDateString() : '-',
+      headerName: 'Dates',
+      width: 150,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <div className="text-sm text-gray-500">
+          {params.row.StartDate && <div>Start: {new Date(params.row.StartDate).toLocaleDateString()}</div>}
+          {params.row.EndDate && <div>End: {new Date(params.row.EndDate).toLocaleDateString()}</div>}
+          {!params.row.StartDate && !params.row.EndDate && '-'}
+        </div>
+      ),
     },
     {
       field: 'BudgetedAmount',
       headerName: 'Budget',
-      width: 120,
-      type: 'number',
-      filterable: true,
-      renderCell: (params) => formatCurrency(params.value),
+      width: 130,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <div className="text-sm text-gray-500">
+          {params.row.BudgetedHours && <div>{params.row.BudgetedHours} hrs</div>}
+          {params.row.BudgetedAmount && <div>{formatCurrency(params.row.BudgetedAmount)}</div>}
+          {!params.row.BudgetedHours && !params.row.BudgetedAmount && '-'}
+        </div>
+      ),
     },
   ];
 
@@ -111,7 +108,7 @@ export default function Projects() {
         <h1 className="text-2xl font-semibold text-gray-900">Projects</h1>
         <Link
           to="/projects/new"
-          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
         >
           <Plus className="w-4 h-4 mr-2" />
           New Project

--- a/client/src/pages/Vendors.tsx
+++ b/client/src/pages/Vendors.tsx
@@ -15,9 +15,9 @@ interface Vendor {
 
 export default function Vendors() {
   const columns: GridColDef[] = [
-    { field: 'Name', headerName: 'Name', width: 200, filterable: true },
-    { field: 'Email', headerName: 'Email', width: 200, filterable: true },
-    { field: 'Phone', headerName: 'Phone', width: 150, filterable: true },
+    { field: 'Name', headerName: 'Name', width: 180, filterable: true },
+    { field: 'Email', headerName: 'Email', width: 180, filterable: true },
+    { field: 'Phone', headerName: 'Phone', width: 130, filterable: true },
     { field: 'PaymentTerms', headerName: 'Payment Terms', width: 130, filterable: true },
     {
       field: 'Status',
@@ -38,9 +38,7 @@ export default function Vendors() {
       width: 80,
       filterable: true,
       renderCell: (params) => params.value ? (
-        <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800">
-          Yes
-        </span>
+        <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800">Yes</span>
       ) : (
         <span className="text-gray-400">No</span>
       ),
@@ -53,7 +51,7 @@ export default function Vendors() {
         <h1 className="text-2xl font-semibold text-gray-900">Vendors</h1>
         <Link
           to="/vendors/new"
-          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
         >
           <Plus className="w-4 h-4 mr-2" />
           New Vendor


### PR DESCRIPTION
## Summary
- Installed `@mui/x-data-grid` package
- Created reusable `ServerDataGrid` component with server-side pagination, sorting, and filtering via GraphQL
- Updated 7 list pages to use the new DataGrid component
- Added Playwright E2E tests for DataGrid functionality

## Changes
### New Component: `ServerDataGrid`
- Server-side pagination using GraphQL `first`/`after` cursors
- Server-side sorting using GraphQL `orderBy`
- Server-side filtering using GraphQL `filter`
- Row click navigation support
- Custom MUI styling matching app theme

### Updated Pages
- Invoices, Customers, Vendors
- Bills, Estimates, Products/Services
- Projects (Time Tracking)

### Tests
- Playwright tests for pagination controls
- Tests for column sorting
- Tests for column filtering
- Tests for row click navigation

## Test plan
- [ ] Verify DataGrid loads on all updated list pages
- [ ] Test pagination (next/previous, page size changes)
- [ ] Test sorting by clicking column headers
- [ ] Test filtering via column menu
- [ ] Verify row click navigates to edit page
- [ ] Run `npm run test:e2e` to execute Playwright tests

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)