### PR TITLE
feat: Add light/dark theme toggle (#65)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { msalConfig } from './lib/authConfig';
 import { initializeApiAuth } from './lib/api';
 import { AuthProvider } from './contexts/AuthContext';
 import { CompanySettingsProvider } from './contexts/CompanySettingsContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
 import Login from './pages/Login';
@@ -132,9 +133,11 @@ function App() {
       <AuthProvider>
         <CompanySettingsProvider>
           <QueryClientProvider client={queryClient}>
-            <ToastProvider>
+            <ThemeProvider>
+              <ToastProvider>
               <AppContent />
             </ToastProvider>
+            </ThemeProvider>
           </QueryClientProvider>
         </CompanySettingsProvider>
       </AuthProvider>

--- a/client/src/components/GlobalSearch.tsx
+++ b/client/src/components/GlobalSearch.tsx
@@ -388,12 +388,12 @@ export default function GlobalSearch() {
     return (
       <button
         onClick={openSearch}
-        className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-500 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+        className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
         aria-label="Open search"
       >
         <Search className="h-4 w-4" />
         <span className="hidden sm:inline">Search...</span>
-        <kbd className="hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium text-gray-400 bg-white rounded border border-gray-200">
+        <kbd className="hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium text-gray-400 dark:text-gray-500 bg-white dark:bg-gray-600 rounded border border-gray-200 dark:border-gray-500">
           <Command className="h-3 w-3" />K
         </kbd>
       </button>
@@ -412,13 +412,13 @@ export default function GlobalSearch() {
       {/* Modal */}
       <div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4">
         <div
-          className="w-full max-w-xl bg-white rounded-xl shadow-2xl overflow-hidden"
+          className="w-full max-w-xl bg-white dark:bg-gray-800 rounded-xl shadow-2xl overflow-hidden"
           role="dialog"
           aria-modal="true"
           aria-label="Global search"
         >
           {/* Search input */}
-          <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+          <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
             <Search className="h-5 w-5 text-gray-400 flex-shrink-0" />
             <input
               ref={inputRef}
@@ -427,7 +427,7 @@ export default function GlobalSearch() {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Search invoices, customers, vendors, bills, products..."
-              className="flex-1 text-base text-gray-900 placeholder-gray-400 bg-transparent border-none outline-none"
+              className="flex-1 text-base text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 bg-transparent border-none outline-none"
               autoComplete="off"
               autoCorrect="off"
               autoCapitalize="off"
@@ -436,7 +436,7 @@ export default function GlobalSearch() {
             {query && (
               <button
                 onClick={() => setQuery('')}
-                className="p-1 text-gray-400 hover:text-gray-600"
+                className="p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
                 aria-label="Clear search"
               >
                 <X className="h-4 w-4" />
@@ -444,7 +444,7 @@ export default function GlobalSearch() {
             )}
             <button
               onClick={closeSearch}
-              className="px-2 py-1 text-xs text-gray-400 bg-gray-100 rounded hover:bg-gray-200"
+              className="px-2 py-1 text-xs text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200 dark:hover:bg-gray-600"
             >
               ESC
             </button>
@@ -464,14 +464,14 @@ export default function GlobalSearch() {
             className="max-h-[60vh] overflow-y-auto"
           >
             {isLoading && (
-              <div className="px-4 py-8 text-center text-gray-500">
+              <div className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
                 <div className="inline-block h-5 w-5 border-2 border-gray-300 border-t-indigo-600 rounded-full animate-spin" />
                 <p className="mt-2 text-sm">Searching...</p>
               </div>
             )}
 
             {!isLoading && error && (
-              <div className="px-4 py-8 text-center text-red-500">
+              <div className="px-4 py-8 text-center text-red-500 dark:text-red-400">
                 <AlertCircle className="h-8 w-8 mx-auto mb-2 text-red-400" />
                 <p className="text-sm">{error}</p>
                 <button
@@ -565,19 +565,19 @@ export default function GlobalSearch() {
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-between px-4 py-2 border-t border-gray-200 bg-gray-50 text-xs text-gray-500">
+          <div className="flex items-center justify-between px-4 py-2 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-xs text-gray-500 dark:text-gray-400">
             <div className="flex items-center gap-4">
               <span className="flex items-center gap-1">
-                <kbd className="px-1.5 py-0.5 bg-white rounded border border-gray-200">↑</kbd>
-                <kbd className="px-1.5 py-0.5 bg-white rounded border border-gray-200">↓</kbd>
+                <kbd className="px-1.5 py-0.5 bg-white dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">↑</kbd>
+                <kbd className="px-1.5 py-0.5 bg-white dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">↓</kbd>
                 <span>to navigate</span>
               </span>
               <span className="flex items-center gap-1">
-                <kbd className="px-1.5 py-0.5 bg-white rounded border border-gray-200">Enter</kbd>
+                <kbd className="px-1.5 py-0.5 bg-white dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">Enter</kbd>
                 <span>to select</span>
               </span>
               <span className="flex items-center gap-1">
-                <kbd className="px-1.5 py-0.5 bg-white rounded border border-gray-200">Esc</kbd>
+                <kbd className="px-1.5 py-0.5 bg-white dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">Esc</kbd>
                 <span>to close</span>
               </span>
             </div>
@@ -608,7 +608,7 @@ function ResultSection({
 }: ResultSectionProps) {
   return (
     <div className="mb-2">
-      <div className="px-4 py-1.5 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+      <div className="px-4 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
         {title}
       </div>
       {results.map((result, index) => {
@@ -622,7 +622,7 @@ function ResultSection({
             onClick={() => onResultClick(result)}
             className={clsx(
               'w-full flex items-center gap-3 px-4 py-2 text-left transition-colors',
-              isSelected ? 'bg-indigo-50' : 'hover:bg-gray-50'
+              isSelected ? 'bg-indigo-50 dark:bg-indigo-900/30' : 'hover:bg-gray-50 dark:hover:bg-gray-700'
             )}
           >
             <div className="flex-shrink-0">
@@ -631,16 +631,16 @@ function ResultSection({
             <div className="flex-1 min-w-0">
               <div className={clsx(
                 'text-sm font-medium truncate',
-                isSelected ? 'text-indigo-700' : 'text-gray-900'
+                isSelected ? 'text-indigo-700 dark:text-indigo-300' : 'text-gray-900 dark:text-white'
               )}>
                 {result.title}
               </div>
-              <div className="text-xs text-gray-500 truncate">
+              <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
                 {result.subtitle}
               </div>
             </div>
             {isSelected && (
-              <div className="flex-shrink-0 text-xs text-indigo-600">
+              <div className="flex-shrink-0 text-xs text-indigo-600 dark:text-indigo-400">
                 Enter to open
               </div>
             )}

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -58,13 +58,13 @@ export default function Layout() {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 flex print:bg-white">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex print:bg-white">
       {/* Sidebar - Hidden when printing */}
       <div className={clsx(
-        "fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-gray-200 transform transition-transform duration-200 ease-in-out lg:translate-x-0 lg:static lg:inset-0 print:hidden",
+        "fixed inset-y-0 left-0 z-50 w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform duration-200 ease-in-out lg:translate-x-0 lg:static lg:inset-0 print:hidden",
         isMobileMenuOpen ? "translate-x-0" : "-translate-x-full"
       )}>
-        <div className="flex items-center justify-between h-16 border-b border-gray-200 px-4">
+        <div className="flex items-center justify-between h-16 border-b border-gray-200 dark:border-gray-700 px-4">
           {companySettings.logoUrl ? (
             <img
               src={companySettings.logoUrl}
@@ -72,33 +72,33 @@ export default function Layout() {
               className="h-10 max-w-[140px] object-contain"
             />
           ) : (
-            <span className="text-xl font-bold text-indigo-600">{companySettings.name || 'Modern Books'}</span>
+            <span className="text-xl font-bold text-indigo-600 dark:text-indigo-400">{companySettings.name || 'Modern Books'}</span>
           )}
           {/* User Menu */}
           <div className="relative" ref={userMenuRef}>
             <button
               onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
-              className="flex items-center gap-1 p-1 rounded-md text-gray-600 hover:bg-gray-100 transition-colors"
+              className="flex items-center gap-1 p-1 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
             >
               <User className="h-5 w-5" />
               <ChevronDown className="h-3 w-3" />
             </button>
             {isUserMenuOpen && (
-              <div className="absolute right-0 mt-2 w-56 bg-white rounded-md shadow-lg border border-gray-200 py-1 z-50">
-                <div className="px-4 py-2 border-b border-gray-100">
-                  <p className="text-sm font-medium text-gray-900 truncate">
+              <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50">
+                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-700">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
                     {user?.name || user?.username || 'User'}
                   </p>
-                  <p className="text-xs text-gray-500 truncate">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
                     {user?.username}
                   </p>
-                  <span className="inline-block mt-1 px-2 py-0.5 text-xs font-medium bg-indigo-100 text-indigo-800 rounded">
+                  <span className="inline-block mt-1 px-2 py-0.5 text-xs font-medium bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 rounded">
                     {userRole}
                   </span>
                 </div>
                 <button
                   onClick={handleLogout}
-                  className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+                  className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                 >
                   <LogOut className="h-4 w-4" />
                   Sign out
@@ -122,8 +122,8 @@ export default function Layout() {
                 className={clsx(
                   "flex items-center px-4 py-2 text-sm font-medium rounded-md transition-colors",
                   isActive
-                    ? "bg-indigo-50 text-indigo-700"
-                    : "text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+                    ? "bg-indigo-50 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300"
+                    : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
                 )}
               >
                 <Icon className="mr-3 h-5 w-5" />
@@ -137,7 +137,7 @@ export default function Layout() {
       {/* Main Content */}
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         {/* Mobile Header - Hidden when printing */}
-        <div className="lg:hidden flex items-center justify-between bg-white border-b border-gray-200 px-4 py-2 print:hidden">
+        <div className="lg:hidden flex items-center justify-between bg-white border-b border-gray-200 dark:border-gray-700 px-4 py-2 print:hidden">
           {companySettings.logoUrl ? (
             <img
               src={companySettings.logoUrl}
@@ -145,13 +145,13 @@ export default function Layout() {
               className="h-8 max-w-[120px] object-contain"
             />
           ) : (
-            <span className="text-lg font-bold text-indigo-600">{companySettings.name || 'Modern Books'}</span>
+            <span className="text-lg font-bold text-indigo-600 dark:text-indigo-400">{companySettings.name || 'Modern Books'}</span>
           )}
           <div className="flex items-center gap-2">
             <GlobalSearch />
             <button
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className="p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+              className="p-2 rounded-md text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
             >
               <Menu className="h-6 w-6" />
             </button>

--- a/client/src/components/ServerDataGrid.tsx
+++ b/client/src/components/ServerDataGrid.tsx
@@ -298,11 +298,11 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
 
   if (error) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-md p-4">
-        <p className="text-red-600">Error loading data: {error}</p>
+      <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md p-4">
+        <p className="text-red-600 dark:text-red-400">Error loading data: {error}</p>
         <button
           onClick={fetchData}
-          className="mt-2 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700"
+          className="mt-2 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
         >
           Retry
         </button>
@@ -317,7 +317,7 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
           {headerActions}
         </div>
       )}
-      <div style={{ height, width: '100%' }} className="bg-white rounded-lg shadow">
+      <div style={{ height, width: '100%' }} className="bg-white dark:bg-gray-800 rounded-lg shadow">
         <DataGrid
           rows={rows}
           columns={columnsWithActions}
@@ -352,8 +352,8 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
               cursor: editPath || onRowClick ? 'pointer' : 'default',
             },
             '& .MuiDataGrid-columnHeaders': {
-              backgroundColor: '#f9fafb',
-              borderBottom: '1px solid #e5e7eb',
+              backgroundColor: 'var(--datagrid-header-bg, #f9fafb)',
+              borderBottom: '1px solid var(--datagrid-border, #e5e7eb)',
             },
             '& .MuiDataGrid-cell': {
               borderBottom: '1px solid #e5e7eb',

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -1,0 +1,98 @@
+import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+type ResolvedTheme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_STORAGE_KEY = 'theme-preference';
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+function getStoredTheme(): ThemePreference {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+  }
+  return 'system';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemePreference>(() => getStoredTheme());
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
+    const stored = getStoredTheme();
+    return stored === 'system' ? getSystemTheme() : stored;
+  });
+
+  const applyTheme = useCallback((resolved: ResolvedTheme) => {
+    const root = document.documentElement;
+    if (resolved === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, []);
+
+  const setTheme = useCallback((newTheme: ThemePreference) => {
+    setThemeState(newTheme);
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme);
+
+    const resolved = newTheme === 'system' ? getSystemTheme() : newTheme;
+    setResolvedTheme(resolved);
+    applyTheme(resolved);
+  }, [applyTheme]);
+
+  // Apply theme on initial load
+  useEffect(() => {
+    applyTheme(resolvedTheme);
+  }, [applyTheme, resolvedTheme]);
+
+  // Listen for system theme changes when using 'system' preference
+  useEffect(() => {
+    if (theme !== 'system') return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      const newResolved = e.matches ? 'dark' : 'light';
+      setResolvedTheme(newResolved);
+      applyTheme(newResolved);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [theme, applyTheme]);
+
+  const value: ThemeContextType = {
+    theme,
+    resolvedTheme,
+    setTheme,
+  };
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,49 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Light mode (default) */
+:root {
+  --datagrid-header-bg: #f9fafb;
+  --datagrid-border: #e5e7eb;
+  --datagrid-text: #111827;
+  --datagrid-text-secondary: #6b7280;
+}
+
+/* Dark mode */
+.dark {
+  --datagrid-header-bg: #1f2937;
+  --datagrid-border: #374151;
+  --datagrid-text: #f9fafb;
+  --datagrid-text-secondary: #9ca3af;
+}
+
+/* MUI DataGrid dark mode overrides */
+.dark .MuiDataGrid-root {
+  color: var(--datagrid-text);
+}
+
+.dark .MuiDataGrid-cell {
+  border-color: var(--datagrid-border);
+}
+
+.dark .MuiDataGrid-columnHeaders {
+  background-color: var(--datagrid-header-bg);
+  border-color: var(--datagrid-border);
+}
+
+.dark .MuiDataGrid-footerContainer {
+  border-color: var(--datagrid-border);
+}
+
+.dark .MuiTablePagination-root {
+  color: var(--datagrid-text);
+}
+
+.dark .MuiIconButton-root {
+  color: var(--datagrid-text-secondary);
+}
+
+.dark .MuiDataGrid-row:hover {
+  background-color: rgba(79, 70, 229, 0.1) !important;
+}

--- a/client/src/pages/CompanySettings.tsx
+++ b/client/src/pages/CompanySettings.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef } from 'react';
-import { Building2, Upload, Save, X } from 'lucide-react';
+import { Building2, Upload, Save, X, Sun, Moon, Monitor } from 'lucide-react';
 import { useCompanySettings } from '../contexts/CompanySettingsContext';
+import { useTheme, ThemePreference } from '../contexts/ThemeContext';
 
 export default function CompanySettings() {
   const { settings, updateSettings } = useCompanySettings();
+  const { theme, setTheme } = useTheme();
   const [formData, setFormData] = useState(settings);
   const [logoPreview, setLogoPreview] = useState(settings.logoUrl);
   const [isSaving, setIsSaving] = useState(false);
@@ -47,6 +49,11 @@ export default function CompanySettings() {
     }
   };
 
+  const themeOptions: { value: ThemePreference; label: string; icon: React.ReactNode }[] = [
+    { value: 'light', label: 'Light', icon: <Sun className="h-4 w-4" /> },
+    { value: 'dark', label: 'Dark', icon: <Moon className="h-4 w-4" /> },
+    { value: 'system', label: 'System', icon: <Monitor className="h-4 w-4" /> },
+  ];
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSaving(true);
@@ -67,17 +74,41 @@ export default function CompanySettings() {
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">Company Settings</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Company Settings</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Configure your company information for invoices and the app header.
           </p>
         </div>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Theme Section */}
+        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">Appearance</h2>
+          <div>
+            <label className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-3">Theme</label>
+            <div className="flex flex-wrap gap-3">
+              {themeOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setTheme(option.value)}
+                  className={}
+                >
+                  {option.icon}
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Choose how the application appears. System will follow your device settings.
+            </p>
+          </div>
+        </div>
+
         {/* Logo Section */}
-        <div className="bg-white shadow-lg rounded-lg p-8">
-          <h2 className="text-lg font-semibold text-gray-900 mb-6">Company Logo</h2>
+        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">Company Logo</h2>
 
           <div className="flex items-start gap-6">
             {/* Logo Preview */}
@@ -129,8 +160,8 @@ export default function CompanySettings() {
         </div>
 
         {/* Company Information */}
-        <div className="bg-white shadow-lg rounded-lg p-8">
-          <h2 className="text-lg font-semibold text-gray-900 mb-6">Company Information</h2>
+        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">Company Information</h2>
 
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div className="sm:col-span-2">

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: [
         "./index.html",
         "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- Add ThemeContext for managing theme preference (light/dark/system)
- Store preference in localStorage with system preference detection
- Update tailwind.config.js with `darkMode: 'class'`
- Add theme toggle UI in Company Settings page with Sun/Moon/Monitor icons
- Update core components with dark mode Tailwind classes

## Components Updated
- Layout (sidebar, header, navigation, user menu)
- GlobalSearch
- ServerDataGrid
- CompanySettings
- index.css base styles

## Test Plan
- [ ] Toggle between Light/Dark/System themes
- [ ] Verify preference persists after page reload
- [ ] Check all updated components render correctly in dark mode
- [ ] Verify print view remains light regardless of theme

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)