### PR TITLE
fix: Add missing Expenses and Receipts database objects for DAB (#234)

### DIFF
--- a/database/AccountingDB.sqlproj
+++ b/database/AccountingDB.sqlproj
@@ -34,6 +34,7 @@
     <Build Include="dbo\Tables\Classes.sql" />
     <Build Include="dbo\Tables\Customers.sql" />
     <Build Include="dbo\Tables\EstimateLines.sql" />
+    <Build Include="dbo\Tables\Expenses.sql" />
     <Build Include="dbo\Tables\Estimates.sql" />
     <Build Include="dbo\Tables\InventoryLocations.sql" />
     <Build Include="dbo\Tables\InventoryTransactions.sql" />
@@ -46,6 +47,7 @@
     <Build Include="dbo\Tables\Projects.sql" />
     <Build Include="dbo\Tables\PurchaseOrderLines.sql" />
     <Build Include="dbo\Tables\PurchaseOrders.sql" />
+    <Build Include="dbo\Tables\Receipts.sql" />
     <Build Include="dbo\Tables\ReconciliationItems.sql" />
     <Build Include="dbo\Tables\RecurringSchedules.sql" />
     <Build Include="dbo\Tables\RecurringTemplates.sql" />
@@ -54,10 +56,12 @@
     <!-- Views -->
     <Build Include="dbo\Views\v_Bills.sql" />
     <Build Include="dbo\Views\v_Estimates.sql" />
+    <Build Include="dbo\Views\v_Expenses.sql" />
     <Build Include="dbo\Views\v_InvoiceLines.sql" />
     <Build Include="dbo\Views\v_Invoices.sql" />
     <Build Include="dbo\Views\v_Projects.sql" />
     <Build Include="dbo\Views\v_PurchaseOrders.sql" />
+    <Build Include="dbo\Views\v_Receipts.sql" />
     <Build Include="dbo\Views\v_TimeEntries.sql" />
     <!-- Stored Procedures -->
     <Build Include="dbo\StoredProcedures\CreateInvoice.sql" />

--- a/database/dbo/Tables/Expenses.sql
+++ b/database/dbo/Tables/Expenses.sql
@@ -1,0 +1,68 @@
+CREATE TABLE [dbo].[Expenses]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [ExpenseNumber] NVARCHAR(50) NULL,
+    [ExpenseDate] DATE NOT NULL,
+    [VendorId] UNIQUEIDENTIFIER NULL,
+    [VendorName] NVARCHAR(255) NULL, -- For quick entry without vendor record
+    [AccountId] UNIQUEIDENTIFIER NOT NULL,
+    [Amount] DECIMAL(19, 4) NOT NULL,
+    [PaymentAccountId] UNIQUEIDENTIFIER NULL, -- Cash, CC used
+    [PaymentMethod] NVARCHAR(50) NULL, -- Cash, Credit Card, Debit Card, Check, etc.
+    [Description] NVARCHAR(500) NULL,
+    [Reference] NVARCHAR(100) NULL, -- Check number, transaction ID, etc.
+    [IsReimbursable] BIT NOT NULL DEFAULT 0,
+    [ReimbursedDate] DATE NULL,
+    [CustomerId] UNIQUEIDENTIFIER NULL, -- If billable to customer
+    [ProjectId] UNIQUEIDENTIFIER NULL,
+    [ClassId] UNIQUEIDENTIFIER NULL,
+    [BankTransactionId] UNIQUEIDENTIFIER NULL,
+    [Status] NVARCHAR(20) NOT NULL DEFAULT 'Recorded', -- Recorded, Pending, Reimbursed, Voided
+    [JournalEntryId] UNIQUEIDENTIFIER NULL,
+    [CreatedBy] NVARCHAR(255) NULL,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    -- Temporal table columns (system-versioned)
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_Expenses_Vendors] FOREIGN KEY ([VendorId]) REFERENCES [dbo].[Vendors]([Id]),
+    CONSTRAINT [FK_Expenses_Accounts] FOREIGN KEY ([AccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_Expenses_PaymentAccounts] FOREIGN KEY ([PaymentAccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_Expenses_Customers] FOREIGN KEY ([CustomerId]) REFERENCES [dbo].[Customers]([Id]),
+    CONSTRAINT [FK_Expenses_Projects] FOREIGN KEY ([ProjectId]) REFERENCES [dbo].[Projects]([Id]),
+    CONSTRAINT [FK_Expenses_Classes] FOREIGN KEY ([ClassId]) REFERENCES [dbo].[Classes]([Id]),
+    CONSTRAINT [FK_Expenses_BankTransactions] FOREIGN KEY ([BankTransactionId]) REFERENCES [dbo].[BankTransactions]([Id]),
+    CONSTRAINT [FK_Expenses_JournalEntries] FOREIGN KEY ([JournalEntryId]) REFERENCES [dbo].[JournalEntries]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[Expenses_History]))
+GO
+
+-- Enable change tracking
+ALTER TABLE [dbo].[Expenses] ENABLE CHANGE_TRACKING
+WITH (TRACK_COLUMNS_UPDATED = ON)
+GO
+
+-- Create indexes for common queries
+CREATE INDEX [IX_Expenses_ExpenseDate] ON [dbo].[Expenses] ([ExpenseDate] DESC)
+GO
+
+CREATE INDEX [IX_Expenses_VendorId] ON [dbo].[Expenses] ([VendorId])
+GO
+
+CREATE INDEX [IX_Expenses_AccountId] ON [dbo].[Expenses] ([AccountId])
+GO
+
+CREATE INDEX [IX_Expenses_Status] ON [dbo].[Expenses] ([Status])
+GO
+
+CREATE INDEX [IX_Expenses_IsReimbursable] ON [dbo].[Expenses] ([IsReimbursable]) WHERE IsReimbursable = 1
+GO
+
+CREATE INDEX [IX_Expenses_CustomerId] ON [dbo].[Expenses] ([CustomerId]) WHERE CustomerId IS NOT NULL
+GO
+
+CREATE INDEX [IX_Expenses_ProjectId] ON [dbo].[Expenses] ([ProjectId]) WHERE ProjectId IS NOT NULL
+GO

