### PR TITLE
feat(reports): Add Sales by Customer and Sales by Product reports

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -95,6 +95,8 @@ import MileageReport from './pages/reports/MileageReport';
 import InventoryValuation from './pages/reports/InventoryValuation';
 import InventoryStockStatus from './pages/reports/InventoryStockStatus';
 import PhysicalInventoryWorksheet from './pages/reports/PhysicalInventoryWorksheet';
+import SalesByCustomer from './pages/reports/SalesByCustomer';
+import SalesByProduct from './pages/reports/SalesByProduct';
 import Payments from './pages/Payments';
 import NewPayment from './pages/NewPayment';
 import BillPayments from './pages/BillPayments';
@@ -221,6 +223,8 @@ function AppContent() {
             <Route path="reports/inventory-valuation" element={<InventoryValuation />} />
             <Route path="reports/inventory-stock-status" element={<InventoryStockStatus />} />
             <Route path="reports/physical-inventory" element={<PhysicalInventoryWorksheet />} />
+            <Route path="reports/sales-by-customer" element={<SalesByCustomer />} />
+            <Route path="reports/sales-by-product" element={<SalesByProduct />} />
             <Route path="tax-rates" element={<TaxRates />} />
             <Route path="admin/enhancements" element={<AdminEnhancements />} />
             <Route path="settings" element={<CompanySettings />} />

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { TrendingUp, Scale, List, Clock, ClipboardList, DollarSign, Receipt, CreditCard, FileText, Users, FileSearch, Car, BookOpen, Package, AlertTriangle, Clipboard } from 'lucide-react';
+import { TrendingUp, Scale, List, Clock, ClipboardList, DollarSign, Receipt, CreditCard, FileText, Users, FileSearch, Car, BookOpen, Package, AlertTriangle, Clipboard, ShoppingCart } from 'lucide-react';
 
 const reports = [
   {
@@ -95,6 +95,23 @@ const reports = [
   },
 ];
 
+const salesReports = [
+  {
+    name: 'Sales by Customer',
+    description: 'Sales breakdown showing customer, invoice count, amount, and percentage of total sales',
+    href: '/reports/sales-by-customer',
+    icon: Users,
+    color: 'bg-indigo-100 text-indigo-600',
+  },
+  {
+    name: 'Sales by Product/Service',
+    description: 'Sales breakdown showing product/service, quantity sold, amount, and percentage of sales',
+    href: '/reports/sales-by-product',
+    icon: ShoppingCart,
+    color: 'bg-emerald-100 text-emerald-600',
+  },
+];
+
 const inventoryReports = [
   {
     name: 'Inventory Valuation Summary',
@@ -131,6 +148,34 @@ export default function Reports() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {reports.map((report) => (
+          <Link
+            key={report.name}
+            to={report.href}
+            className="block p-6 bg-white rounded-lg shadow hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-start gap-4">
+              <div className={`p-3 rounded-lg ${report.color}`}>
+                <report.icon className="h-6 w-6" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">{report.name}</h2>
+                <p className="mt-1 text-sm text-gray-500">{report.description}</p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {/* Sales Reports Section */}
+      <div className="mt-10 mb-6">
+        <h2 className="text-xl font-bold text-gray-900">Sales Reports</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Analyze sales by customer, product, and time period
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {salesReports.map((report) => (
           <Link
             key={report.name}
             to={report.href}

--- a/client/src/pages/reports/SalesByCustomer.tsx
+++ b/client/src/pages/reports/SalesByCustomer.tsx
@@ -1,0 +1,429 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Users } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  PieChart,
+  Pie,
+  Legend,
+} from 'recharts';
+import api from '../../lib/api';
+import { DateRangePicker, ReportHeader, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Invoice {
+  Id: string;
+  InvoiceNumber: string;
+  CustomerId: string;
+  CustomerName: string;
+  IssueDate: string;
+  TotalAmount: number;
+  Status: string;
+}
+
+interface CustomerSalesData {
+  customerId: string;
+  customerName: string;
+  invoiceCount: number;
+  totalAmount: number;
+  percentOfSales: number;
+}
+
+const COLORS = [
+  '#4F46E5', // Indigo
+  '#10B981', // Emerald
+  '#F59E0B', // Amber
+  '#EF4444', // Red
+  '#8B5CF6', // Violet
+  '#06B6D4', // Cyan
+  '#EC4899', // Pink
+  '#84CC16', // Lime
+  '#F97316', // Orange
+  '#6366F1', // Indigo light
+];
+
+export default function SalesByCustomer() {
+  const navigate = useNavigate();
+  const today = new Date();
+  const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const [startDate, setStartDate] = useState(firstDayOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(today.toISOString().split('T')[0]);
+  const [chartType, setChartType] = useState<'bar' | 'pie'>('bar');
+
+  // Fetch invoices
+  const { data: invoices, isLoading: invoicesLoading, error: invoicesError } = useQuery({
+    queryKey: ['invoices-sales-report'],
+    queryFn: async () => {
+      const response = await api.get<{ value: Invoice[] }>('/invoices');
+      return response.data.value;
+    },
+  });
+
+  const isLoading = invoicesLoading;
+  const error = invoicesError;
+
+  // Calculate sales by customer
+  const salesData = useMemo(() => {
+    if (!invoices) {
+      return { customerSales: [] as CustomerSalesData[], totalSales: 0 };
+    }
+
+    // Parse dates
+    const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
+    const start = new Date(startYear, startMonth - 1, startDay, 0, 0, 0, 0);
+    const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
+    const end = new Date(endYear, endMonth - 1, endDay, 23, 59, 59, 999);
+
+    // Filter invoices by date range and exclude voided/cancelled
+    const filteredInvoices = invoices.filter((inv) => {
+      const issueDate = new Date(inv.IssueDate);
+      return (
+        issueDate >= start &&
+        issueDate <= end &&
+        inv.Status !== 'Voided' &&
+        inv.Status !== 'Cancelled'
+      );
+    });
+
+    // Group by customer
+    const customerMap = new Map<string, { customerId: string; customerName: string; invoiceCount: number; totalAmount: number }>();
+
+    filteredInvoices.forEach((inv) => {
+      const existing = customerMap.get(inv.CustomerId);
+      if (existing) {
+        existing.invoiceCount += 1;
+        existing.totalAmount += inv.TotalAmount || 0;
+      } else {
+        customerMap.set(inv.CustomerId, {
+          customerId: inv.CustomerId,
+          customerName: inv.CustomerName || 'Unknown Customer',
+          invoiceCount: 1,
+          totalAmount: inv.TotalAmount || 0,
+        });
+      }
+    });
+
+    // Calculate total sales
+    const totalSales = Array.from(customerMap.values()).reduce((sum, c) => sum + c.totalAmount, 0);
+
+    // Convert to array with percentages and sort by amount descending
+    const customerSales: CustomerSalesData[] = Array.from(customerMap.values())
+      .map((c) => ({
+        ...c,
+        percentOfSales: totalSales > 0 ? (c.totalAmount / totalSales) * 100 : 0,
+      }))
+      .sort((a, b) => b.totalAmount - a.totalAmount);
+
+    return { customerSales, totalSales };
+  }, [invoices, startDate, endDate]);
+
+  // Prepare chart data (top 10 customers)
+  const chartData = useMemo(() => {
+    return salesData.customerSales.slice(0, 10).map((c) => ({
+      name: c.customerName.length > 20 ? c.customerName.substring(0, 17) + '...' : c.customerName,
+      fullName: c.customerName,
+      amount: c.totalAmount,
+      percent: c.percentOfSales,
+    }));
+  }, [salesData.customerSales]);
+
+  const columns: ReportColumn[] = [
+    { key: 'customerName', header: 'Customer', align: 'left' },
+    { key: 'invoiceCount', header: 'Invoices', align: 'right' },
+    {
+      key: 'totalAmount',
+      header: 'Amount',
+      align: 'right',
+      format: (value) => formatCurrency(value || 0),
+    },
+    {
+      key: 'percentOfSales',
+      header: '% of Sales',
+      align: 'right',
+      format: (value) => `${(value || 0).toFixed(1)}%`,
+    },
+  ];
+
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = salesData.customerSales.map((c) => ({
+      customerName: c.customerName,
+      invoiceCount: c.invoiceCount,
+      totalAmount: c.totalAmount,
+      percentOfSales: c.percentOfSales,
+      customerId: c.customerId,
+    }));
+
+    // Add total row
+    if (rows.length > 0) {
+      rows.push({
+        customerName: 'TOTAL',
+        invoiceCount: rows.reduce((sum, r) => sum + (r.invoiceCount || 0), 0),
+        totalAmount: salesData.totalSales,
+        percentOfSales: 100,
+        isTotal: true,
+      });
+    }
+
+    return rows;
+  }, [salesData]);
+
+  const handleExportCSV = () => {
+    exportToCSV(`sales-by-customer-${startDate}-to-${endDate}`, columns, tableData);
+  };
+
+  const formatDateRange = () =>
+    `${new Date(startDate).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })} - ${new Date(endDate).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+
+  const handleRowClick = (row: ReportRow) => {
+    if (row.customerId && !row.isTotal) {
+      // Navigate to customer invoices filtered view
+      navigate(`/invoices?customer=${row.customerId}`);
+    }
+  };
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-white p-3 shadow-lg rounded-lg border border-gray-200">
+          <p className="font-medium text-gray-900">{data.fullName}</p>
+          <p className="text-sm text-gray-600">{formatCurrency(data.amount)}</p>
+          <p className="text-sm text-gray-500">{data.percent.toFixed(1)}% of sales</p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-6xl mx-auto p-4">
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+    return (
+      <div className="max-w-6xl mx-auto p-4">
+        <p className="text-red-600 font-medium">Unable to load sales data.</p>
+        <p className="text-gray-600 mt-2">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-4 print:hidden">
+        <Link
+          to="/reports"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Reports
+        </Link>
+      </div>
+
+      <ReportHeader
+        title="Sales by Customer Summary"
+        subtitle="Sales breakdown by customer for the selected period"
+        dateRange={formatDateRange()}
+        onExportCSV={handleExportCSV}
+      />
+
+      {/* Filters */}
+      <div className="mb-6 print:hidden">
+        <div className="flex flex-wrap items-center gap-4">
+          <DateRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            onStartDateChange={setStartDate}
+            onEndDateChange={setEndDate}
+          />
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700">Chart Type:</label>
+            <select
+              value={chartType}
+              onChange={(e) => setChartType(e.target.value as 'bar' | 'pie')}
+              className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            >
+              <option value="bar">Bar Chart</option>
+              <option value="pie">Pie Chart</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="bg-white shadow rounded-lg p-4">
+          <div className="flex items-center">
+            <div className="flex-shrink-0">
+              <Users className="h-8 w-8 text-indigo-500" />
+            </div>
+            <div className="ml-4">
+              <p className="text-sm font-medium text-gray-500">Total Customers</p>
+              <p className="text-2xl font-semibold text-gray-900">
+                {salesData.customerSales.length}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="bg-white shadow rounded-lg p-4">
+          <div className="ml-4">
+            <p className="text-sm font-medium text-gray-500">Total Sales</p>
+            <p className="text-2xl font-semibold text-gray-900">
+              {formatCurrency(salesData.totalSales)}
+            </p>
+          </div>
+        </div>
+        <div className="bg-white shadow rounded-lg p-4">
+          <div className="ml-4">
+            <p className="text-sm font-medium text-gray-500">Avg. per Customer</p>
+            <p className="text-2xl font-semibold text-gray-900">
+              {formatCurrency(
+                salesData.customerSales.length > 0
+                  ? salesData.totalSales / salesData.customerSales.length
+                  : 0
+              )}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {salesData.customerSales.length === 0 ? (
+        <div className="bg-white shadow rounded-lg p-8 text-center">
+          <Users className="mx-auto h-12 w-12 text-gray-400" />
+          <p className="mt-2 text-gray-500">No sales found for the selected period.</p>
+        </div>
+      ) : (
+        <>
+          {/* Chart */}
+          <div className="bg-white shadow rounded-lg p-6 mb-6 print:hidden">
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              Top 10 Customers by Sales
+            </h3>
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                {chartType === 'bar' ? (
+                  <BarChart data={chartData} layout="vertical" margin={{ left: 100 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis type="number" tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`} />
+                    <YAxis type="category" dataKey="name" width={100} />
+                    <Tooltip content={<CustomTooltip />} />
+                    <Bar dataKey="amount" fill="#4F46E5">
+                      {chartData.map((_, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                ) : (
+                  <PieChart>
+                    <Pie
+                      data={chartData}
+                      cx="50%"
+                      cy="50%"
+                      labelLine={false}
+                      outerRadius={120}
+                      fill="#8884d8"
+                      dataKey="amount"
+                      nameKey="name"
+                      label={({ name, percent }) => `${name} (${(percent * 100).toFixed(0)}%)`}
+                    >
+                      {chartData.map((_, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip content={<CustomTooltip />} />
+                    <Legend />
+                  </PieChart>
+                )}
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Table */}
+          <div className="bg-white shadow rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 print:bg-white">
+                <tr>
+                  {columns.map((column) => (
+                    <th
+                      key={column.key}
+                      className={`px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider print:px-2 print:py-1 ${
+                        column.align === 'right' ? 'text-right' : 'text-left'
+                      }`}
+                    >
+                      {column.header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {tableData.map((row, rowIndex) => {
+                  const rowClasses = row.isTotal
+                    ? 'bg-gray-100 font-bold text-gray-900 border-t-2 border-gray-300'
+                    : 'hover:bg-blue-50 cursor-pointer';
+
+                  return (
+                    <tr
+                      key={row.customerId || `row-${rowIndex}`}
+                      className={rowClasses}
+                      onClick={() => handleRowClick(row)}
+                      title={row.isTotal ? undefined : 'Click to view invoices for this customer'}
+                    >
+                      {columns.map((column) => (
+                        <td
+                          key={column.key}
+                          className={`px-4 py-2 print:px-2 print:py-1 print:text-xs ${
+                            column.align === 'right' ? 'text-right' : 'text-left'
+                          }`}
+                        >
+                          {column.format
+                            ? column.format(row[column.key], row)
+                            : row[column.key] ?? ''}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs">
+        <p>
+          Generated on{' '}
+          {new Date().toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/SalesByProduct.tsx
+++ b/client/src/pages/reports/SalesByProduct.tsx
@@ -1,0 +1,541 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Package } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  PieChart,
+  Pie,
+  Legend,
+} from 'recharts';
+import api from '../../lib/api';
+import { DateRangePicker, ReportHeader, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Invoice {
+  Id: string;
+  InvoiceNumber: string;
+  CustomerId: string;
+  CustomerName: string;
+  IssueDate: string;
+  TotalAmount: number;
+  Status: string;
+}
+
+interface InvoiceLine {
+  Id: string;
+  InvoiceId: string;
+  ProductServiceId: string | null;
+  Description: string;
+  Quantity: number;
+  UnitPrice: number;
+  Amount: number;
+}
+
+interface ProductService {
+  Id: string;
+  Name: string;
+  SKU: string | null;
+  Type: string;
+  Category: string | null;
+}
+
+interface ProductSalesData {
+  productId: string | null;
+  productName: string;
+  sku: string | null;
+  category: string | null;
+  quantitySold: number;
+  totalAmount: number;
+  percentOfSales: number;
+}
+
+const COLORS = [
+  '#10B981', // Emerald
+  '#4F46E5', // Indigo
+  '#F59E0B', // Amber
+  '#EF4444', // Red
+  '#8B5CF6', // Violet
+  '#06B6D4', // Cyan
+  '#EC4899', // Pink
+  '#84CC16', // Lime
+  '#F97316', // Orange
+  '#6366F1', // Indigo light
+];
+
+export default function SalesByProduct() {
+  const navigate = useNavigate();
+  const today = new Date();
+  const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const [startDate, setStartDate] = useState(firstDayOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(today.toISOString().split('T')[0]);
+  const [chartType, setChartType] = useState<'bar' | 'pie'>('bar');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+
+  // Fetch invoices
+  const { data: invoices, isLoading: invoicesLoading, error: invoicesError } = useQuery({
+    queryKey: ['invoices-sales-by-product'],
+    queryFn: async () => {
+      const response = await api.get<{ value: Invoice[] }>('/invoices');
+      return response.data.value;
+    },
+  });
+
+  // Fetch invoice lines
+  const { data: invoiceLines, isLoading: linesLoading } = useQuery({
+    queryKey: ['invoice-lines-sales-by-product'],
+    queryFn: async () => {
+      const response = await api.get<{ value: InvoiceLine[] }>('/invoicelines');
+      return response.data.value;
+    },
+  });
+
+  // Fetch products/services for names
+  const { data: products, isLoading: productsLoading } = useQuery({
+    queryKey: ['products-sales-report'],
+    queryFn: async () => {
+      const response = await api.get<{ value: ProductService[] }>('/productsservices');
+      return response.data.value;
+    },
+  });
+
+  const isLoading = invoicesLoading || linesLoading || productsLoading;
+  const error = invoicesError;
+
+  // Get unique categories
+  const categories = useMemo(() => {
+    if (!products) return [];
+    const cats = new Set(products.filter((p) => p.Category).map((p) => p.Category as string));
+    return Array.from(cats).sort();
+  }, [products]);
+
+  // Calculate sales by product
+  const salesData = useMemo(() => {
+    if (!invoices || !invoiceLines) {
+      return { productSales: [] as ProductSalesData[], totalSales: 0 };
+    }
+
+    // Create invoice map for date filtering
+    const invoiceMap = new Map(invoices.map((inv) => [inv.Id, inv]));
+
+    // Create product map for names
+    const productMap = new Map(products?.map((p) => [p.Id, p]) || []);
+
+    // Parse dates
+    const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
+    const start = new Date(startYear, startMonth - 1, startDay, 0, 0, 0, 0);
+    const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
+    const end = new Date(endYear, endMonth - 1, endDay, 23, 59, 59, 999);
+
+    // Filter and aggregate lines
+    const productSalesMap = new Map<string, ProductSalesData>();
+
+    invoiceLines.forEach((line) => {
+      const invoice = invoiceMap.get(line.InvoiceId);
+      if (!invoice) return;
+
+      // Check date range and status
+      const issueDate = new Date(invoice.IssueDate);
+      if (
+        issueDate < start ||
+        issueDate > end ||
+        invoice.Status === 'Voided' ||
+        invoice.Status === 'Cancelled'
+      ) {
+        return;
+      }
+
+      // Get product info
+      const product = line.ProductServiceId ? productMap.get(line.ProductServiceId) : null;
+      const productKey = line.ProductServiceId || 'no-product';
+      const productName = product?.Name || line.Description || 'Uncategorized';
+      const category = product?.Category || null;
+
+      // Apply category filter
+      if (categoryFilter !== 'all') {
+        if (category !== categoryFilter) return;
+      }
+
+      const existing = productSalesMap.get(productKey);
+      const lineAmount = line.Amount || line.Quantity * line.UnitPrice;
+
+      if (existing) {
+        existing.quantitySold += line.Quantity || 0;
+        existing.totalAmount += lineAmount;
+      } else {
+        productSalesMap.set(productKey, {
+          productId: line.ProductServiceId,
+          productName,
+          sku: product?.SKU || null,
+          category,
+          quantitySold: line.Quantity || 0,
+          totalAmount: lineAmount,
+          percentOfSales: 0,
+        });
+      }
+    });
+
+    // Calculate total sales
+    const totalSales = Array.from(productSalesMap.values()).reduce(
+      (sum, p) => sum + p.totalAmount,
+      0
+    );
+
+    // Convert to array with percentages and sort by amount descending
+    const productSales: ProductSalesData[] = Array.from(productSalesMap.values())
+      .map((p) => ({
+        ...p,
+        percentOfSales: totalSales > 0 ? (p.totalAmount / totalSales) * 100 : 0,
+      }))
+      .sort((a, b) => b.totalAmount - a.totalAmount);
+
+    return { productSales, totalSales };
+  }, [invoices, invoiceLines, products, startDate, endDate, categoryFilter]);
+
+  // Prepare chart data (top 10 products)
+  const chartData = useMemo(() => {
+    return salesData.productSales.slice(0, 10).map((p) => ({
+      name: p.productName.length > 20 ? p.productName.substring(0, 17) + '...' : p.productName,
+      fullName: p.productName,
+      amount: p.totalAmount,
+      percent: p.percentOfSales,
+      quantity: p.quantitySold,
+    }));
+  }, [salesData.productSales]);
+
+  const columns: ReportColumn[] = [
+    { key: 'productName', header: 'Product/Service', align: 'left' },
+    { key: 'sku', header: 'SKU', align: 'left' },
+    { key: 'category', header: 'Category', align: 'left' },
+    {
+      key: 'quantitySold',
+      header: 'Qty Sold',
+      align: 'right',
+      format: (value) => (value || 0).toLocaleString(),
+    },
+    {
+      key: 'totalAmount',
+      header: 'Amount',
+      align: 'right',
+      format: (value) => formatCurrency(value || 0),
+    },
+    {
+      key: 'percentOfSales',
+      header: '% of Sales',
+      align: 'right',
+      format: (value) => `${(value || 0).toFixed(1)}%`,
+    },
+  ];
+
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = salesData.productSales.map((p) => ({
+      productName: p.productName,
+      sku: p.sku || '-',
+      category: p.category || '-',
+      quantitySold: p.quantitySold,
+      totalAmount: p.totalAmount,
+      percentOfSales: p.percentOfSales,
+      productId: p.productId,
+    }));
+
+    // Add total row
+    if (rows.length > 0) {
+      rows.push({
+        productName: 'TOTAL',
+        sku: '',
+        category: '',
+        quantitySold: rows.reduce((sum, r) => sum + (r.quantitySold || 0), 0),
+        totalAmount: salesData.totalSales,
+        percentOfSales: 100,
+        isTotal: true,
+      });
+    }
+
+    return rows;
+  }, [salesData]);
+
+  const handleExportCSV = () => {
+    exportToCSV(`sales-by-product-${startDate}-to-${endDate}`, columns, tableData);
+  };
+
+  const formatDateRange = () =>
+    `${new Date(startDate).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })} - ${new Date(endDate).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+
+  const handleRowClick = (row: ReportRow) => {
+    if (row.productId && !row.isTotal) {
+      // Navigate to product detail page
+      navigate(`/products-services/${row.productId}/edit`);
+    }
+  };
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-white p-3 shadow-lg rounded-lg border border-gray-200">
+          <p className="font-medium text-gray-900">{data.fullName}</p>
+          <p className="text-sm text-gray-600">{formatCurrency(data.amount)}</p>
+          <p className="text-sm text-gray-500">
+            {data.quantity.toLocaleString()} units ({data.percent.toFixed(1)}%)
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-6xl mx-auto p-4">
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+    return (
+      <div className="max-w-6xl mx-auto p-4">
+        <p className="text-red-600 font-medium">Unable to load sales data.</p>
+        <p className="text-gray-600 mt-2">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-4 print:hidden">
+        <Link
+          to="/reports"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Reports
+        </Link>
+      </div>
+
+      <ReportHeader
+        title="Sales by Product/Service Summary"
+        subtitle="Sales breakdown by product and service for the selected period"
+        dateRange={formatDateRange()}
+        onExportCSV={handleExportCSV}
+      />
+
+      {/* Filters */}
+      <div className="mb-6 print:hidden">
+        <div className="flex flex-wrap items-center gap-4">
+          <DateRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            onStartDateChange={setStartDate}
+            onEndDateChange={setEndDate}
+          />
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700">Category:</label>
+            <select
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+              className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            >
+              <option value="all">All Categories</option>
+              {categories.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700">Chart Type:</label>
+            <select
+              value={chartType}
+              onChange={(e) => setChartType(e.target.value as 'bar' | 'pie')}
+              className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+            >
+              <option value="bar">Bar Chart</option>
+              <option value="pie">Pie Chart</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="bg-white shadow rounded-lg p-4">
+          <div className="flex items-center">
+            <div className="flex-shrink-0">
+              <Package className="h-8 w-8 text-emerald-500" />
+            </div>
+            <div className="ml-4">
+              <p className="text-sm font-medium text-gray-500">Products/Services</p>
+              <p className="text-2xl font-semibold text-gray-900">
+                {salesData.productSales.length}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="bg-white shadow rounded-lg p-4">
+          <div className="ml-4">
+            <p className="text-sm font-medium text-gray-500">Total Sales</p>
+            <p className="text-2xl font-semibold text-gray-900">
+              {formatCurrency(salesData.totalSales)}
+            </p>
+          </div>
+        </div>
+        <div className="bg-white shadow rounded-lg p-4">
+          <div className="ml-4">
+            <p className="text-sm font-medium text-gray-500">Total Units Sold</p>
+            <p className="text-2xl font-semibold text-gray-900">
+              {salesData.productSales
+                .reduce((sum, p) => sum + p.quantitySold, 0)
+                .toLocaleString()}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {salesData.productSales.length === 0 ? (
+        <div className="bg-white shadow rounded-lg p-8 text-center">
+          <Package className="mx-auto h-12 w-12 text-gray-400" />
+          <p className="mt-2 text-gray-500">No sales found for the selected period.</p>
+        </div>
+      ) : (
+        <>
+          {/* Chart */}
+          <div className="bg-white shadow rounded-lg p-6 mb-6 print:hidden">
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              Top 10 Products/Services by Sales
+            </h3>
+            <div className="h-80">
+              <ResponsiveContainer width="100%" height="100%">
+                {chartType === 'bar' ? (
+                  <BarChart data={chartData} layout="vertical" margin={{ left: 100 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      type="number"
+                      tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`}
+                    />
+                    <YAxis type="category" dataKey="name" width={100} />
+                    <Tooltip content={<CustomTooltip />} />
+                    <Bar dataKey="amount" fill="#10B981">
+                      {chartData.map((_, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                ) : (
+                  <PieChart>
+                    <Pie
+                      data={chartData}
+                      cx="50%"
+                      cy="50%"
+                      labelLine={false}
+                      outerRadius={120}
+                      fill="#8884d8"
+                      dataKey="amount"
+                      nameKey="name"
+                      label={({ name, percent }) => `${name} (${(percent * 100).toFixed(0)}%)`}
+                    >
+                      {chartData.map((_, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip content={<CustomTooltip />} />
+                    <Legend />
+                  </PieChart>
+                )}
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Table */}
+          <div className="bg-white shadow rounded-lg overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 print:bg-white">
+                <tr>
+                  {columns.map((column) => (
+                    <th
+                      key={column.key}
+                      className={`px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider print:px-2 print:py-1 ${
+                        column.align === 'right' ? 'text-right' : 'text-left'
+                      }`}
+                    >
+                      {column.header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {tableData.map((row, rowIndex) => {
+                  const rowClasses = row.isTotal
+                    ? 'bg-gray-100 font-bold text-gray-900 border-t-2 border-gray-300'
+                    : row.productId
+                    ? 'hover:bg-blue-50 cursor-pointer'
+                    : '';
+
+                  return (
+                    <tr
+                      key={row.productId || `row-${rowIndex}`}
+                      className={rowClasses}
+                      onClick={() => handleRowClick(row)}
+                      title={
+                        row.isTotal
+                          ? undefined
+                          : row.productId
+                          ? 'Click to view product details'
+                          : undefined
+                      }
+                    >
+                      {columns.map((column) => (
+                        <td
+                          key={column.key}
+                          className={`px-4 py-2 print:px-2 print:py-1 print:text-xs ${
+                            column.align === 'right' ? 'text-right' : 'text-left'
+                          }`}
+                        >
+                          {column.format
+                            ? column.format(row[column.key], row)
+                            : row[column.key] ?? ''}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs">
+        <p>
+          Generated on{' '}
+          {new Date().toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add **Sales by Customer Summary** report showing customer breakdown with invoice count, total amount, and percentage of sales
- Add **Sales by Product/Service Summary** report showing product breakdown with quantity sold, amount, and percentage of sales
- Add Sales Reports section to the Reports page with navigation links
- Add routes for both new reports in App.tsx

## Features

Both reports include:
- Date range filtering with presets (This Month, Last Month, This Quarter, etc.)
- Interactive charts - switchable between bar and pie charts
- Summary cards with key metrics (total customers/products, total sales, averages)
- Drill-down navigation (click rows to view related entities)
- CSV export capability
- Print-friendly styling
- Voided/Cancelled invoice exclusion

### Sales by Customer
- Groups invoices by customer
- Shows invoice count, total amount, and % of sales
- Click row to filter invoices by customer

### Sales by Product/Service
- Groups invoice lines by product/service
- Shows quantity sold, total amount, and % of sales
- Category filtering dropdown
- Click row to view product details

## Test plan
- [ ] Navigate to Reports page, verify Sales Reports section appears
- [ ] Click Sales by Customer report
  - [ ] Verify chart displays correctly
  - [ ] Change date range, verify data updates
  - [ ] Switch chart type from bar to pie
  - [ ] Click on a customer row, verify navigation
  - [ ] Export to CSV, verify file downloads
- [ ] Click Sales by Product/Service report
  - [ ] Verify chart displays correctly
  - [ ] Filter by category, verify data updates
  - [ ] Export to CSV, verify file downloads
- [ ] Verify print layout (Ctrl+P)

Closes #228

:robot: Generated with [Claude Code](https://claude.com/claude-code)