### PR TITLE
fix: Estimates convert button not working (#142)

### DIFF
--- a/client/tests/estimates.spec.ts
+++ b/client/tests/estimates.spec.ts
@@ -283,11 +283,13 @@ test.describe('Estimates Management', () => {
     await page.waitForSelector('.MuiDataGrid-root', { timeout: 15000 });
     await page.waitForSelector('.MuiDataGrid-row', { timeout: 15000 });
 
-    // 3. Find and click the first available Convert button
-    const convertButtons = page.getByRole('button', { name: /Convert/i });
-    const firstConvertButton = convertButtons.first();
-    await expect(firstConvertButton).toBeVisible({ timeout: 10000 });
-    await firstConvertButton.click();
+    // 3. Find the specific estimate row by estimateNumber and click its Convert button
+    const estimateRow = page.locator('.MuiDataGrid-row').filter({ hasText: estimateNumber });
+    await expect(estimateRow).toBeVisible({ timeout: 10000 });
+    
+    const convertButton = estimateRow.getByRole('button', { name: /Convert/i });
+    await expect(convertButton).toBeVisible({ timeout: 10000 });
+    await convertButton.click();
 
     // 4. Wait for confirmation modal to appear
     const modalTitle = page.getByRole('heading', { name: 'Convert to Invoice' });
@@ -301,7 +303,19 @@ test.describe('Estimates Management', () => {
     // 5. Should redirect to invoice edit page
     await expect(page).toHaveURL(/\/invoices\/.*\/edit/, { timeout: 30000 });
 
-    // 6. Verify the invoice page loads correctly
+    // 6. Verify the invoice page loads correctly and contains data from the estimate
     await expect(page.getByRole('heading', { name: /Edit Invoice/i })).toBeVisible({ timeout: 10000 });
+    
+    // Verify the invoice has the correct customer (should match the estimate)
+    const customerButton = page.getByRole('button', { name: /Acme Corporation/i });
+    await expect(customerButton).toBeVisible({ timeout: 5000 });
+    
+    // Verify the total amount matches the estimate
+    const totalAmountField = page.getByLabel('Total Amount');
+    await expect(totalAmountField).toHaveValue('1500');
+    
+    // Verify the status is Draft
+    const statusField = page.getByLabel('Status');
+    await expect(statusField).toHaveValue('Draft');
   });
 });


### PR DESCRIPTION
## Summary
Fix the Convert button on the /estimates page that was not working.

## Root Cause
1. **DAB POST Response Issue**: When creating an invoice via `POST /api/invoices_write`, DAB returns `{"value":[]}` instead of the created entity. The code was trying to use `invoiceResponse.data.Id` which was undefined.

2. **Escaped Dollar Sign**: The code used `\$filter` in template literals which was being interpreted literally, causing 400 Bad Request errors.

## Changes
- After creating invoice via POST, query by `InvoiceNumber` to get the actual invoice ID
- Fixed `\$filter` → `$filter` in query strings
- Unskipped and fixed the Playwright test for convert functionality

## Test plan
- [x] `npm run build` passes
- [x] `npx playwright test estimates.spec.ts --grep "convert"` passes
- [x] All 5 estimates tests pass

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)