### PR TITLE
feat(onboarding): Make Feature Tour Key Concepts clickable to ask Milton

### DIFF
--- a/client/src/components/onboarding/FeatureTour.tsx
+++ b/client/src/components/onboarding/FeatureTour.tsx
@@ -116,7 +116,7 @@ export default function FeatureTour() {
     // Add a user message asking about the concept
     addMessage({
       role: 'user',
-      content: `Explain "${term}" in more detail. The brief explanation says: "${explanation}" - can you expand on this and provide examples?`,
+      content: `I'd like to learn more about "${term}". ${explanation} Can you help me understand this better with some practical examples?`,
     });
 
     // Open Milton's chat panel
@@ -218,10 +218,11 @@ export default function FeatureTour() {
                 Click any concept to ask Milton for more details
               </p>
               <div className="space-y-3">
-                {featureDetails.accountingConcepts.slice(0, 3).map((concept, i) => (
+                {featureDetails.accountingConcepts.map((concept, i) => (
                   <button
                     key={i}
                     onClick={() => handleConceptClick(concept.term, concept.explanation)}
+                    aria-label={`Learn more about ${concept.term} from Milton`}
                     className={clsx(
                       "w-full text-left p-3 rounded-lg transition-all duration-200",
                       "bg-gray-50 dark:bg-gray-700/50",


### PR DESCRIPTION
## Summary

- Key Concept cards in the Feature Tour modal are now clickable buttons with hover states
- Clicking a concept opens Milton's chat panel with a pre-formed question asking for a detailed explanation
- Visual feedback includes ring highlight, color transitions, and a chat icon

## Changes

- Added `useChat` hook integration to `FeatureTour.tsx`
- Converted static concept cards to interactive buttons
- Added `handleConceptClick` function that:
  - Adds a user message with the concept term and explanation
  - Opens Milton's chat panel
  - Closes the Feature Tour modal
- Added `MessageCircle` icon and hover states for visual affordance
- Added helper text: "Click any concept to ask Milton for more details"

## Test plan

- [ ] Navigate to a feature that has accounting concepts (e.g., Invoices, Accounts)
- [ ] Open the Feature Tour modal and go to the "Key Concepts" step
- [ ] Verify concepts show hover state (ring, color change, chat icon highlight)
- [ ] Click on a concept and verify:
  - [ ] Feature Tour modal closes
  - [ ] Milton chat panel opens
  - [ ] A user message appears asking about the clicked concept
  - [ ] Milton responds with a detailed explanation

Closes #247

Generated with [Claude Code](https://claude.com/claude-code)