### PR TITLE
fix: Rewrite E2E tests to use MUI DataGrid filter UI pattern (#169)

### DIFF
--- a/client/tests/bills.spec.ts
+++ b/client/tests/bills.spec.ts
@@ -191,17 +191,9 @@ test.describe('Bills Management', () => {
     await filterInput.fill('Open');
     await page.keyboard.press('Enter');
 
-    // Wait for filtering to take effect
-    await page.waitForTimeout(500);
-
-    // Verify filtering occurred - all visible rows should have Open status
+    // Wait for filtering to take effect by waiting for the Open text to appear
     const rows = page.locator('.MuiDataGrid-row');
-    const rowCount = await rows.count();
-
-    if (rowCount > 0) {
-      // Check that Open badge is visible in filtered results
-      await expect(rows.first().getByText('Open')).toBeVisible();
-    }
+    await expect(rows.first().getByText('Open')).toBeVisible({ timeout: 10000 });
   });
 
   test('should verify bill totals are calculated correctly', async ({ page }) => {

--- a/client/tests/products-services.spec.ts
+++ b/client/tests/products-services.spec.ts
@@ -78,20 +78,10 @@ test.describe('Products & Services Management', () => {
     await filterInput.fill('Service');
     await page.keyboard.press('Enter');
 
-    // Wait for filtering to take effect
-    await page.waitForTimeout(500);
-
-    // Verify filtering occurred - rows should contain 'Service' type
-    // All visible rows should have the Service badge (blue badge in Type column)
+    // Wait for filtering to take effect by waiting for the Service badge to appear
     const rows = page.locator('.MuiDataGrid-row');
-    const rowCount = await rows.count();
-
-    // Either we have fewer rows or all rows are Service type
-    if (rowCount > 0) {
-      // Check that Service badge is visible in filtered results - use more specific locator for the Type badge
-      const serviceBadge = rows.first().locator('.bg-blue-100.text-blue-800', { hasText: 'Service' });
-      await expect(serviceBadge).toBeVisible();
-    }
+    const serviceBadge = rows.first().locator('.bg-blue-100.text-blue-800', { hasText: 'Service' });
+    await expect(serviceBadge).toBeVisible({ timeout: 10000 });
   });
 
   test('should filter by status using DataGrid column filter', async ({ page }) => {
@@ -123,17 +113,9 @@ test.describe('Products & Services Management', () => {
     await filterInput.fill('Active');
     await page.keyboard.press('Enter');
 
-    // Wait for filtering to take effect
-    await page.waitForTimeout(500);
-
-    // Verify filtering occurred - all visible rows should have Active status
+    // Wait for filtering to take effect by waiting for the Active text to appear
     const rows = page.locator('.MuiDataGrid-row');
-    const rowCount = await rows.count();
-
-    if (rowCount > 0) {
-      // Check that Active badge is visible in filtered results
-      await expect(rows.first().getByText('Active')).toBeVisible();
-    }
+    await expect(rows.first().getByText('Active')).toBeVisible({ timeout: 10000 });
   });
 
   test('should create inventory product with asset account', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Rewrote 3 skipped E2E tests to use MUI DataGrid's column header filtering instead of expecting separate dropdown filters
- `products-services.spec.ts`: Fixed "filter by type" and "filter by status" tests
- `bills.spec.ts`: Fixed "filter bills using DataGrid column filter" test

## Technical Details

The tests now interact with MUI DataGrid's built-in filter UI:
1. Hover over the column header to reveal the menu icon
2. Click the menu icon button
3. Select "Filter" from the menu
4. Enter the filter value in the filter form input
5. Verify the filtered results contain the expected values

## Test plan

- [x] Run `npx playwright test products-services.spec.ts` - all 9 tests pass
- [x] Run `npx playwright test bills.spec.ts` - all 6 tests pass
- [x] Verified tests interact correctly with MUI DataGrid filter UI

Fixes #169

:robot: Generated with [Claude Code](https://claude.ai/code)