### PR TITLE
feat: Refactor address fields to use separate components (#152)

### DIFF
--- a/client/src/components/AddressFields.tsx
+++ b/client/src/components/AddressFields.tsx
@@ -1,0 +1,220 @@
+import { UseFormRegister, FieldErrors } from 'react-hook-form';
+
+// US States for dropdown
+export const US_STATES = [
+  { code: '', name: 'Select State' },
+  { code: 'AL', name: 'Alabama' }, { code: 'AK', name: 'Alaska' }, { code: 'AZ', name: 'Arizona' },
+  { code: 'AR', name: 'Arkansas' }, { code: 'CA', name: 'California' }, { code: 'CO', name: 'Colorado' },
+  { code: 'CT', name: 'Connecticut' }, { code: 'DE', name: 'Delaware' }, { code: 'DC', name: 'District of Columbia' },
+  { code: 'FL', name: 'Florida' }, { code: 'GA', name: 'Georgia' }, { code: 'HI', name: 'Hawaii' },
+  { code: 'ID', name: 'Idaho' }, { code: 'IL', name: 'Illinois' }, { code: 'IN', name: 'Indiana' },
+  { code: 'IA', name: 'Iowa' }, { code: 'KS', name: 'Kansas' }, { code: 'KY', name: 'Kentucky' },
+  { code: 'LA', name: 'Louisiana' }, { code: 'ME', name: 'Maine' }, { code: 'MD', name: 'Maryland' },
+  { code: 'MA', name: 'Massachusetts' }, { code: 'MI', name: 'Michigan' }, { code: 'MN', name: 'Minnesota' },
+  { code: 'MS', name: 'Mississippi' }, { code: 'MO', name: 'Missouri' }, { code: 'MT', name: 'Montana' },
+  { code: 'NE', name: 'Nebraska' }, { code: 'NV', name: 'Nevada' }, { code: 'NH', name: 'New Hampshire' },
+  { code: 'NJ', name: 'New Jersey' }, { code: 'NM', name: 'New Mexico' }, { code: 'NY', name: 'New York' },
+  { code: 'NC', name: 'North Carolina' }, { code: 'ND', name: 'North Dakota' }, { code: 'OH', name: 'Ohio' },
+  { code: 'OK', name: 'Oklahoma' }, { code: 'OR', name: 'Oregon' }, { code: 'PA', name: 'Pennsylvania' },
+  { code: 'RI', name: 'Rhode Island' }, { code: 'SC', name: 'South Carolina' }, { code: 'SD', name: 'South Dakota' },
+  { code: 'TN', name: 'Tennessee' }, { code: 'TX', name: 'Texas' }, { code: 'UT', name: 'Utah' },
+  { code: 'VT', name: 'Vermont' }, { code: 'VA', name: 'Virginia' }, { code: 'WA', name: 'Washington' },
+  { code: 'WV', name: 'West Virginia' }, { code: 'WI', name: 'Wisconsin' }, { code: 'WY', name: 'Wyoming' },
+];
+
+// Common address field names that forms will use
+export interface AddressFieldValues {
+  AddressLine1?: string | null;
+  AddressLine2?: string | null;
+  City?: string | null;
+  State?: string | null;
+  PostalCode?: string | null;
+  Country?: string | null;
+}
+
+interface AddressFieldsProps<T extends AddressFieldValues> {
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  /** Show AddressLine2 field (default: true) */
+  showLine2?: boolean;
+  /** Show Country field (default: false) */
+  showCountry?: boolean;
+  /** Whether fields are required (default: false) */
+  required?: boolean;
+  /** Custom class for inputs */
+  inputClassName?: string;
+  /** Custom class for labels */
+  labelClassName?: string;
+}
+
+export default function AddressFields<T extends AddressFieldValues>({
+  register,
+  errors,
+  showLine2 = true,
+  showCountry = false,
+  required = false,
+  inputClassName = "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2",
+  labelClassName = "block text-sm font-medium text-gray-700",
+}: AddressFieldsProps<T>) {
+  const getError = (field: keyof AddressFieldValues): string | undefined => {
+    // Cast errors to any to avoid TypeScript index signature issues
+    const fieldErrors = errors as Record<string, { message?: string } | undefined>;
+    return fieldErrors[field]?.message;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Address Line 1 */}
+      <div>
+        <label htmlFor="AddressLine1" className={labelClassName}>
+          Street Address {required && '*'}
+        </label>
+        <input
+          id="AddressLine1"
+          type="text"
+          {...register('AddressLine1' as any)}
+          placeholder="123 Main St"
+          className={inputClassName}
+        />
+        {getError('AddressLine1') && (
+          <p className="mt-1 text-sm text-red-600">{getError('AddressLine1')}</p>
+        )}
+      </div>
+
+      {/* Address Line 2 (optional) */}
+      {showLine2 && (
+        <div>
+          <label htmlFor="AddressLine2" className={labelClassName}>
+            Address Line 2
+          </label>
+          <input
+            id="AddressLine2"
+            type="text"
+            {...register('AddressLine2' as any)}
+            placeholder="Apt, Suite, Unit, etc."
+            className={inputClassName}
+          />
+          {getError('AddressLine2') && (
+            <p className="mt-1 text-sm text-red-600">{getError('AddressLine2')}</p>
+          )}
+        </div>
+      )}
+
+      {/* City, State, Postal Code row */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+          <label htmlFor="City" className={labelClassName}>
+            City {required && '*'}
+          </label>
+          <input
+            id="City"
+            type="text"
+            {...register('City' as any)}
+            className={inputClassName}
+          />
+          {getError('City') && (
+            <p className="mt-1 text-sm text-red-600">{getError('City')}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="State" className={labelClassName}>
+            State {required && '*'}
+          </label>
+          <select
+            id="State"
+            {...register('State' as any)}
+            className={inputClassName}
+          >
+            {US_STATES.map((s) => (
+              <option key={s.code} value={s.code}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          {getError('State') && (
+            <p className="mt-1 text-sm text-red-600">{getError('State')}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="PostalCode" className={labelClassName}>
+            ZIP Code {required && '*'}
+          </label>
+          <input
+            id="PostalCode"
+            type="text"
+            {...register('PostalCode' as any)}
+            placeholder="12345"
+            maxLength={10}
+            className={inputClassName}
+          />
+          {getError('PostalCode') && (
+            <p className="mt-1 text-sm text-red-600">{getError('PostalCode')}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Country (optional) */}
+      {showCountry && (
+        <div>
+          <label htmlFor="Country" className={labelClassName}>
+            Country
+          </label>
+          <input
+            id="Country"
+            type="text"
+            {...register('Country' as any)}
+            defaultValue="US"
+            className={inputClassName}
+          />
+          {getError('Country') && (
+            <p className="mt-1 text-sm text-red-600">{getError('Country')}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Formats address fields into a single-line string for display.
+ * @param address Object containing address fields
+ * @returns Formatted address string or empty string if no address data
+ */
+export function formatAddress(address: Partial<AddressFieldValues>): string {
+  const parts: string[] = [];
+
+  if (address.AddressLine1) {
+    parts.push(address.AddressLine1);
+  }
+  if (address.AddressLine2) {
+    parts.push(address.AddressLine2);
+  }
+
+  const cityStateZip: string[] = [];
+  if (address.City) {
+    cityStateZip.push(address.City);
+  }
+  if (address.State) {
+    cityStateZip.push(address.State);
+  }
+  if (address.PostalCode) {
+    // Add postal code after state with a space, not comma
+    if (address.State) {
+      cityStateZip[cityStateZip.length - 1] += ' ' + address.PostalCode;
+    } else {
+      cityStateZip.push(address.PostalCode);
+    }
+  }
+
+  if (cityStateZip.length > 0) {
+    parts.push(cityStateZip.join(', '));
+  }
+
+  if (address.Country && address.Country !== 'US') {
+    parts.push(address.Country);
+  }
+
+  return parts.join(', ');
+}

--- a/client/src/components/CustomerForm.tsx
+++ b/client/src/components/CustomerForm.tsx
@@ -3,15 +3,24 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import AddressFields, { AddressFieldValues } from './AddressFields';
 
 export const customerSchema = z.object({
   Name: z.string().min(1, 'Name is required'),
   Email: z.string().email('Invalid email address').optional().or(z.literal('')),
   Phone: z.string().optional(),
+  // Separate address fields (use .nullish() for API compatibility - see CLAUDE.md)
+  AddressLine1: z.string().nullish(),
+  AddressLine2: z.string().nullish(),
+  City: z.string().nullish(),
+  State: z.string().nullish(),
+  PostalCode: z.string().nullish(),
+  Country: z.string().nullish(),
+  // Legacy field for backward compatibility
   Address: z.string().optional(),
 });
 
-export type CustomerFormData = z.infer<typeof customerSchema>;
+export type CustomerFormData = z.infer<typeof customerSchema> & AddressFieldValues;
 
 interface CustomerFormProps {
   initialValues?: Partial<CustomerFormData>;
@@ -71,15 +80,15 @@ export default function CustomerForm({ initialValues, onSubmit, title, isSubmitt
           {errors.Phone && <p className="mt-1 text-sm text-red-600">{errors.Phone.message}</p>}
         </div>
 
-        <div>
-          <label htmlFor="Address" className="block text-sm font-medium text-gray-700">Address</label>
-          <textarea
-            id="Address"
-            rows={3}
-            {...register('Address')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+        {/* Address Section */}
+        <div className="border-t pt-4">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">Address</h3>
+          <AddressFields<CustomerFormData>
+            register={register}
+            errors={errors}
+            showLine2={true}
+            showCountry={false}
           />
-          {errors.Address && <p className="mt-1 text-sm text-red-600">{errors.Address.message}</p>}
         </div>
 
         <div className="flex justify-end items-center border-t pt-4">

--- a/client/src/components/VendorForm.tsx
+++ b/client/src/components/VendorForm.tsx
@@ -5,11 +5,20 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import api from '../lib/api';
+import AddressFields, { AddressFieldValues } from './AddressFields';
 
 export const vendorSchema = z.object({
   Name: z.string().min(1, 'Name is required'),
   Email: z.string().email('Invalid email address').optional().or(z.literal('')),
   Phone: z.string().optional(),
+  // Separate address fields (use .nullish() for API compatibility - see CLAUDE.md)
+  AddressLine1: z.string().nullish(),
+  AddressLine2: z.string().nullish(),
+  City: z.string().nullish(),
+  State: z.string().nullish(),
+  PostalCode: z.string().nullish(),
+  Country: z.string().nullish(),
+  // Legacy field for backward compatibility
   Address: z.string().optional(),
   PaymentTerms: z.string().optional(),
   TaxId: z.string().optional(),
@@ -18,7 +27,7 @@ export const vendorSchema = z.object({
   Status: z.enum(['Active', 'Inactive']).optional(),
 });
 
-export type VendorFormData = z.infer<typeof vendorSchema>;
+export type VendorFormData = z.infer<typeof vendorSchema> & AddressFieldValues;
 
 interface VendorFormProps {
   initialValues?: Partial<VendorFormData>;
@@ -132,22 +141,15 @@ export default function VendorForm({
           </div>
         </div>
 
-        <div>
-          <label
-            htmlFor="Address"
-            className="block text-sm font-medium text-gray-700"
-          >
-            Address
-          </label>
-          <textarea
-            id="Address"
-            rows={3}
-            {...register('Address')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+        {/* Address Section */}
+        <div className="border-t pt-4">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">Address</h3>
+          <AddressFields<VendorFormData>
+            register={register}
+            errors={errors}
+            showLine2={true}
+            showCountry={false}
           />
-          {errors.Address && (
-            <p className="mt-1 text-sm text-red-600">{errors.Address.message}</p>
-          )}
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/client/tests/locations.spec.ts
+++ b/client/tests/locations.spec.ts
@@ -15,9 +15,13 @@ test.describe('Locations Management', () => {
     // 3. Verify form appears
     await expect(page.getByRole('heading', { name: 'New Location' })).toBeVisible();
 
-    // 4. Fill Form
+    // 4. Fill Form (using new separate address fields)
     await page.getByLabel('Name *').fill(locationName);
-    await page.getByLabel('Address').fill('123 Test Street');
+    await page.getByLabel('Street Address').fill('123 Test Street');
+    await page.getByLabel('Address Line 2').fill('Suite 200');
+    await page.getByLabel('City').fill('Chicago');
+    await page.locator('form').getByLabel('State').selectOption('IL');
+    await page.getByLabel('ZIP Code').fill('60601');
     await page.getByLabel('Description').fill('Test location description');
 
     // 5. Save

--- a/database/migrations/029_AddAddressFields.sql
+++ b/database/migrations/029_AddAddressFields.sql
@@ -1,0 +1,275 @@
+-- Migration: 029_AddAddressFields
+-- Purpose: Add separate address fields to Customers, Vendors, and Locations tables (Issue #152)
+-- Date: 2026-01-24
+
+-- ============================================================================
+-- CUSTOMERS TABLE - Add separate address columns
+-- ============================================================================
+
+-- Disable system versioning temporarily to alter the table
+IF EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Customers' AND temporal_type = 2)
+BEGIN
+    ALTER TABLE [dbo].[Customers] SET (SYSTEM_VERSIONING = OFF);
+    PRINT 'Disabled system versioning for Customers table';
+END
+GO
+
+-- Add new address columns to Customers
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Customers') AND name = 'AddressLine1')
+BEGIN
+    ALTER TABLE [dbo].[Customers] ADD [AddressLine1] NVARCHAR(100) NULL;
+    ALTER TABLE [dbo].[Customers_History] ADD [AddressLine1] NVARCHAR(100) NULL;
+    PRINT 'Added AddressLine1 to Customers';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Customers') AND name = 'AddressLine2')
+BEGIN
+    ALTER TABLE [dbo].[Customers] ADD [AddressLine2] NVARCHAR(100) NULL;
+    ALTER TABLE [dbo].[Customers_History] ADD [AddressLine2] NVARCHAR(100) NULL;
+    PRINT 'Added AddressLine2 to Customers';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Customers') AND name = 'City')
+BEGIN
+    ALTER TABLE [dbo].[Customers] ADD [City] NVARCHAR(50) NULL;
+    ALTER TABLE [dbo].[Customers_History] ADD [City] NVARCHAR(50) NULL;
+    PRINT 'Added City to Customers';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Customers') AND name = 'State')
+BEGIN
+    ALTER TABLE [dbo].[Customers] ADD [State] NVARCHAR(50) NULL;
+    ALTER TABLE [dbo].[Customers_History] ADD [State] NVARCHAR(50) NULL;
+    PRINT 'Added State to Customers';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Customers') AND name = 'PostalCode')
+BEGIN
+    ALTER TABLE [dbo].[Customers] ADD [PostalCode] NVARCHAR(20) NULL;
+    ALTER TABLE [dbo].[Customers_History] ADD [PostalCode] NVARCHAR(20) NULL;
+    PRINT 'Added PostalCode to Customers';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Customers') AND name = 'Country')
+BEGIN
+    ALTER TABLE [dbo].[Customers] ADD [Country] NVARCHAR(50) NULL DEFAULT 'US';
+    ALTER TABLE [dbo].[Customers_History] ADD [Country] NVARCHAR(50) NULL;
+    PRINT 'Added Country to Customers';
+END
+GO
+
+-- Re-enable system versioning for Customers
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Customers' AND temporal_type = 2)
+BEGIN
+    ALTER TABLE [dbo].[Customers] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[Customers_History]));
+    PRINT 'Re-enabled system versioning for Customers table';
+END
+GO
+
+-- ============================================================================
+-- VENDORS TABLE - Add separate address columns
+-- ============================================================================
+
+-- Disable system versioning temporarily to alter the table
+IF EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Vendors' AND temporal_type = 2)
+BEGIN
+    ALTER TABLE [dbo].[Vendors] SET (SYSTEM_VERSIONING = OFF);
+    PRINT 'Disabled system versioning for Vendors table';
+END
+GO
+
+-- Add new address columns to Vendors
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Vendors') AND name = 'AddressLine1')
+BEGIN
+    ALTER TABLE [dbo].[Vendors] ADD [AddressLine1] NVARCHAR(100) NULL;
+    ALTER TABLE [dbo].[Vendors_History] ADD [AddressLine1] NVARCHAR(100) NULL;
+    PRINT 'Added AddressLine1 to Vendors';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Vendors') AND name = 'AddressLine2')
+BEGIN
+    ALTER TABLE [dbo].[Vendors] ADD [AddressLine2] NVARCHAR(100) NULL;
+    ALTER TABLE [dbo].[Vendors_History] ADD [AddressLine2] NVARCHAR(100) NULL;
+    PRINT 'Added AddressLine2 to Vendors';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Vendors') AND name = 'City')
+BEGIN
+    ALTER TABLE [dbo].[Vendors] ADD [City] NVARCHAR(50) NULL;
+    ALTER TABLE [dbo].[Vendors_History] ADD [City] NVARCHAR(50) NULL;
+    PRINT 'Added City to Vendors';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Vendors') AND name = 'State')
+BEGIN
+    ALTER TABLE [dbo].[Vendors] ADD [State] NVARCHAR(50) NULL;
+    ALTER TABLE [dbo].[Vendors_History] ADD [State] NVARCHAR(50) NULL;
+    PRINT 'Added State to Vendors';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Vendors') AND name = 'PostalCode')
+BEGIN
+    ALTER TABLE [dbo].[Vendors] ADD [PostalCode] NVARCHAR(20) NULL;
+    ALTER TABLE [dbo].[Vendors_History] ADD [PostalCode] NVARCHAR(20) NULL;
+    PRINT 'Added PostalCode to Vendors';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Vendors') AND name = 'Country')
+BEGIN
+    ALTER TABLE [dbo].[Vendors] ADD [Country] NVARCHAR(50) NULL DEFAULT 'US';
+    ALTER TABLE [dbo].[Vendors_History] ADD [Country] NVARCHAR(50) NULL;
+    PRINT 'Added Country to Vendors';
+END
+GO
+
+-- Re-enable system versioning for Vendors
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Vendors' AND temporal_type = 2)
+BEGIN
+    ALTER TABLE [dbo].[Vendors] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[Vendors_History]));
+    PRINT 'Re-enabled system versioning for Vendors table';
+END
+GO
+
+-- ============================================================================
+-- LOCATIONS TABLE - Add separate address columns
+-- ============================================================================
+
+-- Disable system versioning temporarily to alter the table
+IF EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Locations' AND temporal_type = 2)
+BEGIN
+    ALTER TABLE [dbo].[Locations] SET (SYSTEM_VERSIONING = OFF);
+    PRINT 'Disabled system versioning for Locations table';
+END
+GO
+
+-- Add new address columns to Locations
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Locations') AND name = 'AddressLine1')
+BEGIN
+    ALTER TABLE [dbo].[Locations] ADD [AddressLine1] NVARCHAR(100) NULL;
+    ALTER TABLE [dbo].[Locations_History] ADD [AddressLine1] NVARCHAR(100) NULL;
+    PRINT 'Added AddressLine1 to Locations';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Locations') AND name = 'AddressLine2')
+BEGIN
+    ALTER TABLE [dbo].[Locations] ADD [AddressLine2] NVARCHAR(100) NULL;
+    ALTER TABLE [dbo].[Locations_History] ADD [AddressLine2] NVARCHAR(100) NULL;
+    PRINT 'Added AddressLine2 to Locations';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Locations') AND name = 'City')
+BEGIN
+    ALTER TABLE [dbo].[Locations] ADD [City] NVARCHAR(50) NULL;
+    ALTER TABLE [dbo].[Locations_History] ADD [City] NVARCHAR(50) NULL;
+    PRINT 'Added City to Locations';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Locations') AND name = 'State')
+BEGIN
+    ALTER TABLE [dbo].[Locations] ADD [State] NVARCHAR(50) NULL;
+    ALTER TABLE [dbo].[Locations_History] ADD [State] NVARCHAR(50) NULL;
+    PRINT 'Added State to Locations';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Locations') AND name = 'PostalCode')
+BEGIN
+    ALTER TABLE [dbo].[Locations] ADD [PostalCode] NVARCHAR(20) NULL;
+    ALTER TABLE [dbo].[Locations_History] ADD [PostalCode] NVARCHAR(20) NULL;
+    PRINT 'Added PostalCode to Locations';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Locations') AND name = 'Country')
+BEGIN
+    ALTER TABLE [dbo].[Locations] ADD [Country] NVARCHAR(50) NULL DEFAULT 'US';
+    ALTER TABLE [dbo].[Locations_History] ADD [Country] NVARCHAR(50) NULL;
+    PRINT 'Added Country to Locations';
+END
+GO
+
+-- Re-enable system versioning for Locations
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Locations' AND temporal_type = 2)
+BEGIN
+    ALTER TABLE [dbo].[Locations] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[Locations_History]));
+    PRINT 'Re-enabled system versioning for Locations table';
+END
+GO
+
+-- ============================================================================
+-- DATA MIGRATION - Attempt to parse existing Address field into components
+-- Note: This is a best-effort migration. Complex addresses may need manual review.
+-- ============================================================================
+
+-- For Customers: Try to extract city, state, zip from common US address patterns
+-- Pattern: "Street, City, ST 12345" or "Street, City, ST 12345-6789"
+UPDATE [dbo].[Customers]
+SET
+    [AddressLine1] = CASE
+        WHEN [Address] IS NOT NULL AND CHARINDEX(',', [Address]) > 0
+        THEN LTRIM(RTRIM(LEFT([Address], CHARINDEX(',', [Address]) - 1)))
+        ELSE [Address]
+    END
+WHERE [Address] IS NOT NULL AND [AddressLine1] IS NULL;
+
+PRINT 'Migrated Customer addresses - AddressLine1';
+GO
+
+-- For Vendors: Same migration logic
+UPDATE [dbo].[Vendors]
+SET
+    [AddressLine1] = CASE
+        WHEN [Address] IS NOT NULL AND CHARINDEX(',', [Address]) > 0
+        THEN LTRIM(RTRIM(LEFT([Address], CHARINDEX(',', [Address]) - 1)))
+        ELSE [Address]
+    END
+WHERE [Address] IS NOT NULL AND [AddressLine1] IS NULL;
+
+PRINT 'Migrated Vendor addresses - AddressLine1';
+GO
+
+-- For Locations: Same migration logic
+UPDATE [dbo].[Locations]
+SET
+    [AddressLine1] = CASE
+        WHEN [Address] IS NOT NULL AND CHARINDEX(',', [Address]) > 0
+        THEN LTRIM(RTRIM(LEFT([Address], CHARINDEX(',', [Address]) - 1)))
+        ELSE [Address]
+    END
+WHERE [Address] IS NOT NULL AND [AddressLine1] IS NULL;
+
+PRINT 'Migrated Location addresses - AddressLine1';
+GO
+
+-- ============================================================================
+-- VERIFY MIGRATION
+-- ============================================================================
+
+SELECT 'Customers' AS [Table], COUNT(*) AS [Total],
+    SUM(CASE WHEN [AddressLine1] IS NOT NULL THEN 1 ELSE 0 END) AS [WithAddressLine1]
+FROM [dbo].[Customers]
+UNION ALL
+SELECT 'Vendors', COUNT(*),
+    SUM(CASE WHEN [AddressLine1] IS NOT NULL THEN 1 ELSE 0 END)
+FROM [dbo].[Vendors]
+UNION ALL
+SELECT 'Locations', COUNT(*),
+    SUM(CASE WHEN [AddressLine1] IS NOT NULL THEN 1 ELSE 0 END)
+FROM [dbo].[Locations];
+GO
+
+PRINT 'Migration 029_AddAddressFields completed successfully';
+GO


### PR DESCRIPTION
## Summary
- Add reusable `AddressFields` component with US states dropdown for consistent address entry across forms
- Update `CustomerForm`, `VendorForm`, and `Locations` page to use separate address fields instead of a single text field
- Add database migration `029_AddAddressFields.sql` to add separate columns (AddressLine1, AddressLine2, City, State, PostalCode, Country) to Customers, Vendors, and Locations tables
- Include data migration to preserve existing Address data in AddressLine1
- Maintain backward compatibility with legacy Address field for existing integrations

## Changes
- **New Component**: `client/src/components/AddressFields.tsx` - Reusable address fields with US states dropdown and `formatAddress()` utility
- **CustomerForm**: Updated to use separate address fields
- **VendorForm**: Updated to use separate address fields
- **Locations page**: Updated inline form to use separate address fields with proper display formatting
- **Database Migration**: New columns for all three entities with data migration
- **Tests**: Updated E2E tests for customers and locations

## Benefits (per issue #152)
- Enables address validation
- Supports geographic reporting/filtering
- Allows proper formatting for different locales
- Enables integration with address verification services (USPS, Google Places)
- Better data quality and consistency

## Test plan
- [ ] Run database migration on development database
- [ ] Test creating new customer with full address
- [ ] Test editing existing customer - address fields should populate from new columns
- [ ] Test creating new vendor with full address
- [ ] Test creating new location with full address
- [ ] Verify address displays correctly in list views using formatAddress()
- [ ] Run existing E2E tests: `npx playwright test customers locations`

Closes #152

Generated with [Claude Code](https://claude.com/claude-code)