### PR TITLE
feat: Add Purchase Orders module

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -57,6 +57,9 @@ import Inventory from './pages/Inventory';
 import Bills from './pages/Bills';
 import NewBill from './pages/NewBill';
 import EditBill from './pages/EditBill';
+import PurchaseOrders from './pages/PurchaseOrders';
+import NewPurchaseOrder from './pages/NewPurchaseOrder';
+import EditPurchaseOrder from './pages/EditPurchaseOrder';
 import RecurringTransactions from './pages/RecurringTransactions';
 import Submissions from './pages/Submissions';
 import NewSubmission from './pages/NewSubmission';
@@ -126,6 +129,9 @@ function AppContent() {
             <Route path="bills" element={<Bills />} />
             <Route path="bills/new" element={<NewBill />} />
             <Route path="bills/:id/edit" element={<EditBill />} />
+            <Route path="purchase-orders" element={<PurchaseOrders />} />
+            <Route path="purchase-orders/new" element={<NewPurchaseOrder />} />
+            <Route path="purchase-orders/:id/edit" element={<EditPurchaseOrder />} />
             <Route path="projects" element={<Projects />} />
             <Route path="projects/new" element={<NewProject />} />
             <Route path="projects/:id/edit" element={<EditProject />} />

--- a/client/src/components/PurchaseOrderForm.tsx
+++ b/client/src/components/PurchaseOrderForm.tsx
@@ -1,0 +1,355 @@
+import { useForm, useFieldArray, useWatch, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '../lib/api';
+import ProductServiceSelector, { ProductService } from './ProductServiceSelector';
+
+// Line item schema with proper validation
+const lineItemSchema = z.object({
+  Id: z.string().nullish(),
+  ProductServiceId: z.string().nullish(),
+  Description: z.string().min(1, 'Description is required'),
+  Quantity: z.number().min(0.0001, 'Quantity must be positive'),
+  UnitPrice: z.number().min(0, 'Unit price must be zero or positive'),
+  Amount: z.number().nullish()
+});
+
+// Main purchase order schema with date validation
+export const purchaseOrderSchema = z.object({
+  PONumber: z.string().min(1, 'PO number is required'),
+  VendorId: z.string().uuid('Please select a valid vendor'),
+  PODate: z.string().min(1, 'PO date is required'),
+  ExpectedDate: z.string().optional(),
+  Subtotal: z.number().min(0, 'Subtotal must be zero or positive'),
+  Total: z.number().min(0, 'Total must be zero or positive'),
+  Status: z.enum(['Draft', 'Sent', 'Received', 'Partial', 'Cancelled']),
+  Notes: z.string().optional(),
+  Lines: z.array(lineItemSchema).min(1, 'At least one line item is required')
+}).refine((data) => {
+  // Validate that ExpectedDate is on or after PODate if both are provided
+  if (data.ExpectedDate && data.PODate) {
+    return new Date(data.ExpectedDate) >= new Date(data.PODate);
+  }
+  return true;
+}, {
+  message: 'Expected date must be on or after the PO date',
+  path: ['ExpectedDate']
+});
+
+export type PurchaseOrderFormData = z.infer<typeof purchaseOrderSchema>;
+
+export interface PurchaseOrderLine {
+  Id?: string;
+  ProductServiceId?: string;
+  Description: string;
+  Quantity: number;
+  UnitPrice: number;
+  Amount?: number;
+}
+
+interface Vendor {
+  Id: string;
+  Name: string;
+  PaymentTerms: string;
+}
+
+interface PurchaseOrderFormProps {
+  initialValues?: Partial<PurchaseOrderFormData>;
+  onSubmit: (data: PurchaseOrderFormData) => Promise<void>;
+  title: string;
+  isSubmitting?: boolean;
+  submitButtonText?: string;
+}
+
+export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSubmitting: externalIsSubmitting, submitButtonText = 'Save Purchase Order' }: PurchaseOrderFormProps) {
+  const navigate = useNavigate();
+
+  const { data: vendors } = useQuery({
+    queryKey: ['vendors'],
+    queryFn: async () => {
+      const response = await api.get<{ value: Vendor[] }>('/vendors');
+      return response.data.value;
+    },
+  });
+
+  const { register, control, handleSubmit, setValue, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<PurchaseOrderFormData>({
+    resolver: zodResolver(purchaseOrderSchema),
+    defaultValues: {
+      Status: 'Draft',
+      PODate: new Date().toISOString().split('T')[0],
+      ExpectedDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().split('T')[0], // 2 weeks from now
+      Lines: [{ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0 }],
+      Subtotal: 0,
+      Total: 0,
+      Notes: '',
+      ...initialValues
+    }
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "Lines"
+  });
+
+  const lines = useWatch({
+    control,
+    name: "Lines"
+  });
+
+  useEffect(() => {
+    const subtotal = lines.reduce((sum, line) => {
+      return sum + (line.Quantity || 0) * (line.UnitPrice || 0);
+    }, 0);
+    setValue('Subtotal', subtotal);
+    setValue('Total', subtotal); // For now, total equals subtotal (no taxes on POs)
+  }, [lines, setValue]);
+
+  const isSubmitting = externalIsSubmitting || formIsSubmitting;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6 flex items-center">
+        <button onClick={() => navigate('/purchase-orders')} className="mr-4 text-gray-500 hover:text-gray-700">
+          <ArrowLeft className="w-6 h-6" />
+        </button>
+        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <div>
+            <label htmlFor="PONumber" className="block text-sm font-medium text-gray-700">
+              PO Number <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="PONumber"
+              type="text"
+              {...register('PONumber')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              placeholder="PO-001"
+            />
+            {errors.PONumber && <p className="mt-1 text-sm text-red-600">{errors.PONumber.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="VendorId" className="block text-sm font-medium text-gray-700">
+              Vendor <span className="text-red-500">*</span>
+            </label>
+            <select
+              id="VendorId"
+              {...register('VendorId')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="">Select a vendor...</option>
+              {vendors?.map((vendor) => (
+                <option key={vendor.Id} value={vendor.Id}>
+                  {vendor.Name}
+                </option>
+              ))}
+            </select>
+            {errors.VendorId && <p className="mt-1 text-sm text-red-600">{errors.VendorId.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="PODate" className="block text-sm font-medium text-gray-700">
+              PO Date <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="PODate"
+              type="date"
+              {...register('PODate')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            />
+            {errors.PODate && <p className="mt-1 text-sm text-red-600">{errors.PODate.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="ExpectedDate" className="block text-sm font-medium text-gray-700">
+              Expected Delivery Date
+            </label>
+            <input
+              id="ExpectedDate"
+              type="date"
+              {...register('ExpectedDate')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            />
+            {errors.ExpectedDate && <p className="mt-1 text-sm text-red-600">{errors.ExpectedDate.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="Status" className="block text-sm font-medium text-gray-700">Status</label>
+            <select
+              id="Status"
+              {...register('Status')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="Draft">Draft</option>
+              <option value="Sent">Sent</option>
+              <option value="Received">Received</option>
+              <option value="Partial">Partial</option>
+              <option value="Cancelled">Cancelled</option>
+            </select>
+            {errors.Status && <p className="mt-1 text-sm text-red-600">{errors.Status.message}</p>}
+          </div>
+        </div>
+
+        {/* Notes */}
+        <div>
+          <label htmlFor="Notes" className="block text-sm font-medium text-gray-700">Notes</label>
+          <textarea
+            id="Notes"
+            rows={3}
+            {...register('Notes')}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            placeholder="Additional notes for this purchase order..."
+          />
+        </div>
+
+        {/* Line Items */}
+        <div className="mt-8">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-medium text-gray-900">
+              Line Items <span className="text-red-500">*</span>
+            </h3>
+            <button
+              type="button"
+              onClick={() => append({ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0 })}
+              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              Add Item
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            {fields.map((field, index) => {
+              const handleProductServiceSelect = (productServiceId: string, productService?: ProductService) => {
+                setValue(`Lines.${index}.ProductServiceId`, productServiceId);
+                if (productService) {
+                  // Auto-populate description and price from product/service
+                  setValue(`Lines.${index}.Description`, productService.Name);
+                  // Use PurchaseCost for purchase orders (not SalesPrice)
+                  if (productService.PurchaseCost !== null) {
+                    setValue(`Lines.${index}.UnitPrice`, productService.PurchaseCost);
+                  } else if (productService.SalesPrice !== null) {
+                    // Fall back to sales price if no purchase cost is set
+                    setValue(`Lines.${index}.UnitPrice`, productService.SalesPrice);
+                  }
+                }
+              };
+
+              return (
+                <div key={field.id} className="bg-gray-50 p-4 rounded-md">
+                  <div className="flex gap-4 items-start mb-3">
+                    <div className="flex-grow">
+                      <label className="block text-xs font-medium text-gray-500">Product/Service</label>
+                      <Controller
+                        name={`Lines.${index}.ProductServiceId`}
+                        control={control}
+                        render={({ field: psField }) => (
+                          <ProductServiceSelector
+                            value={psField.value || ''}
+                            onChange={handleProductServiceSelect}
+                            disabled={isSubmitting}
+                            placeholder="Select or type description below"
+                          />
+                        )}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex gap-4 items-start">
+                    <div className="flex-grow">
+                      <label className="block text-xs font-medium text-gray-500">
+                        Description <span className="text-red-500">*</span>
+                      </label>
+                      <input
+                        {...register(`Lines.${index}.Description`)}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                        placeholder="Item description"
+                      />
+                      {errors.Lines?.[index]?.Description && (
+                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Description?.message}</p>
+                      )}
+                    </div>
+                    <div className="w-24">
+                      <label className="block text-xs font-medium text-gray-500">
+                        Qty <span className="text-red-500">*</span>
+                      </label>
+                      <input
+                        type="number"
+                        step="0.0001"
+                        min="0.0001"
+                        {...register(`Lines.${index}.Quantity`, { valueAsNumber: true })}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      />
+                      {errors.Lines?.[index]?.Quantity && (
+                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Quantity?.message}</p>
+                      )}
+                    </div>
+                    <div className="w-32">
+                      <label className="block text-xs font-medium text-gray-500">
+                        Unit Price <span className="text-red-500">*</span>
+                      </label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        {...register(`Lines.${index}.UnitPrice`, { valueAsNumber: true })}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      />
+                      {errors.Lines?.[index]?.UnitPrice && (
+                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.UnitPrice?.message}</p>
+                      )}
+                    </div>
+                    <div className="w-32">
+                      <label className="block text-xs font-medium text-gray-500">Amount</label>
+                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium">
+                        ${((lines[index]?.Quantity || 0) * (lines[index]?.UnitPrice || 0)).toFixed(2)}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => remove(index)}
+                      disabled={fields.length === 1}
+                      className="mt-6 text-red-600 hover:text-red-800 disabled:text-gray-300 disabled:cursor-not-allowed"
+                      title={fields.length === 1 ? 'At least one line item is required' : 'Remove item'}
+                    >
+                      <Trash2 className="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {errors.Lines && typeof errors.Lines.message === 'string' && (
+            <p className="mt-2 text-sm text-red-600">{errors.Lines.message}</p>
+          )}
+        </div>
+
+        <div className="flex justify-end items-center border-t pt-4">
+          <div className="text-xl font-bold text-gray-900 mr-6">
+            Total: ${lines.reduce((sum, line) => sum + (line.Quantity || 0) * (line.UnitPrice || 0), 0).toFixed(2)}
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/purchase-orders')}
+            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Saving...' : submitButtonText}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/navigation/navConfig.ts
+++ b/client/src/components/navigation/navConfig.ts
@@ -1,4 +1,4 @@
-import { LucideIcon, LayoutDashboard, FileText, ClipboardList, Users, Package, Warehouse, Truck, UserCheck, DollarSign, Receipt, FolderOpen, Clock, Tag, MapPin, RefreshCw, Layers, Building2, BookOpen, Upload, Database, Scale, BarChart3, MessageSquare, Sparkles, Settings } from 'lucide-react';
+import { LucideIcon, LayoutDashboard, FileText, ClipboardList, Users, Package, Warehouse, Truck, UserCheck, DollarSign, Receipt, FolderOpen, Clock, Tag, MapPin, RefreshCw, Layers, Building2, BookOpen, Upload, Database, Scale, BarChart3, MessageSquare, Sparkles, Settings, ShoppingCart } from 'lucide-react';
 
 export interface NavItem {
   id: string;
@@ -40,12 +40,15 @@ export const navigationConfig: NavEntry[] = [
     ],
   },
 
-  // Bills - standalone
+  // Purchasing group
   {
-    id: 'bills',
-    name: 'Bills',
-    href: '/bills',
+    id: 'purchasing',
+    name: 'Purchasing',
     icon: Receipt,
+    items: [
+      { id: 'purchase-orders', name: 'Purchase Orders', href: '/purchase-orders', icon: ShoppingCart },
+      { id: 'bills', name: 'Bills', href: '/bills', icon: Receipt },
+    ],
   },
 
   // People group

--- a/client/src/pages/EditPurchaseOrder.tsx
+++ b/client/src/pages/EditPurchaseOrder.tsx
@@ -1,0 +1,139 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../lib/api';
+import PurchaseOrderForm, { PurchaseOrderFormData } from '../components/PurchaseOrderForm';
+import { formatGuidForOData, isValidUUID } from '../lib/validation';
+import { useToast } from '../hooks/useToast';
+
+interface PurchaseOrder {
+  Id: string;
+  PONumber: string;
+  VendorId: string;
+  PODate: string;
+  ExpectedDate?: string;
+  Subtotal: number;
+  Total: number;
+  Status: 'Draft' | 'Sent' | 'Received' | 'Partial' | 'Cancelled';
+  Notes?: string;
+  Lines?: PurchaseOrderLine[];
+}
+
+interface PurchaseOrderLine {
+  Id?: string;
+  PurchaseOrderId: string;
+  ProductServiceId?: string;
+  Description: string;
+  Quantity: number;
+  UnitPrice: number;
+  Amount?: number;
+}
+
+export default function EditPurchaseOrder() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  // Validate ID early
+  const isIdValid = isValidUUID(id);
+
+  const { data: purchaseOrder, isLoading, error } = useQuery({
+    queryKey: ['purchaseorder', id],
+    queryFn: async () => {
+      // Validate ID before using in OData filter
+      if (!isValidUUID(id)) {
+        throw new Error('Invalid purchase order ID');
+      }
+
+      // Fetch purchase order and lines separately since $expand is not supported
+      // Use properly quoted GUID in OData filter
+      const [poResponse, linesResponse] = await Promise.all([
+        api.get<{ value: PurchaseOrder[] }>(`/purchaseorders?$filter=Id eq ${formatGuidForOData(id, 'PurchaseOrderId')}`),
+        api.get<{ value: PurchaseOrderLine[] }>(`/purchaseorderlines?$filter=PurchaseOrderId eq ${formatGuidForOData(id, 'PurchaseOrderId')}`)
+      ]);
+
+      const purchaseOrder = poResponse.data.value[0];
+      if (purchaseOrder) {
+        purchaseOrder.Lines = linesResponse.data.value;
+      }
+      return purchaseOrder;
+    },
+    enabled: isIdValid
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: PurchaseOrderFormData) => {
+      // Validate ID before using
+      if (!isValidUUID(id)) {
+        throw new Error('Invalid purchase order ID');
+      }
+
+      // 1. Update PurchaseOrder (exclude Lines)
+      const { Lines, ...poData } = data;
+      await api.patch(`/purchaseorders_write/Id/${id}`, poData);
+
+      // 2. Handle Lines Reconciliation
+      // Fetch current lines from DB to know what to delete
+      // Use properly quoted GUID in OData filter
+      const currentLinesResponse = await api.get<{ value: PurchaseOrderLine[] }>(
+        `/purchaseorderlines?$filter=PurchaseOrderId eq ${formatGuidForOData(id, 'PurchaseOrderId')}`
+      );
+      const currentLines = currentLinesResponse.data.value;
+      const currentLineIds = new Set(currentLines.map(l => l.Id));
+
+      const incomingLines = Lines || [];
+      const incomingLineIds = new Set(incomingLines.map(l => l.Id).filter(Boolean));
+
+      // Identify operations
+      const toDelete = currentLines.filter(l => !incomingLineIds.has(l.Id));
+      const toUpdate = incomingLines.filter(l => l.Id && currentLineIds.has(l.Id));
+      const toAdd = incomingLines.filter(l => !l.Id);
+
+      // Execute operations
+      const promises = [
+        ...toDelete.map(l => api.delete(`/purchaseorderlines/Id/${l.Id}`)),
+        ...toUpdate.map(l => api.patch(`/purchaseorderlines/Id/${l.Id}`, {
+          ProductServiceId: l.ProductServiceId || null,
+          Description: l.Description,
+          Quantity: l.Quantity,
+          UnitPrice: l.UnitPrice
+        })),
+        ...toAdd.map(l => api.post('/purchaseorderlines', {
+          PurchaseOrderId: id,
+          ProductServiceId: l.ProductServiceId || null,
+          Description: l.Description,
+          Quantity: l.Quantity,
+          UnitPrice: l.UnitPrice
+        }))
+      ];
+
+      await Promise.all(promises);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['purchaseorders'] });
+      queryClient.invalidateQueries({ queryKey: ['purchaseorder', id] });
+      showToast('Purchase order updated successfully', 'success');
+      navigate('/purchase-orders');
+    },
+    onError: (error) => {
+      console.error('Failed to update purchase order:', error);
+      showToast('Failed to update purchase order', 'error');
+    }
+  });
+
+  if (!isIdValid) {
+    return <div className="p-4 text-red-600">Invalid purchase order ID</div>;
+  }
+
+  if (isLoading) return <div className="p-4">Loading purchase order...</div>;
+  if (error || !purchaseOrder) return <div className="p-4 text-red-600">Error loading purchase order</div>;
+
+  return (
+    <PurchaseOrderForm
+      title="Edit Purchase Order"
+      initialValues={purchaseOrder}
+      onSubmit={(data) => mutation.mutateAsync(data)}
+      isSubmitting={mutation.isPending}
+    />
+  );
+}

--- a/client/src/pages/NewPurchaseOrder.tsx
+++ b/client/src/pages/NewPurchaseOrder.tsx
@@ -1,0 +1,70 @@
+import { useNavigate } from 'react-router-dom';
+import api from '../lib/api';
+import PurchaseOrderForm, { PurchaseOrderFormData } from '../components/PurchaseOrderForm';
+import { useToast } from '../hooks/useToast';
+
+interface CreatePurchaseOrderResponse {
+  Id: string;
+  PONumber: string;
+  VendorId: string;
+  PODate: string;
+  ExpectedDate: string | null;
+  Subtotal: number;
+  Total: number;
+  Status: string;
+  Notes: string | null;
+}
+
+export default function NewPurchaseOrder() {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  const onSubmit = async (data: PurchaseOrderFormData) => {
+    try {
+      // Separate lines from purchase order data
+      const { Lines, ...poData } = data;
+
+      // Create the purchase order first
+      await api.post('/purchaseorders_write', poData);
+
+      // DAB doesn't return the created entity, so we need to query for it
+      const escapedPONumber = String(poData.PONumber).replace(/'/g, "''");
+      const queryResponse = await api.get<{ value: CreatePurchaseOrderResponse[] }>(
+        `/purchaseorders?$filter=PONumber eq '${escapedPONumber}'`
+      );
+      const purchaseOrder = queryResponse.data.value[0];
+
+      if (!purchaseOrder?.Id) {
+        throw new Error('Failed to retrieve created purchase order');
+      }
+
+      // Create purchase order lines
+      await Promise.all(
+        Lines.map((line) =>
+          api.post('/purchaseorderlines', {
+            PurchaseOrderId: purchaseOrder.Id,
+            ProductServiceId: line.ProductServiceId || null,
+            Description: line.Description,
+            Quantity: line.Quantity,
+            UnitPrice: line.UnitPrice,
+          })
+        )
+      );
+
+      showToast('Purchase order created successfully', 'success');
+      navigate('/purchase-orders');
+    } catch (error) {
+      console.error('Failed to create purchase order:', error);
+      showToast('Failed to create purchase order', 'error');
+      throw error; // Re-throw to keep the form in submitting state
+    }
+  };
+
+  return (
+    <PurchaseOrderForm
+      title="New Purchase Order"
+      onSubmit={onSubmit}
+      submitButtonText="Create Purchase Order"
+    />
+  );
+}

--- a/client/src/pages/PurchaseOrders.tsx
+++ b/client/src/pages/PurchaseOrders.tsx
@@ -1,0 +1,264 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../lib/api';
+import { Plus, FileText, ArrowRight } from 'lucide-react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useState } from 'react';
+import { GridColDef } from '@mui/x-data-grid';
+import RestDataGrid from '../components/RestDataGrid';
+import { formatGuidForOData, isValidUUID } from '../lib/validation';
+import { formatDate } from '../lib/dateUtils';
+import ConfirmModal from '../components/ConfirmModal';
+import { useToast } from '../hooks/useToast';
+
+interface PurchaseOrder {
+  Id: string;
+  PONumber: string;
+  VendorId: string;
+  VendorName: string;
+  PODate: string;
+  ExpectedDate: string | null;
+  Total: number;
+  Status: string;
+  ConvertedToBillId: string | null;
+  Notes: string | null;
+}
+
+interface PurchaseOrderLine {
+  Id: string;
+  PurchaseOrderId: string;
+  ProductServiceId: string | null;
+  Description: string;
+  Quantity: number;
+  UnitPrice: number;
+  Amount?: number;
+}
+
+interface Bill {
+  Id: string;
+  BillNumber: string;
+  VendorId: string;
+  BillDate: string;
+  DueDate: string;
+  TotalAmount: number;
+  Status: string;
+}
+
+const statusColors: Record<string, string> = {
+  Draft: 'bg-gray-100 text-gray-800',
+  Sent: 'bg-blue-100 text-blue-800',
+  Received: 'bg-green-100 text-green-800',
+  Partial: 'bg-yellow-100 text-yellow-800',
+  Cancelled: 'bg-red-100 text-red-800',
+  Converted: 'bg-purple-100 text-purple-800',
+};
+
+export default function PurchaseOrders() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [confirmModal, setConfirmModal] = useState<{
+    isOpen: boolean;
+    purchaseOrder: PurchaseOrder | null;
+  }>({ isOpen: false, purchaseOrder: null });
+
+  const convertToBillMutation = useMutation({
+    mutationFn: async (purchaseOrder: PurchaseOrder) => {
+      if (!isValidUUID(purchaseOrder.Id)) {
+        throw new Error('Invalid purchase order ID');
+      }
+
+      // Fetch purchase order lines
+      const linesResponse = await api.get<{ value: PurchaseOrderLine[] }>(
+        `/purchaseorderlines?\$filter=PurchaseOrderId eq ${formatGuidForOData(purchaseOrder.Id, 'PurchaseOrderId')}`
+      );
+      const lines = linesResponse.data.value;
+
+      // Generate bill number
+      const billNumber = `BILL-${Date.now().toString().slice(-6)}`;
+
+      // Create the bill
+      const billResponse = await api.post<Bill>('/bills_write', {
+        BillNumber: billNumber,
+        VendorId: purchaseOrder.VendorId,
+        BillDate: new Date().toISOString().split('T')[0],
+        DueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+        TotalAmount: purchaseOrder.Total,
+        AmountPaid: 0,
+        Status: 'Open',
+        Terms: 'Net 30',
+        Memo: `Converted from PO ${purchaseOrder.PONumber}`,
+      });
+      const bill = billResponse.data;
+
+      // Fetch all expense accounts to find a default
+      const accountsResponse = await api.get<{ value: { Id: string; Name: string; Type: string }[] }>(
+        `/accounts?\$filter=Type eq 'Expense'&\$top=1`
+      );
+      const defaultAccountId = accountsResponse.data.value[0]?.Id;
+
+      if (!defaultAccountId) {
+        throw new Error('No expense account found for bill lines');
+      }
+
+      // Create bill lines from purchase order lines
+      await Promise.all(
+        lines.map((line: PurchaseOrderLine) =>
+          api.post('/billlines', {
+            BillId: bill.Id,
+            AccountId: defaultAccountId, // Use default expense account
+            Description: line.Description,
+            Amount: (line.Quantity || 0) * (line.UnitPrice || 0),
+          })
+        )
+      );
+
+      // Update purchase order status and link to bill
+      await api.patch(`/purchaseorders_write/Id/${purchaseOrder.Id}`, {
+        Status: 'Received',
+        ConvertedToBillId: bill.Id,
+      });
+
+      return bill;
+    },
+    onSuccess: (bill) => {
+      queryClient.invalidateQueries({ queryKey: ['purchaseorders'] });
+      queryClient.invalidateQueries({ queryKey: ['bills'] });
+      setRefreshKey(k => k + 1);
+      showToast('Purchase order converted to bill successfully', 'success');
+      navigate(`/bills/${bill.Id}/edit`);
+    },
+    onError: (error) => {
+      console.error('Failed to convert purchase order:', error);
+      showToast('Failed to convert purchase order to bill', 'error');
+    },
+  });
+
+  const handleConvertClick = (purchaseOrder: PurchaseOrder) => {
+    setConfirmModal({ isOpen: true, purchaseOrder });
+  };
+
+  const handleConfirmConvert = () => {
+    if (confirmModal.purchaseOrder) {
+      convertToBillMutation.mutate(confirmModal.purchaseOrder);
+    }
+    setConfirmModal({ isOpen: false, purchaseOrder: null });
+  };
+
+  const handleCloseModal = () => {
+    setConfirmModal({ isOpen: false, purchaseOrder: null });
+  };
+
+  const columns: GridColDef[] = [
+    { field: 'PONumber', headerName: 'PO #', width: 130, filterable: true },
+    { field: 'VendorName', headerName: 'Vendor', width: 180, filterable: true },
+    { field: 'PODate', headerName: 'Date', width: 120, filterable: true, renderCell: (params) => formatDate(params.value) },
+    {
+      field: 'ExpectedDate',
+      headerName: 'Expected',
+      width: 120,
+      filterable: true,
+      renderCell: (params) => formatDate(params.value) || '-'
+    },
+    {
+      field: 'Total',
+      headerName: 'Total',
+      width: 120,
+      type: 'number',
+      filterable: true,
+      renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
+    },
+    {
+      field: 'Status',
+      headerName: 'Status',
+      width: 120,
+      filterable: true,
+      renderCell: (params) => (
+        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${statusColors[params.value] || 'bg-gray-100 text-gray-800'}`}>
+          {params.value}
+        </span>
+      ),
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      width: 250,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/purchase-orders/${params.row.Id}/edit`);
+            }}
+            className="text-indigo-600 hover:text-indigo-900"
+          >
+            Edit
+          </button>
+          {(params.row.Status === 'Sent' || params.row.Status === 'Draft') &&
+            !params.row.ConvertedToBillId && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleConvertClick(params.row as PurchaseOrder);
+                }}
+                disabled={convertToBillMutation.isPending}
+                className="text-green-600 hover:text-green-900 inline-flex items-center"
+              >
+                <ArrowRight className="w-4 h-4 mr-1" />
+                Convert to Bill
+              </button>
+            )}
+          {params.row.ConvertedToBillId && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                navigate(`/bills/${params.row.ConvertedToBillId}/edit`);
+              }}
+              className="text-purple-600 hover:text-purple-900 inline-flex items-center"
+            >
+              <FileText className="w-4 h-4 mr-1" />
+              View Bill
+            </button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">Purchase Orders</h1>
+        <Link
+          to="/purchase-orders/new"
+          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          New Purchase Order
+        </Link>
+      </div>
+
+      <RestDataGrid<PurchaseOrder>
+        key={refreshKey}
+        endpoint="/purchaseorders"
+        columns={columns}
+        editPath="/purchase-orders/{id}/edit"
+        initialPageSize={25}
+        emptyMessage="No purchase orders found."
+      />
+
+      <ConfirmModal
+        isOpen={confirmModal.isOpen}
+        onClose={handleCloseModal}
+        onConfirm={handleConfirmConvert}
+        title="Convert to Bill"
+        message={`Are you sure you want to convert purchase order ${confirmModal.purchaseOrder?.PONumber || ''} to a bill? This action will create a new bill with the same line items.`}
+        confirmText="Convert"
+        cancelText="Cancel"
+        isLoading={convertToBillMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/dab-config.json
+++ b/dab-config.json
@@ -993,6 +993,126 @@
                 "Id"
             ]
         },
+        "purchaseorders": {
+            "source": {
+                "object": "dbo.v_PurchaseOrders",
+                "type": "view",
+                "key-fields": ["Id"]
+            },
+            "graphql": {
+                "enabled": false
+            },
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "VendorId": "VendorId",
+                "VendorName": "VendorName",
+                "PONumber": "PONumber",
+                "PODate": "PODate",
+                "ExpectedDate": "ExpectedDate",
+                "Status": "Status",
+                "Notes": "Notes",
+                "Subtotal": "Subtotal",
+                "Total": "Total",
+                "ConvertedToBillId": "ConvertedToBillId",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            }
+        },
+        "purchaseorders_write": {
+            "source": "dbo.PurchaseOrders",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "create",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ],
+            "key-fields": [
+                "Id"
+            ],
+            "mappings": {
+                "Id": "Id",
+                "VendorId": "VendorId",
+                "PONumber": "PONumber",
+                "PODate": "PODate",
+                "ExpectedDate": "ExpectedDate",
+                "Status": "Status",
+                "Notes": "Notes",
+                "Subtotal": "Subtotal",
+                "Total": "Total",
+                "ConvertedToBillId": "ConvertedToBillId"
+            },
+            "relationships": {
+                "Vendor": {
+                    "target.entity": "vendors",
+                    "cardinality": "one",
+                    "source.fields": [
+                        "VendorId"
+                    ],
+                    "target.fields": [
+                        "Id"
+                    ]
+                },
+                "Bill": {
+                    "target.entity": "bills",
+                    "cardinality": "one",
+                    "source.fields": [
+                        "ConvertedToBillId"
+                    ],
+                    "target.fields": [
+                        "Id"
+                    ]
+                }
+            }
+        },
+        "purchaseorderlines": {
+            "source": "dbo.PurchaseOrderLines",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "*"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "PurchaseOrderId": "PurchaseOrderId",
+                "ProductServiceId": "ProductServiceId",
+                "Description": "Description",
+                "Quantity": "Quantity",
+                "UnitPrice": "UnitPrice",
+                "Amount": "Amount",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            },
+            "relationships": {
+                "ProductService": {
+                    "target.entity": "productsservices",
+                    "cardinality": "one",
+                    "source.fields": [
+                        "ProductServiceId"
+                    ],
+                    "target.fields": [
+                        "Id"
+                    ]
+                }
+            },
+            "key-fields": [
+                "Id"
+            ]
+        },
         "recurringtemplates": {
             "source": "dbo.RecurringTemplates",
             "permissions": [

--- a/database/dbo/Tables/PurchaseOrderLines.sql
+++ b/database/dbo/Tables/PurchaseOrderLines.sql
@@ -1,0 +1,32 @@
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE TABLE [dbo].[PurchaseOrderLines] (
+    [Id] UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    [PurchaseOrderId] UNIQUEIDENTIFIER NOT NULL,
+    [ProductServiceId] UNIQUEIDENTIFIER NULL, -- FK to ProductsServices (optional)
+    [Description] NVARCHAR(500) NOT NULL,
+    [Quantity] DECIMAL(18, 4) NOT NULL DEFAULT 1,
+    [UnitPrice] DECIMAL(18, 2) NOT NULL DEFAULT 0,
+    [Amount] AS ([Quantity] * [UnitPrice]) PERSISTED,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    -- Temporal table columns (system-versioned)
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_PurchaseOrderLines_PurchaseOrders] FOREIGN KEY ([PurchaseOrderId])
+        REFERENCES [dbo].[PurchaseOrders] ([Id]) ON DELETE CASCADE,
+    CONSTRAINT [FK_PurchaseOrderLines_ProductsServices] FOREIGN KEY ([ProductServiceId])
+        REFERENCES [dbo].[ProductsServices] ([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[PurchaseOrderLines_History]));
+GO
+
+CREATE INDEX [IX_PurchaseOrderLines_PurchaseOrderId] ON [dbo].[PurchaseOrderLines] ([PurchaseOrderId]);
+GO
+
+CREATE INDEX [IX_PurchaseOrderLines_ProductServiceId] ON [dbo].[PurchaseOrderLines] ([ProductServiceId]);
+GO

--- a/database/dbo/Tables/PurchaseOrders.sql
+++ b/database/dbo/Tables/PurchaseOrders.sql
@@ -1,0 +1,38 @@
+CREATE TABLE [dbo].[PurchaseOrders]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [VendorId] UNIQUEIDENTIFIER NOT NULL,
+    [PONumber] NVARCHAR(50) NOT NULL,
+    [PODate] DATE NOT NULL,
+    [ExpectedDate] DATE NULL,
+    [Status] NVARCHAR(20) NOT NULL DEFAULT 'Draft', -- Draft, Sent, Received, Partial, Cancelled
+    [Notes] NVARCHAR(1000) NULL,
+    [Subtotal] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [Total] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [ConvertedToBillId] UNIQUEIDENTIFIER NULL, -- FK to Bills when converted
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+    CONSTRAINT [FK_PurchaseOrders_Vendors] FOREIGN KEY ([VendorId]) REFERENCES [dbo].[Vendors]([Id]),
+    CONSTRAINT [FK_PurchaseOrders_Bills] FOREIGN KEY ([ConvertedToBillId]) REFERENCES [dbo].[Bills]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[PurchaseOrders_History]))
+GO
+
+ALTER TABLE [dbo].[PurchaseOrders] ENABLE CHANGE_TRACKING
+WITH (TRACK_COLUMNS_UPDATED = ON)
+GO
+
+CREATE INDEX [IX_PurchaseOrders_VendorId] ON [dbo].[PurchaseOrders] ([VendorId])
+GO
+
+CREATE INDEX [IX_PurchaseOrders_Status] ON [dbo].[PurchaseOrders] ([Status])
+GO
+
+CREATE INDEX [IX_PurchaseOrders_PONumber] ON [dbo].[PurchaseOrders] ([PONumber])
+GO
+
+CREATE INDEX [IX_PurchaseOrders_PODate] ON [dbo].[PurchaseOrders] ([PODate])
+GO

--- a/database/dbo/Views/v_PurchaseOrders.sql
+++ b/database/dbo/Views/v_PurchaseOrders.sql
@@ -1,0 +1,19 @@
+CREATE VIEW [dbo].[v_PurchaseOrders] AS
+SELECT
+    po.[Id],
+    po.[VendorId],
+    v.[Name] AS VendorName,
+    po.[PONumber],
+    po.[PODate],
+    po.[ExpectedDate],
+    po.[Status],
+    po.[Notes],
+    po.[Subtotal],
+    po.[Total],
+    po.[ConvertedToBillId],
+    po.[CreatedAt],
+    po.[UpdatedAt]
+FROM
+    [dbo].[PurchaseOrders] po
+    LEFT JOIN [dbo].[Vendors] v ON po.[VendorId] = v.[Id];
+GO

--- a/database/migrations/028_AddPurchaseOrders.sql
+++ b/database/migrations/028_AddPurchaseOrders.sql
@@ -1,0 +1,161 @@
+/*
+Migration: Add Purchase Orders Module
+Description: Creates PurchaseOrders and PurchaseOrderLines tables for tracking orders to vendors
+             before they become bills. Includes a view for joined data and conversion tracking.
+*/
+
+-- ============================================================================
+-- PURCHASE ORDERS TABLE
+-- ============================================================================
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'PurchaseOrders')
+BEGIN
+    CREATE TABLE [dbo].[PurchaseOrders]
+    (
+        [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+        [VendorId] UNIQUEIDENTIFIER NOT NULL,
+        [PONumber] NVARCHAR(50) NOT NULL,
+        [PODate] DATE NOT NULL,
+        [ExpectedDate] DATE NULL,
+        [Status] NVARCHAR(20) NOT NULL DEFAULT 'Draft', -- Draft, Sent, Received, Partial, Cancelled
+        [Notes] NVARCHAR(1000) NULL,
+        [Subtotal] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [Total] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [ConvertedToBillId] UNIQUEIDENTIFIER NULL, -- FK to Bills when converted
+        [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+        [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+        -- Temporal table columns (system-versioned)
+        [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+        [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+        PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+        CONSTRAINT [FK_PurchaseOrders_Vendors] FOREIGN KEY ([VendorId]) REFERENCES [dbo].[Vendors]([Id]),
+        CONSTRAINT [FK_PurchaseOrders_Bills] FOREIGN KEY ([ConvertedToBillId]) REFERENCES [dbo].[Bills]([Id])
+    )
+    WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[PurchaseOrders_History]));
+
+    PRINT 'Created PurchaseOrders table';
+END
+GO
+
+-- Enable change tracking for PurchaseOrders
+IF EXISTS (SELECT * FROM sys.tables WHERE name = 'PurchaseOrders')
+   AND NOT EXISTS (SELECT * FROM sys.change_tracking_tables WHERE object_id = OBJECT_ID('dbo.PurchaseOrders'))
+BEGIN
+    ALTER TABLE [dbo].[PurchaseOrders] ENABLE CHANGE_TRACKING
+    WITH (TRACK_COLUMNS_UPDATED = ON);
+    PRINT 'Enabled change tracking for PurchaseOrders';
+END
+GO
+
+-- Create indexes for common queries
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_PurchaseOrders_VendorId')
+BEGIN
+    CREATE INDEX [IX_PurchaseOrders_VendorId] ON [dbo].[PurchaseOrders] ([VendorId]);
+    PRINT 'Created index IX_PurchaseOrders_VendorId';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_PurchaseOrders_Status')
+BEGIN
+    CREATE INDEX [IX_PurchaseOrders_Status] ON [dbo].[PurchaseOrders] ([Status]);
+    PRINT 'Created index IX_PurchaseOrders_Status';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_PurchaseOrders_PONumber')
+BEGIN
+    CREATE INDEX [IX_PurchaseOrders_PONumber] ON [dbo].[PurchaseOrders] ([PONumber]);
+    PRINT 'Created index IX_PurchaseOrders_PONumber';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_PurchaseOrders_PODate')
+BEGIN
+    CREATE INDEX [IX_PurchaseOrders_PODate] ON [dbo].[PurchaseOrders] ([PODate]);
+    PRINT 'Created index IX_PurchaseOrders_PODate';
+END
+GO
+
+-- ============================================================================
+-- PURCHASE ORDER LINES TABLE
+-- ============================================================================
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'PurchaseOrderLines')
+BEGIN
+    CREATE TABLE [dbo].[PurchaseOrderLines]
+    (
+        [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+        [PurchaseOrderId] UNIQUEIDENTIFIER NOT NULL,
+        [ProductServiceId] UNIQUEIDENTIFIER NULL, -- FK to ProductsServices (optional)
+        [Description] NVARCHAR(500) NOT NULL,
+        [Quantity] DECIMAL(18, 4) NOT NULL DEFAULT 1,
+        [UnitPrice] DECIMAL(18, 2) NOT NULL DEFAULT 0,
+        [Amount] AS ([Quantity] * [UnitPrice]) PERSISTED,
+        [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+        [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+        -- Temporal table columns (system-versioned)
+        [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+        [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+        PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+        CONSTRAINT [FK_PurchaseOrderLines_PurchaseOrders] FOREIGN KEY ([PurchaseOrderId])
+            REFERENCES [dbo].[PurchaseOrders] ([Id]) ON DELETE CASCADE,
+        CONSTRAINT [FK_PurchaseOrderLines_ProductsServices] FOREIGN KEY ([ProductServiceId])
+            REFERENCES [dbo].[ProductsServices] ([Id])
+    )
+    WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[PurchaseOrderLines_History]));
+
+    PRINT 'Created PurchaseOrderLines table';
+END
+GO
+
+-- Create indexes for PurchaseOrderLines
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_PurchaseOrderLines_PurchaseOrderId')
+BEGIN
+    CREATE INDEX [IX_PurchaseOrderLines_PurchaseOrderId] ON [dbo].[PurchaseOrderLines] ([PurchaseOrderId]);
+    PRINT 'Created index IX_PurchaseOrderLines_PurchaseOrderId';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_PurchaseOrderLines_ProductServiceId')
+BEGIN
+    CREATE INDEX [IX_PurchaseOrderLines_ProductServiceId] ON [dbo].[PurchaseOrderLines] ([ProductServiceId]);
+    PRINT 'Created index IX_PurchaseOrderLines_ProductServiceId';
+END
+GO
+
+-- ============================================================================
+-- VIEW FOR PURCHASE ORDERS WITH VENDOR NAME
+-- ============================================================================
+IF EXISTS (SELECT * FROM sys.views WHERE name = 'v_PurchaseOrders')
+BEGIN
+    DROP VIEW [dbo].[v_PurchaseOrders];
+END
+GO
+
+CREATE VIEW [dbo].[v_PurchaseOrders] AS
+SELECT
+    po.[Id],
+    po.[VendorId],
+    v.[Name] AS VendorName,
+    po.[PONumber],
+    po.[PODate],
+    po.[ExpectedDate],
+    po.[Status],
+    po.[Notes],
+    po.[Subtotal],
+    po.[Total],
+    po.[ConvertedToBillId],
+    po.[CreatedAt],
+    po.[UpdatedAt]
+FROM
+    [dbo].[PurchaseOrders] po
+    LEFT JOIN [dbo].[Vendors] v ON po.[VendorId] = v.[Id];
+GO
+
+PRINT 'Created view v_PurchaseOrders';
+GO
+
+PRINT 'Purchase Orders migration complete.';
+GO


### PR DESCRIPTION
## Summary
- Implement Purchase Orders module for tracking vendor orders before they become bills
- Add database migration with PurchaseOrders and PurchaseOrderLines tables (temporal versioning enabled)
- Configure DAB entities for API access
- Create frontend pages: list view, create form, edit form
- Add navigation under new "Purchasing" group with Bills

## Features
- Track PO number, vendor, date, expected delivery, status (Draft/Sent/Received/Partial/Cancelled)
- Line items with product/service selection, quantity, and unit price (auto-populates PurchaseCost)
- Convert Purchase Order to Bill when goods are received
- Status badge colors and "Convert to Bill" action in list view

## Files Changed
- `database/migrations/027_AddPurchaseOrders.sql` - Migration for tables and view
- `database/dbo/Tables/PurchaseOrders.sql` - Table definition
- `database/dbo/Tables/PurchaseOrderLines.sql` - Line items table
- `database/dbo/Views/v_PurchaseOrders.sql` - View with vendor name
- `dab-config.json` - DAB entity configuration
- `client/src/components/PurchaseOrderForm.tsx` - Form component
- `client/src/pages/PurchaseOrders.tsx` - List page
- `client/src/pages/NewPurchaseOrder.tsx` - Create page
- `client/src/pages/EditPurchaseOrder.tsx` - Edit page
- `client/src/App.tsx` - Routes
- `client/src/components/navigation/navConfig.ts` - Navigation

## Test plan
- [ ] Run database migration 027_AddPurchaseOrders.sql
- [ ] Verify DAB endpoints: GET /purchaseorders, POST /purchaseorders_write, etc.
- [ ] Create a new purchase order with line items
- [ ] Edit an existing purchase order
- [ ] Convert a purchase order to a bill and verify bill is created

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)