### PR TITLE
fix: Remove excessive dashboard padding and wasted space (#139)

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -172,7 +172,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="max-w-6xl mx-auto">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
         <p className="mt-2 text-sm text-gray-600">Financial overview and pending actions</p>


### PR DESCRIPTION
## Summary
Fix excessive empty space between the left sidebar and main dashboard content.

## Changes
Changed the dashboard container class from:
```diff
- <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+ <div className="max-w-6xl mx-auto">
```

This matches the consistent pattern used by other pages (Invoices, Bills, Customers, etc.)

## Test plan
- [x] `npm run build` passes
- [x] Layout matches other pages
- [x] Responsive behavior preserved

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)