--- a/database/dbo/Tables/Receipts.sql
+++ b/database/dbo/Tables/Receipts.sql
@@ -1,0 +1,46 @@
+CREATE TABLE [dbo].[Receipts]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [ExpenseId] UNIQUEIDENTIFIER NULL,
+    [BankTransactionId] UNIQUEIDENTIFIER NULL,
+    [FileName] NVARCHAR(255) NOT NULL,
+    [FileType] NVARCHAR(50) NULL, -- image/jpeg, image/png, application/pdf
+    [FileSize] INT NULL,
+    [FileData] VARBINARY(MAX) NULL, -- Store file in DB (for simplicity; can be moved to blob storage)
+    [ThumbnailData] VARBINARY(MAX) NULL, -- Thumbnail for preview
+
+    -- OCR extracted data
+    [ExtractedVendor] NVARCHAR(255) NULL,
+    [ExtractedAmount] DECIMAL(19, 4) NULL,
+    [ExtractedDate] DATE NULL,
+    [ExtractedLineItems] NVARCHAR(MAX) NULL, -- JSON array of extracted line items
+    [OcrConfidence] DECIMAL(5, 2) NULL, -- 0-100 confidence score
+    [OcrStatus] NVARCHAR(20) NOT NULL DEFAULT 'Pending', -- Pending, Processing, Completed, Failed
+    [OcrErrorMessage] NVARCHAR(500) NULL,
+
+    [UploadedBy] NVARCHAR(255) NULL,
+    [UploadedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    -- Temporal table columns (system-versioned)
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_Receipts_Expenses] FOREIGN KEY ([ExpenseId]) REFERENCES [dbo].[Expenses]([Id]) ON DELETE SET NULL,
+    CONSTRAINT [FK_Receipts_BankTransactions] FOREIGN KEY ([BankTransactionId]) REFERENCES [dbo].[BankTransactions]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[Receipts_History]))
+GO
+
+-- Create indexes for common queries
+CREATE INDEX [IX_Receipts_ExpenseId] ON [dbo].[Receipts] ([ExpenseId]) WHERE ExpenseId IS NOT NULL
+GO
+
+CREATE INDEX [IX_Receipts_BankTransactionId] ON [dbo].[Receipts] ([BankTransactionId]) WHERE BankTransactionId IS NOT NULL
+GO
+
+CREATE INDEX [IX_Receipts_OcrStatus] ON [dbo].[Receipts] ([OcrStatus])
+GO
+
+CREATE INDEX [IX_Receipts_UploadedAt] ON [dbo].[Receipts] ([UploadedAt] DESC)
+GO

