### PR TITLE
feat: Show customer/vendor names on list pages

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -133,6 +133,7 @@ export interface ProjectInput {
 export interface TimeEntry {
   Id: string;
   ProjectId: string;
+  ProjectName: string;
   CustomerId: string;
   EmployeeName: string;
   EntryDate: string;

--- a/client/src/lib/invoiceUtils.ts
+++ b/client/src/lib/invoiceUtils.ts
@@ -6,6 +6,7 @@ export interface Invoice {
   Id: string;
   InvoiceNumber: string;
   CustomerId: string;
+  CustomerName?: string;
   IssueDate: string;
   DueDate: string;
   TotalAmount: number;

--- a/client/src/pages/Bills.tsx
+++ b/client/src/pages/Bills.tsx
@@ -1,26 +1,21 @@
 import { Link } from 'react-router-dom';
 import { Plus } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
 import { GridColDef } from '@mui/x-data-grid';
 import ServerDataGrid from '../components/ServerDataGrid';
-import api from '../lib/api';
 
 interface Bill {
   Id: string;
   VendorId: string;
+  VendorName: string;
   BillNumber: string;
   BillDate: string;
   DueDate: string;
   TotalAmount: number;
   AmountPaid: number;
+  BalanceDue: number;
   Status: string;
   Terms: string;
   Memo: string;
-}
-
-interface Vendor {
-  Id: string;
-  Name: string;
 }
 
 const getStatusColor = (status: string) => {
@@ -35,28 +30,9 @@ const getStatusColor = (status: string) => {
 };
 
 export default function Bills() {
-  const { data: vendors } = useQuery({
-    queryKey: ['vendors'],
-    queryFn: async () => {
-      const response = await api.get<{ value: Vendor[] }>('/vendors');
-      return response.data.value;
-    },
-  });
-
-  const vendorMap = vendors?.reduce((acc, vendor) => {
-    acc[vendor.Id] = vendor.Name;
-    return acc;
-  }, {} as Record<string, string>) || {};
-
   const columns: GridColDef[] = [
     { field: 'BillNumber', headerName: 'Bill #', width: 120, filterable: true },
-    {
-      field: 'VendorId',
-      headerName: 'Vendor',
-      width: 180,
-      filterable: true,
-      renderCell: (params) => vendorMap[params.value] || 'Unknown Vendor'
-    },
+    { field: 'VendorName', headerName: 'Vendor', width: 180, filterable: true },
     { field: 'BillDate', headerName: 'Bill Date', width: 120, filterable: true },
     { field: 'DueDate', headerName: 'Due Date', width: 120, filterable: true },
     {
@@ -68,12 +44,12 @@ export default function Bills() {
       renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
     },
     {
-      field: 'balance',
+      field: 'BalanceDue',
       headerName: 'Balance Due',
       width: 120,
-      sortable: false,
-      filterable: false,
-      renderCell: (params) => `$${((params.row.TotalAmount || 0) - (params.row.AmountPaid || 0)).toFixed(2)}`,
+      type: 'number',
+      filterable: true,
+      renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
     },
     {
       field: 'Status',
@@ -103,7 +79,7 @@ export default function Bills() {
 
       <ServerDataGrid<Bill>
         entityName="bills"
-        queryFields="Id VendorId BillNumber BillDate DueDate TotalAmount AmountPaid Status Terms Memo"
+        queryFields="Id VendorId VendorName BillNumber BillDate DueDate TotalAmount AmountPaid BalanceDue Status Terms Memo"
         columns={columns}
         editPath="/bills/{id}/edit"
         initialPageSize={25}

--- a/client/src/pages/Invoices.tsx
+++ b/client/src/pages/Invoices.tsx
@@ -118,6 +118,7 @@ export default function Invoices() {
 
   const columns: GridColDef[] = [
     { field: 'InvoiceNumber', headerName: 'Invoice #', width: 130, filterable: true },
+    { field: 'CustomerName', headerName: 'Customer', width: 180, filterable: true },
     { field: 'IssueDate', headerName: 'Date', width: 120, filterable: true },
     { field: 'DueDate', headerName: 'Due Date', width: 120, filterable: true },
     {
@@ -196,7 +197,7 @@ export default function Invoices() {
       <ServerDataGrid<Invoice>
         key={refreshKey}
         entityName="invoices"
-        queryFields="Id InvoiceNumber CustomerId IssueDate DueDate TotalAmount Status"
+        queryFields="Id InvoiceNumber CustomerId CustomerName IssueDate DueDate TotalAmount Status"
         columns={columns}
         editPath="/invoices/{id}/edit"
         initialPageSize={25}

--- a/client/src/pages/Projects.tsx
+++ b/client/src/pages/Projects.tsx
@@ -1,14 +1,13 @@
 import { Link } from 'react-router-dom';
 import { Plus } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
 import { GridColDef } from '@mui/x-data-grid';
 import ServerDataGrid from '../components/ServerDataGrid';
-import { customersApi, Customer } from '../lib/api';
 
 interface Project {
   Id: string;
   Name: string;
   CustomerId: string;
+  CustomerName: string;
   Description?: string;
   Status: 'Active' | 'Completed' | 'OnHold';
   StartDate?: string;
@@ -32,13 +31,6 @@ const formatCurrency = (amount?: number) => {
 };
 
 export default function Projects() {
-  const { data: customers = [] } = useQuery<Customer[]>({
-    queryKey: ['customers'],
-    queryFn: customersApi.getAll,
-  });
-
-  const customersMap = new Map(customers.map(c => [c.Id, c.Name]));
-
   const columns: GridColDef[] = [
     {
       field: 'Name',
@@ -54,13 +46,7 @@ export default function Projects() {
         </div>
       )
     },
-    {
-      field: 'CustomerId',
-      headerName: 'Customer',
-      width: 150,
-      filterable: true,
-      renderCell: (params) => customersMap.get(params.value) || 'Unknown'
-    },
+    { field: 'CustomerName', headerName: 'Customer', width: 150, filterable: true },
     {
       field: 'Status',
       headerName: 'Status',
@@ -117,7 +103,7 @@ export default function Projects() {
 
       <ServerDataGrid<Project>
         entityName="projects"
-        queryFields="Id Name CustomerId Description Status StartDate EndDate BudgetedHours BudgetedAmount"
+        queryFields="Id Name CustomerId CustomerName Description Status StartDate EndDate BudgetedHours BudgetedAmount"
         columns={columns}
         editPath="/projects/{id}/edit"
         initialPageSize={25}

--- a/client/src/pages/TimeEntries.tsx
+++ b/client/src/pages/TimeEntries.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { Plus, ChevronLeft, ChevronRight, Calendar, List, Trash2 } from 'lucide-react';
-import { timeEntriesApi, projectsApi, TimeEntry, Project } from '../lib/api';
+import { timeEntriesApi, TimeEntry } from '../lib/api';
 import clsx from 'clsx';
 
 type ViewMode = 'list' | 'calendar';
@@ -31,13 +31,6 @@ export default function TimeEntries() {
     queryKey: ['timeEntries'],
     queryFn: timeEntriesApi.getAll,
   });
-
-  const { data: projects = [] } = useQuery<Project[]>({
-    queryKey: ['projects'],
-    queryFn: projectsApi.getAll,
-  });
-
-  const projectsMap = new Map(projects.map(p => [p.Id, p.Name]));
 
   // Filter entries for current week
   const weekEntries = useMemo(() => {
@@ -209,7 +202,7 @@ export default function TimeEntries() {
                           className="text-xs p-1 bg-indigo-50 rounded border-l-2 border-indigo-500"
                         >
                           <div className="font-medium truncate">
-                            {projectsMap.get(entry.ProjectId) || 'Unknown'}
+                            {entry.ProjectName || 'Unknown'}
                           </div>
                           <div className="text-gray-500">{entry.Hours}h</div>
                         </div>
@@ -284,7 +277,7 @@ export default function TimeEntries() {
                         })}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                        {projectsMap.get(entry.ProjectId) || 'Unknown'}
+                        {entry.ProjectName || 'Unknown'}
                       </td>
                       <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
                         {entry.Description || '-'}

--- a/dab-config.json
+++ b/dab-config.json
@@ -175,6 +175,7 @@
                 "Id": "Id",
                 "InvoiceNumber": "InvoiceNumber",
                 "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName",
                 "IssueDate": "IssueDate",
                 "DueDate": "DueDate",
                 "TotalAmount": "TotalAmount",
@@ -454,7 +455,7 @@
             ]
         },
         "projects": {
-            "source": "dbo.Projects",
+            "source": "dbo.v_Projects",
             "permissions": [
                 {
                     "role": "anonymous",
@@ -467,6 +468,7 @@
                 "Id": "Id",
                 "Name": "Name",
                 "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName",
                 "Description": "Description",
                 "Status": "Status",
                 "StartDate": "StartDate",
@@ -503,7 +505,7 @@
             ]
         },
         "timeentries": {
-            "source": "dbo.TimeEntries",
+            "source": "dbo.v_TimeEntries",
             "permissions": [
                 {
                     "role": "anonymous",
@@ -515,6 +517,7 @@
             "mappings": {
                 "Id": "Id",
                 "ProjectId": "ProjectId",
+                "ProjectName": "ProjectName",
                 "CustomerId": "CustomerId",
                 "EmployeeName": "EmployeeName",
                 "EntryDate": "EntryDate",
@@ -730,7 +733,7 @@
             ]
         },
         "bills": {
-            "source": "dbo.Bills",
+            "source": "dbo.v_Bills",
             "permissions": [
                 {
                     "role": "anonymous",
@@ -742,11 +745,13 @@
             "mappings": {
                 "Id": "Id",
                 "VendorId": "VendorId",
+                "VendorName": "VendorName",
                 "BillNumber": "BillNumber",
                 "BillDate": "BillDate",
                 "DueDate": "DueDate",
                 "TotalAmount": "TotalAmount",
                 "AmountPaid": "AmountPaid",
+                "BalanceDue": "BalanceDue",
                 "Status": "Status",
                 "Terms": "Terms",
                 "Memo": "Memo",
@@ -838,6 +843,7 @@
                 "Id": "Id",
                 "EstimateNumber": "EstimateNumber",
                 "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName",
                 "IssueDate": "IssueDate",
                 "ExpirationDate": "ExpirationDate",
                 "TotalAmount": "TotalAmount",

--- a/database/dbo/Views/v_Estimates.sql
+++ b/database/dbo/Views/v_Estimates.sql
@@ -1,16 +1,18 @@
 CREATE VIEW [dbo].[v_Estimates] AS
 SELECT
-    [Id],
-    [EstimateNumber],
-    [CustomerId],
-    [IssueDate],
-    [ExpirationDate],
-    [TotalAmount],
-    [Status],
-    [ConvertedToInvoiceId],
-    [Notes],
-    [CreatedAt],
-    [UpdatedAt]
+    e.[Id],
+    e.[EstimateNumber],
+    e.[CustomerId],
+    c.[Name] AS CustomerName,
+    e.[IssueDate],
+    e.[ExpirationDate],
+    e.[TotalAmount],
+    e.[Status],
+    e.[ConvertedToInvoiceId],
+    e.[Notes],
+    e.[CreatedAt],
+    e.[UpdatedAt]
 FROM
-    [dbo].[Estimates];
+    [dbo].[Estimates] e
+    LEFT JOIN [dbo].[Customers] c ON e.[CustomerId] = c.[Id];
 GO

--- a/database/dbo/Views/v_Invoices.sql
+++ b/database/dbo/Views/v_Invoices.sql
@@ -1,14 +1,16 @@
 CREATE VIEW [dbo].[v_Invoices] AS
 SELECT
-    [Id],
-    [InvoiceNumber],
-    [CustomerId],
-    [IssueDate],
-    [DueDate],
-    [TotalAmount],
-    [Status],
-    [CreatedAt],
-    [UpdatedAt]
+    i.[Id],
+    i.[InvoiceNumber],
+    i.[CustomerId],
+    c.[Name] AS CustomerName,
+    i.[IssueDate],
+    i.[DueDate],
+    i.[TotalAmount],
+    i.[Status],
+    i.[CreatedAt],
+    i.[UpdatedAt]
 FROM
-    [dbo].[Invoices];
+    [dbo].[Invoices] i
+    LEFT JOIN [dbo].[Customers] c ON i.[CustomerId] = c.[Id];
 GO

--- a/database/dbo/Views/v_Projects.sql
+++ b/database/dbo/Views/v_Projects.sql
@@ -1,0 +1,18 @@
+CREATE VIEW [dbo].[v_Projects] AS
+SELECT
+    p.[Id],
+    p.[Name],
+    p.[CustomerId],
+    c.[Name] AS CustomerName,
+    p.[Description],
+    p.[Status],
+    p.[StartDate],
+    p.[EndDate],
+    p.[BudgetedHours],
+    p.[BudgetedAmount],
+    p.[CreatedAt],
+    p.[UpdatedAt]
+FROM
+    [dbo].[Projects] p
+    LEFT JOIN [dbo].[Customers] c ON p.[CustomerId] = c.[Id];
+GO

--- a/database/dbo/Views/v_TimeEntries.sql
+++ b/database/dbo/Views/v_TimeEntries.sql
@@ -1,0 +1,20 @@
+CREATE VIEW [dbo].[v_TimeEntries] AS
+SELECT
+    t.[Id],
+    t.[ProjectId],
+    p.[Name] AS ProjectName,
+    t.[CustomerId],
+    t.[EmployeeName],
+    t.[EntryDate],
+    t.[Hours],
+    t.[HourlyRate],
+    t.[Description],
+    t.[IsBillable],
+    t.[Status],
+    t.[InvoiceLineId],
+    t.[CreatedAt],
+    t.[UpdatedAt]
+FROM
+    [dbo].[TimeEntries] t
+    LEFT JOIN [dbo].[Projects] p ON t.[ProjectId] = p.[Id];
+GO


### PR DESCRIPTION
## Summary
- Add CustomerName column to invoices and estimates list pages
- Add VendorName column to bills list page (using existing v_Bills view)
- Add CustomerName column to projects list page
- Add ProjectName column to time entries page
- Remove inefficient pattern of fetching entire lookup tables to display names

## Changes
- Updated SQL views (v_Invoices, v_Estimates) to JOIN with Customers table
- Created new views (v_Projects, v_TimeEntries) with related entity names
- Updated DAB config to use views and expose new name fields
- Simplified frontend code by removing lookup queries and maps

## Benefits
- Names are now sortable and filterable (they're real database columns)
- Reduced API calls - no more fetching all customers/vendors/projects just for name lookup
- Better performance, especially with large datasets

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)