### PR TITLE
Fix silent form validation failure when editing records

### DIFF
--- a/client/src/components/BillForm.tsx
+++ b/client/src/components/BillForm.tsx
@@ -18,9 +18,9 @@ export const billSchema = z.object({
   Terms: z.string().optional(),
   Memo: z.string().optional(),
   Lines: z.array(z.object({
-    Id: z.string().optional(),
+    Id: z.string().nullish(),
     AccountId: z.string().uuid('Please select an account'),
-    Description: z.string().optional(),
+    Description: z.string().nullish(),
     Amount: z.number().min(0, 'Amount must be positive')
   })).min(1, 'At least one line item is required')
 });

--- a/client/src/components/EstimateForm.tsx
+++ b/client/src/components/EstimateForm.tsx
@@ -9,12 +9,12 @@ import ProductServiceSelector, { ProductService } from './ProductServiceSelector
 
 // Line item schema with proper validation
 const lineItemSchema = z.object({
-  Id: z.string().optional(),
-  ProductServiceId: z.string().optional(),
+  Id: z.string().nullish(),
+  ProductServiceId: z.string().nullish(),
   Description: z.string().min(1, 'Description is required'),
   Quantity: z.number().min(0.0001, 'Quantity must be positive'),
   UnitPrice: z.number().min(0, 'Unit price must be zero or positive'),
-  Amount: z.number().optional()
+  Amount: z.number().nullish()
 });
 
 // Main estimate schema with date validation

--- a/client/src/components/InvoiceForm.tsx
+++ b/client/src/components/InvoiceForm.tsx
@@ -15,12 +15,12 @@ export const invoiceSchema = z.object({
   TotalAmount: z.number().min(0, 'Amount must be positive'),
   Status: z.enum(['Draft', 'Sent', 'Paid', 'Overdue']),
   Lines: z.array(z.object({
-    Id: z.string().optional(),
-    ProductServiceId: z.string().optional(),
+    Id: z.string().nullish(),
+    ProductServiceId: z.string().nullish(),
     Description: z.string().min(1, 'Description is required'),
     Quantity: z.number().min(1, 'Quantity must be at least 1'),
     UnitPrice: z.number().min(0, 'Unit price must be positive'),
-    Amount: z.number().optional()
+    Amount: z.number().nullish()
   })).min(1, 'At least one line item is required')
 });
 

--- a/client/tests/estimates.spec.ts
+++ b/client/tests/estimates.spec.ts
@@ -61,8 +61,7 @@ test.describe('Estimates Management', () => {
     await expect(page).toHaveURL(/\/estimates$/, { timeout: 30000 });
   });
 
-  // TODO: Known issue - form save not triggering in test environment (works in browser)
-  test.skip('should edit an existing estimate', async ({ page }) => {
+  test('should edit an existing estimate', async ({ page }) => {
     const timestamp = Date.now();
     const estimateNumber = `EST-EDIT-${timestamp}`;
 


### PR DESCRIPTION
## Summary
- Fix Zod schema validation that silently failed when editing existing records
- Use `.nullish()` instead of `.optional()` for API fields that can return `null`
- Enable previously-skipped edit estimate test
- Document the pattern in CLAUDE.md lessons learned

## Root Cause
PR #137 added `ProductServiceId: z.string().optional()` to line item schemas, but:
- Database columns are `UNIQUEIDENTIFIER NULL`
- API returns `null` for empty fields (not `undefined`)
- Zod `.optional()` only accepts `undefined`, causing silent validation failure

## Files Changed
- `EstimateForm.tsx` - line item schema
- `InvoiceForm.tsx` - line item schema
- `BillForm.tsx` - line item schema
- `estimates.spec.ts` - enable edit test
- `CLAUDE.md` - document lesson learned

## Test plan
- [x] `npm run build` passes
- [x] All estimate tests pass (including previously-skipped edit test)
- [x] Manual test: edit existing estimate and save successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)