### PR TITLE
feat: Rename AI chatbot to 'Milton'

### DIFF
--- a/client/src/components/ChatInterface.tsx
+++ b/client/src/components/ChatInterface.tsx
@@ -547,7 +547,7 @@ export default function ChatInterface() {
       // Add welcome message from assistant
       addMessage({
         role: 'assistant',
-        content: `Welcome to ACTO! I'm your accounting assistant and I'm here to help you get started.
+        content: `Welcome to ACTO! I'm Milton, your accounting assistant, and I'm here to help you get started.
 
 **Are you migrating from another accounting platform** like QuickBooks, Xero, or FreshBooks? I can help import your existing data to make the transition seamless!
 
@@ -805,7 +805,7 @@ What would you like to do?`
       <div className="bg-indigo-600 dark:bg-indigo-700 text-white p-4 rounded-t-lg flex items-center justify-between">
         <div className="flex items-center gap-2">
           <MessageCircle className="w-5 h-5" />
-          <h3 className="font-semibold">Accounting Assistant</h3>
+          <h3 className="font-semibold">Milton</h3>
         </div>
         <div className="flex items-center gap-1">
           <CopyAllButton messages={messages} />
@@ -1086,7 +1086,7 @@ What would you like to do?`
           <input
             ref={inputRef}
             type="text"
-            placeholder="Ask me anything... (↑ to edit last message)"
+            placeholder="Ask Milton anything... (↑ to edit last message)"
             className="flex-1 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2
               focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400
               text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100

--- a/client/src/contexts/ChatContext.tsx
+++ b/client/src/contexts/ChatContext.tsx
@@ -89,7 +89,7 @@ const ChatContext = createContext<ChatContextType | undefined>(undefined);
 const initialMessage: Message = {
   id: '1',
   role: 'assistant',
-  content: "Hi! I'm your accounting assistant. I can help you with:\n\n" +
+  content: "Hi! I'm Milton, your accounting assistant. I can help you with:\n\n" +
     "- **Data queries**: \"Show all invoices\", \"Who are my top customers?\", \"What's overdue?\"\n" +
     "- **Financial summaries**: \"Revenue this month\", \"How much do we owe vendors?\"\n" +
     "- **Accounting guidance**: \"Where should I expense a phone bill?\", \"What is depreciation?\"\n\n" +

--- a/client/tests/chat-enhancements.spec.ts
+++ b/client/tests/chat-enhancements.spec.ts
@@ -14,10 +14,10 @@ test.describe('Chat Enhancements', () => {
     await page.click('button[aria-label="Open chat"]');
     
     // Verify chat is open
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     
     // Verify initial welcome message
-    await expect(page.getByText(/Hi! I'm your accounting assistant/)).toBeVisible();
+    await expect(page.getByText(/Hi! I'm Milton, your accounting assistant/)).toBeVisible();
   });
 
   test('should display file attachment button', async ({ page }) => {
@@ -33,7 +33,7 @@ test.describe('Chat Enhancements', () => {
     await page.click('button[aria-label="Open chat"]');
     
     // Type a message
-    await page.fill('input[placeholder*="Ask me anything"]', 'What is double-entry accounting?');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'What is double-entry accounting?');
     
     // Send the message
     await page.click('button[aria-label="Send message"]');
@@ -57,7 +57,7 @@ test.describe('Chat Enhancements', () => {
     await page.click('button[aria-label="Open chat"]');
     
     // Send a message
-    await page.fill('input[placeholder*="Ask me anything"]', 'Test message');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'Test message');
     await page.click('button[aria-label="Send message"]');
     
     // Wait for the message to appear
@@ -80,7 +80,7 @@ test.describe('Chat Enhancements', () => {
     await page.click('button[aria-label="Open chat"]');
     
     // Verify the chat interface loads
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     
     // Note: Testing actual retry functionality would require mocking the API
     // or creating a test scenario that produces an error
@@ -102,7 +102,7 @@ test.describe('Chat Enhancements', () => {
     await page.click('button[aria-label="Open chat"]');
     
     // Send a message
-    await page.fill('input[placeholder*="Ask me anything"]', 'Test message');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'Test message');
     await page.click('button[aria-label="Send message"]');
     
     // Wait for the message
@@ -121,7 +121,7 @@ test.describe('Chat Enhancements', () => {
     await page.click('button[aria-label="Open chat"]');
     
     // Verify chat is open
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     
     // Close chat
     await page.click('button[aria-label="Close chat"]');

--- a/client/tests/demos/ai-chat-assistant-demo.spec.ts
+++ b/client/tests/demos/ai-chat-assistant-demo.spec.ts
@@ -23,7 +23,7 @@ test.describe('AI Chat Assistant Demo', () => {
 
     // Scene 2: Open the Chat Interface
     await page.click('button[aria-label="Open chat"]');
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     await demoPause(1500);
 
     // Scene 3: Show the welcome message
@@ -46,7 +46,7 @@ test.describe('AI Chat Assistant Demo', () => {
     }
 
     // Scene 5: Ask about revenue
-    await page.fill('input[placeholder*="Ask me anything"]', 'What was my revenue this month?');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'What was my revenue this month?');
     await demoPause(1000);
     await page.click('button[aria-label="Send message"]');
 
@@ -56,7 +56,7 @@ test.describe('AI Chat Assistant Demo', () => {
     await demoPause(3000);
 
     // Scene 6: Ask a follow-up question
-    await page.fill('input[placeholder*="Ask me anything"]', 'Who are my top 3 customers?');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'Who are my top 3 customers?');
     await demoPause(1000);
     await page.click('button[aria-label="Send message"]');
 
@@ -78,7 +78,7 @@ test.describe('AI Chat Assistant Demo', () => {
 
     // Scene 2: Open Chat
     await page.click('button[aria-label="Open chat"]');
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     await demoPause(1500);
 
     // Wait for welcome message
@@ -86,7 +86,7 @@ test.describe('AI Chat Assistant Demo', () => {
     await demoPause(1000);
 
     // Scene 3: Ask about accounting concepts
-    await page.fill('input[placeholder*="Ask me anything"]', 'Explain double-entry accounting in simple terms');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'Explain double-entry accounting in simple terms');
     await demoPause(800);
     await page.click('button[aria-label="Send message"]');
 
@@ -96,7 +96,7 @@ test.describe('AI Chat Assistant Demo', () => {
     await demoPause(4000);
 
     // Scene 4: Ask practical question
-    await page.fill('input[placeholder*="Ask me anything"]', 'How do I record a customer payment?');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'How do I record a customer payment?');
     await demoPause(800);
     await page.click('button[aria-label="Send message"]');
 
@@ -117,11 +117,11 @@ test.describe('AI Chat Assistant Demo', () => {
 
     // Scene 2: Open Chat - it should show context-aware suggestions
     await page.click('button[aria-label="Open chat"]');
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     await demoPause(2000);
 
     // Scene 3: Ask about current page context
-    await page.fill('input[placeholder*="Ask me anything"]', 'What can I do on this page?');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'What can I do on this page?');
     await demoPause(800);
     await page.click('button[aria-label="Send message"]');
 
@@ -140,11 +140,11 @@ test.describe('AI Chat Assistant Demo', () => {
 
     // Scene 5: Open chat again on new page
     await page.click('button[aria-label="Open chat"]');
-    await expect(page.getByText('Accounting Assistant')).toBeVisible();
+    await expect(page.getByText('Milton')).toBeVisible();
     await demoPause(1500);
 
     // Scene 6: Ask about customers
-    await page.fill('input[placeholder*="Ask me anything"]', 'Show me customers with outstanding balances');
+    await page.fill('input[placeholder*="Ask Milton anything"]', 'Show me customers with outstanding balances');
     await demoPause(800);
     await page.click('button[aria-label="Send message"]');
 

--- a/client/tests/e2e.spec.ts
+++ b/client/tests/e2e.spec.ts
@@ -153,10 +153,10 @@ test('can use AI chat to get invoices', async ({ page }) => {
   await page.getByLabel('Open chat').click();
   
   // Wait for chat to open
-  await expect(page.getByText('Accounting Assistant')).toBeVisible();
-  
+  await expect(page.getByText('Milton')).toBeVisible();
+
   // Send message
-  await page.getByPlaceholder('Ask me anything...').fill('show me all invoices');
+  await page.getByPlaceholder('Ask Milton anything...').fill('show me all invoices');
   await page.getByLabel('Send message').click();
   
   // Wait for response (with longer timeout for AI)


### PR DESCRIPTION
## Summary
- Renames the AI chatbot from "Accounting Assistant" to "Milton" for a more personable, memorable brand identity
- Updates chat header, welcome messages, placeholder text, and initial message
- Updates all E2E tests to reflect the new name

## Changes
- `client/src/components/ChatInterface.tsx`: Header title, welcome message, input placeholder
- `client/src/contexts/ChatContext.tsx`: Initial message content
- `client/tests/chat-enhancements.spec.ts`: Updated test assertions
- `client/tests/demos/ai-chat-assistant-demo.spec.ts`: Updated test assertions  
- `client/tests/e2e.spec.ts`: Updated test assertions

## Test plan
- [ ] Open chat interface and verify header shows "Milton"
- [ ] Verify welcome message says "Hi! I'm Milton, your accounting assistant..."
- [ ] Verify input placeholder says "Ask Milton anything..."
- [ ] Verify clearing chat shows initial message with Milton branding
- [ ] Run Playwright tests: `npx playwright test chat-enhancements.spec.ts`

Closes #245

---
Generated with [Claude Code](https://claude.ai/code)