--- a/database/dbo/Views/v_Expenses.sql
+++ b/database/dbo/Views/v_Expenses.sql
@@ -1,0 +1,40 @@
+CREATE VIEW [dbo].[v_Expenses] AS
+SELECT
+    e.[Id],
+    e.[ExpenseNumber],
+    e.[ExpenseDate],
+    e.[VendorId],
+    COALESCE(v.[Name], e.[VendorName]) AS VendorName,
+    e.[AccountId],
+    a.[Name] AS AccountName,
+    a.[Type] AS AccountType,
+    e.[Amount],
+    e.[PaymentAccountId],
+    pa.[Name] AS PaymentAccountName,
+    e.[PaymentMethod],
+    e.[Description],
+    e.[Reference],
+    e.[IsReimbursable],
+    e.[ReimbursedDate],
+    e.[CustomerId],
+    c.[Name] AS CustomerName,
+    e.[ProjectId],
+    p.[Name] AS ProjectName,
+    e.[ClassId],
+    cl.[Name] AS ClassName,
+    e.[BankTransactionId],
+    e.[Status],
+    e.[JournalEntryId],
+    e.[CreatedBy],
+    e.[CreatedAt],
+    e.[UpdatedAt],
+    (SELECT COUNT(*) FROM [dbo].[Receipts] r WHERE r.[ExpenseId] = e.[Id]) AS ReceiptCount
+FROM
+    [dbo].[Expenses] e
+    LEFT JOIN [dbo].[Vendors] v ON e.[VendorId] = v.[Id]
+    LEFT JOIN [dbo].[Accounts] a ON e.[AccountId] = a.[Id]
+    LEFT JOIN [dbo].[Accounts] pa ON e.[PaymentAccountId] = pa.[Id]
+    LEFT JOIN [dbo].[Customers] c ON e.[CustomerId] = c.[Id]
+    LEFT JOIN [dbo].[Projects] p ON e.[ProjectId] = p.[Id]
+    LEFT JOIN [dbo].[Classes] cl ON e.[ClassId] = cl.[Id];
+GO

--- a/database/dbo/Views/v_Receipts.sql
+++ b/database/dbo/Views/v_Receipts.sql
@@ -1,0 +1,23 @@
+CREATE VIEW [dbo].[v_Receipts] AS
+SELECT
+    r.[Id],
+    r.[ExpenseId],
+    e.[ExpenseNumber],
+    e.[ExpenseDate],
+    r.[BankTransactionId],
+    r.[FileName],
+    r.[FileType],
+    r.[FileSize],
+    r.[ExtractedVendor],
+    r.[ExtractedAmount],
+    r.[ExtractedDate],
+    r.[OcrConfidence],
+    r.[OcrStatus],
+    r.[OcrErrorMessage],
+    r.[UploadedBy],
+    r.[UploadedAt],
+    CASE WHEN r.[ExpenseId] IS NULL THEN 0 ELSE 1 END AS IsMatched
+FROM
+    [dbo].[Receipts] r
+    LEFT JOIN [dbo].[Expenses] e ON r.[ExpenseId] = e.[Id];
+GO


### PR DESCRIPTION
## Summary

- Adds missing database schema files for the Expenses module that were causing 404 errors on the Expenses page
- The `v_Expenses` view was defined only in migration 030 but never added to the SQL Server project file
- Created dedicated schema files for `Expenses` table, `Receipts` table, `v_Expenses` view, and `v_Receipts` view
- Updated `AccountingDB.sqlproj` to include these new files in database deployments

## Root Cause

The DAB config referenced `dbo.v_Expenses` view which existed in the migration file (`030_AddExpensesAndReceipts.sql`) but was never added to the `database/dbo/Views/` folder or the `AccountingDB.sqlproj` file. When deploying via the sqlproj method, these objects were never created in the database.

## Changes

| File | Description |
|------|-------------|
| `database/dbo/Tables/Expenses.sql` | Expenses table with system versioning and change tracking |
| `database/dbo/Tables/Receipts.sql` | Receipts table for expense attachments with OCR fields |
| `database/dbo/Views/v_Expenses.sql` | View joining expenses with vendor, account, customer, project names |
| `database/dbo/Views/v_Receipts.sql` | View for receipt inbox feature |
| `database/AccountingDB.sqlproj` | Added references to the new schema files |

## Test plan

- [ ] Deploy database using sqlproj and verify Expenses/Receipts tables exist
- [ ] Start DAB server and verify `/api/expenses` endpoint returns 200
- [ ] Navigate to Expenses page in the app and confirm data loads without 404

Closes #234

---
Generated with [Claude Code](https://claude.ai/code)