### PR TITLE
Fix wasted space between sidebar and content on all pages

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,9 +1,8 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import { Menu } from 'lucide-react';
 import { useState, useEffect } from 'react';
-import clsx from 'clsx';
 import { useCompanySettings } from '../contexts/CompanySettingsContext';
-import { SidebarProvider, useSidebar } from '../contexts/SidebarContext';
+import { SidebarProvider } from '../contexts/SidebarContext';
 import GlobalSearch from './GlobalSearch';
 import Sidebar from './navigation/Sidebar';
 
@@ -11,7 +10,6 @@ function LayoutContent() {
   const location = useLocation();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const { settings: companySettings } = useCompanySettings();
-  const { isCollapsed } = useSidebar();
 
   // Close mobile menu on navigation
   useEffect(() => {
@@ -33,10 +31,7 @@ function LayoutContent() {
 
       {/* Main Content */}
       <div
-        className={clsx(
-          "flex-1 flex flex-col min-w-0 overflow-hidden transition-all duration-200",
-          isCollapsed ? "lg:ml-16" : "lg:ml-64"
-        )}
+        className="flex-1 flex flex-col min-w-0 overflow-hidden"
       >
         {/* Mobile Header - Hidden when printing */}
         <div className="lg:hidden flex items-center justify-between bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-2 print:hidden">


### PR DESCRIPTION
## Summary
- Removed redundant `lg:ml-64`/`lg:ml-16` margin from the main content container in `Layout.tsx`
- The sidebar uses `lg:static` positioning which puts it in the document flow, so the flex container naturally handles spacing
- The previous margin was creating double spacing (once from the sidebar's natural width, once from the margin)

## Test plan
- [x] Build succeeds
- [x] Sidebar navigation tests pass (7 tests)
- [x] Sidebar collapsed invoices tests pass (3 tests)
- [x] Invoice tests pass (5 tests)
- [ ] Manually verify Dashboard page has proper spacing
- [ ] Manually verify Time Entries page has proper spacing
- [ ] Verify sidebar collapse/expand behavior works correctly
- [ ] Verify layout is responsive on different screen sizes

Fixes #171

Generated with [Claude Code](https://claude.com/claude-code)