### PR TITLE
feat: Sales Receipts for Cash Sales (#224)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -113,6 +113,9 @@ import BankImportHistory from './pages/BankImportHistory';
 import BankRules from './pages/BankRules';
 import VendorHierarchy from './pages/VendorHierarchy';
 import CustomerHierarchy from './pages/CustomerHierarchy';
+import SalesReceipts from './pages/SalesReceipts';
+import NewSalesReceipt from './pages/NewSalesReceipt';
+import EditSalesReceipt from './pages/EditSalesReceipt';
 import ChatInterface from './components/ChatInterface';
 import OnboardingWelcome from './components/onboarding/OnboardingWelcome';
 import FeatureTour from './components/onboarding/FeatureTour';
@@ -148,6 +151,9 @@ function AppContent() {
             <Route path="invoices/new" element={<NewInvoice />} />
             <Route path="invoices/:id" element={<InvoiceView />} />
             <Route path="invoices/:id/edit" element={<EditInvoice />} />
+            <Route path="sales-receipts" element={<SalesReceipts />} />
+            <Route path="sales-receipts/new" element={<NewSalesReceipt />} />
+            <Route path="sales-receipts/:id/edit" element={<EditSalesReceipt />} />
             <Route path="estimates" element={<Estimates />} />
             <Route path="estimates/new" element={<NewEstimate />} />
             <Route path="estimates/:id/edit" element={<EditEstimate />} />

--- a/client/src/components/SalesReceiptForm.tsx
+++ b/client/src/components/SalesReceiptForm.tsx
@@ -1,0 +1,516 @@
+import { useForm, useFieldArray, useWatch, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
+import { useEffect, ReactNode, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import CustomerSelector from './CustomerSelector';
+import ProductServiceSelector, { ProductService } from './ProductServiceSelector';
+import api from '../lib/api';
+import { PAYMENT_METHODS } from '../lib/salesReceiptUtils';
+
+// Tax rate interface
+interface TaxRate {
+  Id: string;
+  Name: string;
+  Rate: number;
+  Description: string | null;
+  IsDefault: boolean;
+  IsActive: boolean;
+}
+
+// Account interface for deposit account selector
+interface Account {
+  Id: string;
+  Name: string;
+  Type: string;
+  AccountNumber?: string;
+}
+
+export const salesReceiptSchema = z.object({
+  SalesReceiptNumber: z.string().min(1, 'Sales receipt number is required'),
+  CustomerId: z.string().nullish(),
+  SaleDate: z.string().min(1, 'Sale date is required'),
+  DepositAccountId: z.string().uuid('Please select a deposit account'),
+  PaymentMethod: z.string().nullish(),
+  Reference: z.string().nullish(),
+  Subtotal: z.number().min(0, 'Subtotal must be positive'),
+  TaxRateId: z.string().nullish(),
+  TaxAmount: z.number().min(0, 'Tax amount must be positive'),
+  TotalAmount: z.number().min(0, 'Amount must be positive'),
+  Memo: z.string().nullish(),
+  Status: z.enum(['Completed', 'Voided']),
+  ClassId: z.string().nullish(),
+  LocationId: z.string().nullish(),
+  Lines: z.array(z.object({
+    Id: z.string().nullish(),
+    ProductServiceId: z.string().nullish(),
+    Description: z.string().min(1, 'Description is required'),
+    Quantity: z.number().min(0.0001, 'Quantity must be greater than 0'),
+    UnitPrice: z.number().min(0, 'Unit price must be positive'),
+    Amount: z.number().nullish(),
+    AccountId: z.string().nullish(),
+    IsTaxable: z.boolean().optional()
+  })).min(1, 'At least one line item is required')
+});
+
+export type SalesReceiptFormData = z.infer<typeof salesReceiptSchema>;
+
+interface SalesReceiptFormProps {
+  initialValues?: Partial<SalesReceiptFormData>;
+  onSubmit: (data: SalesReceiptFormData) => Promise<void>;
+  title: string;
+  isSubmitting?: boolean;
+  submitButtonText?: string;
+  headerActions?: ReactNode;
+}
+
+export default function SalesReceiptForm({
+  initialValues,
+  onSubmit,
+  title,
+  isSubmitting: externalIsSubmitting,
+  submitButtonText = 'Save Sales Receipt',
+  headerActions
+}: SalesReceiptFormProps) {
+  const navigate = useNavigate();
+
+  // Track taxable status for each line item
+  const [lineTaxableStatus, setLineTaxableStatus] = useState<Record<number, boolean>>({});
+
+  // Fetch active tax rates
+  const { data: taxRates } = useQuery({
+    queryKey: ['taxrates-active'],
+    queryFn: async (): Promise<TaxRate[]> => {
+      const response = await api.get('/taxrates?$filter=IsActive eq true&$orderby=Name');
+      return response.data.value;
+    },
+  });
+
+  // Fetch bank/cash accounts for deposit
+  const { data: depositAccounts } = useQuery({
+    queryKey: ['deposit-accounts'],
+    queryFn: async (): Promise<Account[]> => {
+      // Get Bank and Cash type accounts
+      const response = await api.get("/accounts?$filter=Type eq 'Asset' and (SubType eq 'Bank' or SubType eq 'Cash' or SubType eq 'Checking' or SubType eq 'Savings')&$orderby=Name");
+      return response.data.value;
+    },
+  });
+
+  // Get default tax rate
+  const defaultTaxRate = useMemo(() => {
+    return taxRates?.find(tr => tr.IsDefault);
+  }, [taxRates]);
+
+  const { register, control, handleSubmit, setValue, watch, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<SalesReceiptFormData>({
+    resolver: zodResolver(salesReceiptSchema),
+    defaultValues: {
+      Status: 'Completed',
+      SaleDate: new Date().toISOString().split('T')[0],
+      Lines: [{ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0, IsTaxable: true }],
+      Subtotal: 0,
+      TaxRateId: initialValues?.TaxRateId || null,
+      TaxAmount: 0,
+      TotalAmount: 0,
+      ...initialValues
+    }
+  });
+
+  // Set default tax rate when tax rates load and no initial value
+  useEffect(() => {
+    if (defaultTaxRate && !initialValues?.TaxRateId) {
+      setValue('TaxRateId', defaultTaxRate.Id);
+    }
+  }, [defaultTaxRate, initialValues?.TaxRateId, setValue]);
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "Lines"
+  });
+
+  const lines = useWatch({
+    control,
+    name: "Lines"
+  });
+
+  const selectedTaxRateId = watch('TaxRateId');
+
+  // Get the selected tax rate
+  const selectedTaxRate = useMemo(() => {
+    if (!selectedTaxRateId || !taxRates) return null;
+    return taxRates.find(tr => tr.Id === selectedTaxRateId) || null;
+  }, [selectedTaxRateId, taxRates]);
+
+  // Calculate subtotal, taxable amount, tax, and total
+  const calculations = useMemo(() => {
+    let subtotal = 0;
+    let taxableAmount = 0;
+
+    lines.forEach((line, index) => {
+      const lineAmount = (line.Quantity || 0) * (line.UnitPrice || 0);
+      subtotal += lineAmount;
+
+      // Check if this line is taxable
+      const isTaxable = lineTaxableStatus[index] ?? true; // Default to taxable
+      if (isTaxable) {
+        taxableAmount += lineAmount;
+      }
+    });
+
+    const taxRate = selectedTaxRate?.Rate || 0;
+    const taxAmount = taxableAmount * taxRate;
+    const total = subtotal + taxAmount;
+
+    return {
+      subtotal: Math.round(subtotal * 100) / 100,
+      taxableAmount: Math.round(taxableAmount * 100) / 100,
+      taxAmount: Math.round(taxAmount * 100) / 100,
+      total: Math.round(total * 100) / 100,
+      taxRate: taxRate
+    };
+  }, [lines, lineTaxableStatus, selectedTaxRate]);
+
+  // Update form values when calculations change
+  useEffect(() => {
+    setValue('Subtotal', calculations.subtotal);
+    setValue('TaxAmount', calculations.taxAmount);
+    setValue('TotalAmount', calculations.total);
+  }, [calculations, setValue]);
+
+  const isSubmitting = externalIsSubmitting || formIsSubmitting;
+
+  // Format tax rate for display
+  const formatTaxRate = (rate: number) => {
+    return `${(rate * 100).toFixed(2)}%`;
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center">
+          <button onClick={() => navigate('/sales-receipts')} className="mr-4 text-gray-500 hover:text-gray-700">
+            <ArrowLeft className="w-6 h-6" />
+          </button>
+          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        </div>
+        {headerActions && <div className="flex items-center">{headerActions}</div>}
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <div>
+            <label htmlFor="SalesReceiptNumber" className="block text-sm font-medium text-gray-700">Sales Receipt #</label>
+            <input
+              id="SalesReceiptNumber"
+              type="text"
+              {...register('SalesReceiptNumber')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              placeholder="SR-001"
+            />
+            {errors.SalesReceiptNumber && <p className="mt-1 text-sm text-red-600">{errors.SalesReceiptNumber.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700">Customer (Optional)</label>
+            <Controller
+              name="CustomerId"
+              control={control}
+              render={({ field }) => (
+                <CustomerSelector
+                  value={field.value || ''}
+                  onChange={field.onChange}
+                  error={errors.CustomerId?.message}
+                  disabled={isSubmitting}
+                />
+              )}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="SaleDate" className="block text-sm font-medium text-gray-700">Sale Date</label>
+            <input
+              id="SaleDate"
+              type="date"
+              {...register('SaleDate')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            />
+            {errors.SaleDate && <p className="mt-1 text-sm text-red-600">{errors.SaleDate.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="DepositAccountId" className="block text-sm font-medium text-gray-700">Deposit To</label>
+            <select
+              id="DepositAccountId"
+              {...register('DepositAccountId')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="">Select deposit account...</option>
+              {depositAccounts?.map((account) => (
+                <option key={account.Id} value={account.Id}>
+                  {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
+                </option>
+              ))}
+            </select>
+            {errors.DepositAccountId && <p className="mt-1 text-sm text-red-600">{errors.DepositAccountId.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="PaymentMethod" className="block text-sm font-medium text-gray-700">Payment Method</label>
+            <select
+              id="PaymentMethod"
+              {...register('PaymentMethod')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="">Select payment method...</option>
+              {PAYMENT_METHODS.map((method) => (
+                <option key={method.value} value={method.value}>
+                  {method.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="Reference" className="block text-sm font-medium text-gray-700">Reference # (Check #, etc.)</label>
+            <input
+              id="Reference"
+              type="text"
+              {...register('Reference')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              placeholder="Optional"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="TaxRateId" className="block text-sm font-medium text-gray-700">Tax Rate</label>
+            <select
+              id="TaxRateId"
+              {...register('TaxRateId')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="">No Tax</option>
+              {taxRates?.map((taxRate) => (
+                <option key={taxRate.Id} value={taxRate.Id}>
+                  {taxRate.Name} ({formatTaxRate(taxRate.Rate)})
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-gray-500">
+              Tax will be applied to taxable line items only
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="Status" className="block text-sm font-medium text-gray-700">Status</label>
+            <select
+              id="Status"
+              {...register('Status')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="Completed">Completed</option>
+              <option value="Voided">Voided</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Line Items */}
+        <div className="mt-8">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-medium text-gray-900">Line Items</h3>
+            <button
+              type="button"
+              onClick={() => {
+                append({ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0, IsTaxable: true });
+                setLineTaxableStatus(prev => ({ ...prev, [fields.length]: true }));
+              }}
+              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              Add Item
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            {fields.map((field, index) => {
+              const handleProductServiceSelect = (productServiceId: string, productService?: ProductService) => {
+                setValue(`Lines.${index}.ProductServiceId`, productServiceId);
+                if (productService) {
+                  setValue(`Lines.${index}.Description`, productService.Name);
+                  if (productService.SalesPrice !== null) {
+                    setValue(`Lines.${index}.UnitPrice`, productService.SalesPrice);
+                  }
+                  setLineTaxableStatus(prev => ({ ...prev, [index]: productService.Taxable }));
+                } else {
+                  setLineTaxableStatus(prev => ({ ...prev, [index]: true }));
+                }
+              };
+
+              const lineAmount = (lines[index]?.Quantity || 0) * (lines[index]?.UnitPrice || 0);
+              const isTaxable = lineTaxableStatus[index] ?? true;
+
+              return (
+                <div key={field.id} className="bg-gray-50 p-4 rounded-md">
+                  <div className="flex gap-4 items-start mb-3">
+                    <div className="flex-grow">
+                      <label className="block text-xs font-medium text-gray-500">Product/Service</label>
+                      <Controller
+                        name={`Lines.${index}.ProductServiceId`}
+                        control={control}
+                        render={({ field: psField }) => (
+                          <ProductServiceSelector
+                            value={psField.value || ''}
+                            onChange={handleProductServiceSelect}
+                            disabled={isSubmitting}
+                            placeholder="Select or type description below"
+                          />
+                        )}
+                      />
+                    </div>
+                    <div className="flex items-center pt-5">
+                      <input
+                        type="checkbox"
+                        id={`taxable-${index}`}
+                        checked={isTaxable}
+                        onChange={(e) => {
+                          setLineTaxableStatus(prev => ({ ...prev, [index]: e.target.checked }));
+                        }}
+                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      />
+                      <label htmlFor={`taxable-${index}`} className="ml-2 text-xs text-gray-600">
+                        Taxable
+                      </label>
+                    </div>
+                  </div>
+                  <div className="flex gap-4 items-start">
+                    <div className="flex-grow">
+                      <label className="block text-xs font-medium text-gray-500">Description</label>
+                      <input
+                        {...register(`Lines.${index}.Description`)}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                        placeholder="Item description"
+                      />
+                      {errors.Lines?.[index]?.Description && (
+                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Description?.message}</p>
+                      )}
+                    </div>
+                    <div className="w-24">
+                      <label className="block text-xs font-medium text-gray-500">Qty</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        {...register(`Lines.${index}.Quantity`, { valueAsNumber: true })}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      />
+                    </div>
+                    <div className="w-32">
+                      <label className="block text-xs font-medium text-gray-500">Unit Price</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        {...register(`Lines.${index}.UnitPrice`, { valueAsNumber: true })}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      />
+                    </div>
+                    <div className="w-32">
+                      <label className="block text-xs font-medium text-gray-500">Amount</label>
+                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium">
+                        ${lineAmount.toFixed(2)}
+                        {!isTaxable && selectedTaxRate && (
+                          <span className="ml-1 text-xs text-gray-400">(no tax)</span>
+                        )}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        remove(index);
+                        setLineTaxableStatus(prev => {
+                          const newStatus: Record<number, boolean> = {};
+                          Object.keys(prev).forEach(key => {
+                            const keyNum = parseInt(key);
+                            if (keyNum < index) {
+                              newStatus[keyNum] = prev[keyNum];
+                            } else if (keyNum > index) {
+                              newStatus[keyNum - 1] = prev[keyNum];
+                            }
+                          });
+                          return newStatus;
+                        });
+                      }}
+                      className="mt-6 text-red-600 hover:text-red-800"
+                    >
+                      <Trash2 className="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {errors.Lines && <p className="mt-2 text-sm text-red-600">{errors.Lines.message}</p>}
+        </div>
+
+        {/* Memo */}
+        <div>
+          <label htmlFor="Memo" className="block text-sm font-medium text-gray-700">Memo / Message</label>
+          <textarea
+            id="Memo"
+            {...register('Memo')}
+            rows={2}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            placeholder="Notes or message to customer"
+          />
+        </div>
+
+        {/* Totals Section */}
+        <div className="border-t pt-4">
+          <div className="flex justify-end">
+            <div className="w-72 space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Subtotal:</span>
+                <span className="font-medium text-gray-900">${calculations.subtotal.toFixed(2)}</span>
+              </div>
+              {selectedTaxRate && (
+                <>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-600">
+                      Tax ({selectedTaxRate.Name} - {formatTaxRate(selectedTaxRate.Rate)}):
+                    </span>
+                    <span className="font-medium text-gray-900">${calculations.taxAmount.toFixed(2)}</span>
+                  </div>
+                  {calculations.taxableAmount !== calculations.subtotal && (
+                    <div className="flex justify-between text-xs text-gray-500">
+                      <span>Taxable amount:</span>
+                      <span>${calculations.taxableAmount.toFixed(2)}</span>
+                    </div>
+                  )}
+                </>
+              )}
+              <div className="flex justify-between text-lg font-bold border-t pt-2">
+                <span className="text-gray-900">Total:</span>
+                <span className="text-gray-900">${calculations.total.toFixed(2)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end items-center border-t pt-4">
+          <button
+            type="button"
+            onClick={() => navigate('/sales-receipts')}
+            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Saving...' : submitButtonText}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/navigation/navConfig.ts
+++ b/client/src/components/navigation/navConfig.ts
@@ -1,4 +1,4 @@
-import { LucideIcon, LayoutDashboard, FileText, ClipboardList, Users, Package, Warehouse, Truck, UserCheck, DollarSign, Receipt, FolderOpen, Clock, Tag, MapPin, RefreshCw, Layers, Building2, BookOpen, Upload, Database, Scale, BarChart3, MessageSquare, Sparkles, Settings, ShoppingCart, Percent, CreditCard, FileUp, CheckSquare, FileMinus, Car, ListFilter } from 'lucide-react';
+import { LucideIcon, LayoutDashboard, FileText, ClipboardList, Users, Package, Warehouse, Truck, UserCheck, DollarSign, Receipt, FolderOpen, Clock, Tag, MapPin, RefreshCw, Layers, Building2, BookOpen, Upload, Database, Scale, BarChart3, MessageSquare, Sparkles, Settings, ShoppingCart, Percent, CreditCard, FileUp, CheckSquare, FileMinus, Car, ListFilter, Banknote } from 'lucide-react';
 
 export interface NavItem {
   id: string;
@@ -42,6 +42,7 @@ export const navigationConfig: NavEntry[] = [
     icon: FileText,
     items: [
       { id: 'invoices', name: 'Invoices', href: '/invoices', icon: FileText, featureKey: 'invoices' },
+      { id: 'sales-receipts', name: 'Sales Receipts', href: '/sales-receipts', icon: Banknote, featureKey: 'sales_receipts' },
       { id: 'estimates', name: 'Estimates', href: '/estimates', icon: ClipboardList, featureKey: 'estimates' },
     ],
   },

--- a/client/src/lib/salesReceiptUtils.ts
+++ b/client/src/lib/salesReceiptUtils.ts
@@ -1,0 +1,96 @@
+/**
+ * Sales Receipt utility functions
+ */
+
+export interface SalesReceipt {
+  Id: string;
+  SalesReceiptNumber: string;
+  CustomerId?: string;
+  CustomerName?: string;
+  SaleDate: string;
+  DepositAccountId: string;
+  DepositAccountName?: string;
+  PaymentMethod?: string;
+  Reference?: string;
+  Subtotal: number;
+  TaxRateId?: string;
+  TaxRateName?: string;
+  TaxRate?: number;
+  TaxAmount: number;
+  TotalAmount: number;
+  Memo?: string;
+  Status: string;
+  JournalEntryId?: string;
+  ClassId?: string;
+  ClassName?: string;
+  LocationId?: string;
+  LocationName?: string;
+}
+
+export interface SalesReceiptLine {
+  Id?: string;
+  SalesReceiptId?: string;
+  ProductServiceId?: string;
+  Description: string;
+  Quantity: number;
+  UnitPrice: number;
+  Amount?: number;
+  AccountId?: string;
+  TaxRateId?: string;
+  ClassId?: string;
+  SortOrder?: number;
+}
+
+/**
+ * Generates the next sequential sales receipt number based on existing receipts
+ * @param receipts - Array of existing sales receipts
+ * @returns The next sales receipt number in format SR-XXX (e.g., SR-003)
+ */
+export function generateNextSalesReceiptNumber(receipts: SalesReceipt[]): string {
+  const existingNumbers = receipts
+    .map(sr => {
+      const match = sr.SalesReceiptNumber.match(/^SR-(\d+)$/);
+      return match ? parseInt(match[1], 10) : 0;
+    })
+    .filter(n => n > 0);
+
+  const maxNumber = existingNumbers.length > 0 ? Math.max(...existingNumbers) : 0;
+  return 'SR-' + String(maxNumber + 1).padStart(3, '0');
+}
+
+/**
+ * Calculates the subtotal from sales receipt line items
+ * @param lines - Array of sales receipt line items
+ * @returns The subtotal amount
+ */
+export function calculateSubtotal(lines: { Quantity: number; UnitPrice: number }[]): number {
+  return lines.reduce((sum, line) => sum + (line.Quantity * line.UnitPrice), 0);
+}
+
+/**
+ * Gets the current date in ISO format (YYYY-MM-DD)
+ * @returns Current date string
+ */
+export function getCurrentDate(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+/**
+ * Payment method options for sales receipts
+ */
+export const PAYMENT_METHODS = [
+  { value: 'Cash', label: 'Cash' },
+  { value: 'Check', label: 'Check' },
+  { value: 'Credit Card', label: 'Credit Card' },
+  { value: 'Debit Card', label: 'Debit Card' },
+  { value: 'ACH', label: 'ACH/Bank Transfer' },
+  { value: 'Other', label: 'Other' },
+] as const;
+
+/**
+ * Status options for sales receipts
+ */
+export const SALES_RECEIPT_STATUSES = [
+  { value: 'Completed', label: 'Completed' },
+  { value: 'Voided', label: 'Voided' },
+] as const;

--- a/client/src/pages/EditSalesReceipt.tsx
+++ b/client/src/pages/EditSalesReceipt.tsx
@@ -1,0 +1,144 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../lib/api';
+import SalesReceiptForm, { SalesReceiptFormData } from '../components/SalesReceiptForm';
+import { SalesReceipt, SalesReceiptLine } from '../lib/salesReceiptUtils';
+import { formatGuidForOData } from '../lib/validation';
+
+export default function EditSalesReceipt() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  // Fetch the sales receipt
+  const { data: salesReceipt, isLoading: loadingReceipt } = useQuery({
+    queryKey: ['salesreceipt', id],
+    queryFn: async () => {
+      const response = await api.get<{ value: SalesReceipt[] }>(
+        `/salesreceipts?$filter=Id eq ${formatGuidForOData(id!, 'Sales Receipt Id')}`
+      );
+      return response.data.value[0];
+    },
+    enabled: !!id,
+  });
+
+  // Fetch the sales receipt lines
+  const { data: lines, isLoading: loadingLines } = useQuery({
+    queryKey: ['salesreceiptlines', id],
+    queryFn: async () => {
+      const response = await api.get<{ value: SalesReceiptLine[] }>(
+        `/salesreceiptlines?$filter=SalesReceiptId eq ${formatGuidForOData(id!, 'Sales Receipt Id')}&$orderby=SortOrder`
+      );
+      return response.data.value;
+    },
+    enabled: !!id,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (data: SalesReceiptFormData) => {
+      const { Lines, ...salesReceiptData } = data;
+
+      // Update the sales receipt
+      await api.patch(`/salesreceipts_write/Id/${id}`, salesReceiptData);
+
+      // Get existing line IDs
+      const existingLineIds = new Set(lines?.map(l => l.Id) || []);
+      const newLineIds = new Set(Lines.filter(l => l.Id).map(l => l.Id!));
+
+      // Delete removed lines
+      const linesToDelete = [...existingLineIds].filter(lineId => lineId && !newLineIds.has(lineId));
+      await Promise.all(
+        linesToDelete.map(lineId =>
+          lineId ? api.delete(`/salesreceiptlines/Id/${lineId}`) : Promise.resolve()
+        )
+      );
+
+      // Update existing lines and create new ones
+      await Promise.all(
+        Lines.map(async (line, index) => {
+          const lineData = {
+            SalesReceiptId: id,
+            ProductServiceId: line.ProductServiceId || null,
+            Description: line.Description,
+            Quantity: line.Quantity,
+            UnitPrice: line.UnitPrice,
+            Amount: line.Quantity * line.UnitPrice,
+            SortOrder: index,
+          };
+
+          if (line.Id && existingLineIds.has(line.Id)) {
+            // Update existing line
+            await api.patch(`/salesreceiptlines/Id/${line.Id}`, lineData);
+          } else {
+            // Create new line
+            await api.post('/salesreceiptlines', lineData);
+          }
+        })
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['salesreceipt', id] });
+      queryClient.invalidateQueries({ queryKey: ['salesreceiptlines', id] });
+      queryClient.invalidateQueries({ queryKey: ['salesreceipts'] });
+      navigate('/sales-receipts');
+    },
+    onError: (error) => {
+      console.error('Failed to update sales receipt:', error);
+      alert('Failed to update sales receipt');
+    },
+  });
+
+  const isLoading = loadingReceipt || loadingLines;
+
+  if (isLoading) {
+    return (
+      <div className="max-w-4xl mx-auto py-8">
+        <div className="text-center text-gray-500">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!salesReceipt) {
+    return (
+      <div className="max-w-4xl mx-auto py-8">
+        <div className="text-center text-red-500">Sales receipt not found</div>
+      </div>
+    );
+  }
+
+  // Transform data for the form
+  const initialValues: Partial<SalesReceiptFormData> = {
+    SalesReceiptNumber: salesReceipt.SalesReceiptNumber,
+    CustomerId: salesReceipt.CustomerId || undefined,
+    SaleDate: salesReceipt.SaleDate,
+    DepositAccountId: salesReceipt.DepositAccountId,
+    PaymentMethod: salesReceipt.PaymentMethod || undefined,
+    Reference: salesReceipt.Reference || undefined,
+    Subtotal: salesReceipt.Subtotal,
+    TaxRateId: salesReceipt.TaxRateId || undefined,
+    TaxAmount: salesReceipt.TaxAmount,
+    TotalAmount: salesReceipt.TotalAmount,
+    Memo: salesReceipt.Memo || undefined,
+    Status: salesReceipt.Status as 'Completed' | 'Voided',
+    ClassId: salesReceipt.ClassId || undefined,
+    LocationId: salesReceipt.LocationId || undefined,
+    Lines: lines?.map(line => ({
+      Id: line.Id,
+      ProductServiceId: line.ProductServiceId || '',
+      Description: line.Description,
+      Quantity: line.Quantity,
+      UnitPrice: line.UnitPrice,
+      Amount: line.Amount,
+    })) || [{ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0 }],
+  };
+
+  return (
+    <SalesReceiptForm
+      title={`Edit Sales Receipt ${salesReceipt.SalesReceiptNumber}`}
+      initialValues={initialValues}
+      onSubmit={(data) => updateMutation.mutateAsync(data)}
+      submitButtonText="Save Changes"
+      isSubmitting={updateMutation.isPending}
+    />
+  );
+}

--- a/client/src/pages/NewSalesReceipt.tsx
+++ b/client/src/pages/NewSalesReceipt.tsx
@@ -1,0 +1,74 @@
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '../lib/api';
+import SalesReceiptForm, { SalesReceiptFormData } from '../components/SalesReceiptForm';
+import { generateNextSalesReceiptNumber, SalesReceipt } from '../lib/salesReceiptUtils';
+
+export default function NewSalesReceipt() {
+  const navigate = useNavigate();
+
+  // Fetch all existing sales receipts to generate the next number
+  const { data: existingReceipts } = useQuery({
+    queryKey: ['salesreceipts-all'],
+    queryFn: async () => {
+      const response = await api.get<{ value: SalesReceipt[] }>('/salesreceipts');
+      return response.data.value;
+    },
+  });
+
+  const onSubmit = async (data: SalesReceiptFormData) => {
+    try {
+      // Separate lines from sales receipt data
+      const { Lines, ...salesReceiptData } = data;
+
+      // Create the sales receipt first
+      await api.post('/salesreceipts_write', salesReceiptData);
+
+      // DAB doesn't return the created entity, so we need to query for it
+      const escapedNumber = String(salesReceiptData.SalesReceiptNumber).replace(/'/g, "''");
+      const queryResponse = await api.get<{ value: SalesReceipt[] }>(
+        `/salesreceipts?$filter=SalesReceiptNumber eq '${escapedNumber}'`
+      );
+      const salesReceipt = queryResponse.data.value[0];
+
+      if (!salesReceipt?.Id) {
+        throw new Error('Failed to retrieve created sales receipt');
+      }
+
+      // Create sales receipt lines
+      if (Lines && Lines.length > 0) {
+        await Promise.all(
+          Lines.map((line, index) =>
+            api.post('/salesreceiptlines', {
+              SalesReceiptId: salesReceipt.Id,
+              ProductServiceId: line.ProductServiceId || null,
+              Description: line.Description,
+              Quantity: line.Quantity,
+              UnitPrice: line.UnitPrice,
+              Amount: line.Quantity * line.UnitPrice,
+              SortOrder: index,
+            })
+          )
+        );
+      }
+
+      navigate('/sales-receipts');
+    } catch (error) {
+      console.error('Failed to create sales receipt:', error);
+      alert('Failed to create sales receipt');
+    }
+  };
+
+  const nextNumber = existingReceipts ? generateNextSalesReceiptNumber(existingReceipts) : 'SR-001';
+
+  return (
+    <SalesReceiptForm
+      title="New Sales Receipt"
+      onSubmit={onSubmit}
+      submitButtonText="Create Sales Receipt"
+      initialValues={{
+        SalesReceiptNumber: nextNumber,
+      }}
+    />
+  );
+}

--- a/client/src/pages/SalesReceipts.tsx
+++ b/client/src/pages/SalesReceipts.tsx
@@ -1,0 +1,89 @@
+import { Plus } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { GridColDef } from '@mui/x-data-grid';
+import RestDataGrid from '../components/RestDataGrid';
+import { SalesReceipt } from '../lib/salesReceiptUtils';
+import { formatDate } from '../lib/dateUtils';
+
+const statusColors: Record<string, string> = {
+  Completed: 'bg-green-100 text-green-800',
+  Voided: 'bg-red-100 text-red-800',
+};
+
+export default function SalesReceipts() {
+
+  const columns: GridColDef[] = [
+    { field: 'SalesReceiptNumber', headerName: 'Receipt #', width: 130, filterable: true },
+    { field: 'CustomerName', headerName: 'Customer', width: 180, filterable: true },
+    { field: 'SaleDate', headerName: 'Date', width: 120, filterable: true, renderCell: (params) => formatDate(params.value) },
+    { field: 'PaymentMethod', headerName: 'Payment', width: 120, filterable: true },
+    { field: 'DepositAccountName', headerName: 'Deposit To', width: 150, filterable: true },
+    {
+      field: 'TotalAmount',
+      headerName: 'Amount',
+      width: 120,
+      type: 'number',
+      filterable: true,
+      renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
+    },
+    {
+      field: 'Status',
+      headerName: 'Status',
+      width: 120,
+      filterable: true,
+      renderCell: (params) => (
+        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${statusColors[params.value] || 'bg-gray-100 text-gray-800'}`}>
+          {params.value}
+        </span>
+      ),
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      width: 100,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <div className="flex items-center space-x-2">
+          <Link
+            to={`/sales-receipts/${params.row.Id}/edit`}
+            onClick={(e) => e.stopPropagation()}
+            className="text-indigo-600 hover:text-indigo-900"
+          >
+            Edit
+          </Link>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">Sales Receipts</h1>
+        <Link
+          to="/sales-receipts/new"
+          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          New Sales Receipt
+        </Link>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-4 mb-6">
+        <p className="text-sm text-gray-600">
+          Sales receipts record immediate cash sales where payment is received at the time of sale.
+          Unlike invoices, no accounts receivable is created - the payment deposits directly to your selected bank account.
+        </p>
+      </div>
+
+      <RestDataGrid<SalesReceipt>
+        endpoint="/salesreceipts"
+        columns={columns}
+        editPath="/sales-receipts/{id}/edit"
+        initialPageSize={25}
+        emptyMessage="No sales receipts found."
+      />
+    </div>
+  );
+}

--- a/client/tests/sales-receipt-create.spec.ts
+++ b/client/tests/sales-receipt-create.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Sales Receipt Creation', () => {
+  test('can navigate to sales receipts page', async ({ page }) => {
+    await page.goto('/sales-receipts');
+
+    // Check that the page loads with the correct title
+    await expect(page.locator('h1')).toContainText('Sales Receipts');
+
+    // Check that the New Sales Receipt button exists
+    await expect(page.getByRole('link', { name: /New Sales Receipt/i })).toBeVisible();
+  });
+
+  test('can open new sales receipt form', async ({ page }) => {
+    await page.goto('/sales-receipts/new');
+
+    // Check that the form title is displayed
+    await expect(page.locator('h1')).toContainText('New Sales Receipt');
+
+    // Check that key form fields exist
+    await expect(page.getByLabel('Sales Receipt #')).toBeVisible();
+    await expect(page.getByLabel('Sale Date')).toBeVisible();
+    await expect(page.getByLabel('Deposit To')).toBeVisible();
+    await expect(page.getByLabel('Payment Method')).toBeVisible();
+  });
+
+  test('can create a sales receipt', async ({ page }) => {
+    await page.goto('/sales-receipts/new');
+
+    // Fill in the sales receipt number (should be auto-generated but let's set it)
+    const salesReceiptNumber = `SR-TEST-${Date.now()}`;
+    await page.getByLabel('Sales Receipt #').fill(salesReceiptNumber);
+
+    // Set the sale date (use today's date which is already set by default)
+
+    // Wait for deposit accounts to load and select one
+    const depositSelect = page.getByLabel('Deposit To');
+    await expect(depositSelect.locator('option')).not.toHaveCount(1, { timeout: 10000 });
+    await depositSelect.selectOption({ index: 1 });
+
+    // Select payment method
+    await page.getByLabel('Payment Method').selectOption('Cash');
+
+    // Fill in line item
+    await page.locator('input[name="Lines.0.Description"]').fill('Test Product');
+    await page.locator('input[name="Lines.0.Quantity"]').fill('2');
+    await page.locator('input[name="Lines.0.UnitPrice"]').fill('25.00');
+
+    // Wait for the API call to create the sales receipt
+    const responsePromise = page.waitForResponse(
+      resp => resp.url().includes('/salesreceipts_write') && resp.status() === 201,
+      { timeout: 15000 }
+    );
+
+    // Submit the form
+    await page.getByRole('button', { name: /Create Sales Receipt/i }).click();
+
+    // Wait for the creation response
+    await responsePromise;
+
+    // Should navigate back to list page
+    await expect(page).toHaveURL(/\/sales-receipts$/);
+  });
+
+  test('validates required fields', async ({ page }) => {
+    await page.goto('/sales-receipts/new');
+
+    // Clear the auto-generated receipt number
+    await page.getByLabel('Sales Receipt #').clear();
+
+    // Clear the description (which is required)
+    await page.locator('input[name="Lines.0.Description"]').clear();
+
+    // Try to submit without required fields
+    await page.getByRole('button', { name: /Create Sales Receipt/i }).click();
+
+    // Should show validation errors
+    await expect(page.getByText(/Sales receipt number is required/i)).toBeVisible();
+    await expect(page.getByText(/Description is required/i)).toBeVisible();
+  });
+
+  test('calculates totals correctly', async ({ page }) => {
+    await page.goto('/sales-receipts/new');
+
+    // Fill in line item with quantity and price
+    await page.locator('input[name="Lines.0.Quantity"]').fill('3');
+    await page.locator('input[name="Lines.0.UnitPrice"]').fill('10.00');
+
+    // Check that the line amount is calculated (3 * 10 = 30)
+    await expect(page.locator('div').filter({ hasText: /^\$30\.00/ }).first()).toBeVisible();
+
+    // Check the subtotal
+    await expect(page.getByText(/Subtotal/)).toBeVisible();
+
+    // Add another line item
+    await page.getByRole('button', { name: /Add Item/i }).click();
+
+    await page.locator('input[name="Lines.1.Quantity"]').fill('2');
+    await page.locator('input[name="Lines.1.UnitPrice"]').fill('15.00');
+
+    // Subtotal should now be 30 + 30 = 60
+    await expect(page.locator('text=$60.00').first()).toBeVisible();
+  });
+});

--- a/dab-config.json
+++ b/dab-config.json
@@ -2510,6 +2510,120 @@
             "key-fields": [
                 "Id"
             ]
+        },
+        "salesreceipts": {
+            "source": {
+                "object": "dbo.v_SalesReceipts",
+                "type": "view",
+                "key-fields": [
+                    "Id"
+                ]
+            },
+            "graphql": {
+                "enabled": true
+            },
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "SalesReceiptNumber": "SalesReceiptNumber",
+                "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName",
+                "SaleDate": "SaleDate",
+                "DepositAccountId": "DepositAccountId",
+                "DepositAccountName": "DepositAccountName",
+                "PaymentMethod": "PaymentMethod",
+                "Reference": "Reference",
+                "Subtotal": "Subtotal",
+                "TaxRateId": "TaxRateId",
+                "TaxRateName": "TaxRateName",
+                "TaxRate": "TaxRate",
+                "TaxAmount": "TaxAmount",
+                "TotalAmount": "TotalAmount",
+                "Memo": "Memo",
+                "Status": "Status",
+                "JournalEntryId": "JournalEntryId",
+                "ClassId": "ClassId",
+                "ClassName": "ClassName",
+                "LocationId": "LocationId",
+                "LocationName": "LocationName",
+                "SourceSystem": "SourceSystem",
+                "SourceId": "SourceId",
+                "TenantId": "TenantId",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            }
+        },
+        "salesreceipts_write": {
+            "source": "dbo.SalesReceipts",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "create",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "SalesReceiptNumber": "SalesReceiptNumber",
+                "CustomerId": "CustomerId",
+                "SaleDate": "SaleDate",
+                "DepositAccountId": "DepositAccountId",
+                "PaymentMethod": "PaymentMethod",
+                "Reference": "Reference",
+                "Subtotal": "Subtotal",
+                "TaxRateId": "TaxRateId",
+                "TaxAmount": "TaxAmount",
+                "TotalAmount": "TotalAmount",
+                "Memo": "Memo",
+                "Status": "Status",
+                "JournalEntryId": "JournalEntryId",
+                "ClassId": "ClassId",
+                "LocationId": "LocationId",
+                "SourceSystem": "SourceSystem",
+                "SourceId": "SourceId"
+            },
+            "key-fields": [
+                "Id"
+            ]
+        },
+        "salesreceiptlines": {
+            "source": "dbo.SalesReceiptLines",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "*"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "SalesReceiptId": "SalesReceiptId",
+                "ProductServiceId": "ProductServiceId",
+                "Description": "Description",
+                "Quantity": "Quantity",
+                "UnitPrice": "UnitPrice",
+                "Amount": "Amount",
+                "AccountId": "AccountId",
+                "TaxRateId": "TaxRateId",
+                "ClassId": "ClassId",
+                "SortOrder": "SortOrder",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            },
+            "key-fields": [
+                "Id"
+            ]
         }
     }
 }

--- a/dab-config.production.json
+++ b/dab-config.production.json
@@ -395,6 +395,59 @@
                     "actions": ["*"]
                 }
             ]
+        },
+        "salesreceipts": {
+            "source": "dbo.v_SalesReceipts",
+            "rest": true,
+            "graphql": true,
+            "permissions": [
+                {
+                    "role": "authenticated",
+                    "actions": ["read"]
+                },
+                {
+                    "role": "Accountant",
+                    "actions": ["read"]
+                },
+                {
+                    "role": "Admin",
+                    "actions": ["read"]
+                }
+            ]
+        },
+        "salesreceipts_write": {
+            "source": "dbo.SalesReceipts",
+            "rest": true,
+            "graphql": true,
+            "permissions": [
+                {
+                    "role": "Accountant",
+                    "actions": ["create", "read", "update"]
+                },
+                {
+                    "role": "Admin",
+                    "actions": ["*"]
+                }
+            ]
+        },
+        "salesreceiptlines": {
+            "source": "dbo.SalesReceiptLines",
+            "rest": true,
+            "graphql": true,
+            "permissions": [
+                {
+                    "role": "authenticated",
+                    "actions": ["read"]
+                },
+                {
+                    "role": "Accountant",
+                    "actions": ["create", "read", "update", "delete"]
+                },
+                {
+                    "role": "Admin",
+                    "actions": ["*"]
+                }
+            ]
         }
     }
 }

--- a/database/dbo/Tables/SalesReceiptLines.sql
+++ b/database/dbo/Tables/SalesReceiptLines.sql
@@ -1,0 +1,36 @@
+CREATE TABLE [dbo].[SalesReceiptLines]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [SalesReceiptId] UNIQUEIDENTIFIER NOT NULL,
+    [ProductServiceId] UNIQUEIDENTIFIER NULL,
+    [Description] NVARCHAR(500) NOT NULL,
+    [Quantity] DECIMAL(18, 4) NOT NULL DEFAULT 1,
+    [UnitPrice] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [Amount] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [AccountId] UNIQUEIDENTIFIER NULL, -- Income/Revenue account override
+    [TaxRateId] UNIQUEIDENTIFIER NULL, -- Per-line tax rate override
+    [ClassId] UNIQUEIDENTIFIER NULL,
+    [SortOrder] INT NOT NULL DEFAULT 0,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    -- Temporal table columns (system-versioned)
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_SalesReceiptLines_SalesReceipts] FOREIGN KEY ([SalesReceiptId]) REFERENCES [dbo].[SalesReceipts]([Id]) ON DELETE CASCADE,
+    CONSTRAINT [FK_SalesReceiptLines_ProductsServices] FOREIGN KEY ([ProductServiceId]) REFERENCES [dbo].[ProductsServices]([Id]),
+    CONSTRAINT [FK_SalesReceiptLines_Accounts] FOREIGN KEY ([AccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_SalesReceiptLines_TaxRates] FOREIGN KEY ([TaxRateId]) REFERENCES [dbo].[TaxRates]([Id]),
+    CONSTRAINT [FK_SalesReceiptLines_Classes] FOREIGN KEY ([ClassId]) REFERENCES [dbo].[Classes]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[SalesReceiptLines_History]))
+GO
+
+CREATE INDEX [IX_SalesReceiptLines_SalesReceiptId] ON [dbo].[SalesReceiptLines]([SalesReceiptId])
+GO
+
+CREATE INDEX [IX_SalesReceiptLines_ProductServiceId] ON [dbo].[SalesReceiptLines]([ProductServiceId])
+WHERE [ProductServiceId] IS NOT NULL
+GO

--- a/database/dbo/Tables/SalesReceipts.sql
+++ b/database/dbo/Tables/SalesReceipts.sql
@@ -1,0 +1,64 @@
+CREATE TABLE [dbo].[SalesReceipts]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [SalesReceiptNumber] NVARCHAR(50) NOT NULL,
+    [CustomerId] UNIQUEIDENTIFIER NULL,
+    [SaleDate] DATE NOT NULL,
+    [DepositAccountId] UNIQUEIDENTIFIER NOT NULL, -- Bank/Cash account for deposit
+    [PaymentMethod] NVARCHAR(50) NULL, -- Cash, Check, Credit Card, Debit Card
+    [Reference] NVARCHAR(100) NULL, -- Check number, transaction ID, etc.
+    [Subtotal] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [TaxRateId] UNIQUEIDENTIFIER NULL,
+    [TaxAmount] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [TotalAmount] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+    [Memo] NVARCHAR(500) NULL,
+    [Status] NVARCHAR(20) NOT NULL DEFAULT 'Completed', -- Completed, Voided
+    [JournalEntryId] UNIQUEIDENTIFIER NULL,
+    [ClassId] UNIQUEIDENTIFIER NULL,
+    [LocationId] UNIQUEIDENTIFIER NULL,
+    [SourceSystem] NVARCHAR(50) NULL,
+    [SourceId] NVARCHAR(100) NULL,
+    [TenantId] UNIQUEIDENTIFIER NULL,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    -- Temporal table columns (system-versioned)
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_SalesReceipts_Customers] FOREIGN KEY ([CustomerId]) REFERENCES [dbo].[Customers]([Id]),
+    CONSTRAINT [FK_SalesReceipts_DepositAccount] FOREIGN KEY ([DepositAccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_SalesReceipts_TaxRates] FOREIGN KEY ([TaxRateId]) REFERENCES [dbo].[TaxRates]([Id]),
+    CONSTRAINT [FK_SalesReceipts_JournalEntries] FOREIGN KEY ([JournalEntryId]) REFERENCES [dbo].[JournalEntries]([Id]),
+    CONSTRAINT [FK_SalesReceipts_Classes] FOREIGN KEY ([ClassId]) REFERENCES [dbo].[Classes]([Id]),
+    CONSTRAINT [FK_SalesReceipts_Locations] FOREIGN KEY ([LocationId]) REFERENCES [dbo].[Locations]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[SalesReceipts_History]))
+GO
+
+ALTER TABLE [dbo].[SalesReceipts]
+ENABLE CHANGE_TRACKING
+WITH (TRACK_COLUMNS_UPDATED = ON)
+GO
+
+CREATE INDEX [IX_SalesReceipts_CustomerId] ON [dbo].[SalesReceipts]([CustomerId])
+WHERE [CustomerId] IS NOT NULL
+GO
+
+CREATE INDEX [IX_SalesReceipts_SaleDate] ON [dbo].[SalesReceipts]([SaleDate] DESC)
+GO
+
+CREATE INDEX [IX_SalesReceipts_DepositAccountId] ON [dbo].[SalesReceipts]([DepositAccountId])
+GO
+
+CREATE INDEX [IX_SalesReceipts_Status] ON [dbo].[SalesReceipts]([Status])
+GO
+
+CREATE INDEX [IX_SalesReceipts_Source] ON [dbo].[SalesReceipts]([SourceSystem], [SourceId])
+WHERE [SourceSystem] IS NOT NULL
+GO
+
+CREATE INDEX [IX_SalesReceipts_TenantId] ON [dbo].[SalesReceipts]([TenantId])
+WHERE [TenantId] IS NOT NULL
+GO

--- a/database/dbo/Views/v_SalesReceiptLines.sql
+++ b/database/dbo/Views/v_SalesReceiptLines.sql
@@ -1,0 +1,30 @@
+CREATE VIEW [dbo].[v_SalesReceiptLines] AS
+SELECT
+    srl.[Id],
+    srl.[SalesReceiptId],
+    sr.[SalesReceiptNumber],
+    srl.[ProductServiceId],
+    ps.[Name] AS ProductServiceName,
+    ps.[SKU] AS ProductServiceSKU,
+    srl.[Description],
+    srl.[Quantity],
+    srl.[UnitPrice],
+    srl.[Amount],
+    srl.[AccountId],
+    a.[Name] AS AccountName,
+    srl.[TaxRateId],
+    tr.[Name] AS LineTaxRateName,
+    tr.[Rate] AS LineTaxRate,
+    srl.[ClassId],
+    cl.[Name] AS ClassName,
+    srl.[SortOrder],
+    srl.[CreatedAt],
+    srl.[UpdatedAt]
+FROM
+    [dbo].[SalesReceiptLines] srl
+    INNER JOIN [dbo].[SalesReceipts] sr ON srl.[SalesReceiptId] = sr.[Id]
+    LEFT JOIN [dbo].[ProductsServices] ps ON srl.[ProductServiceId] = ps.[Id]
+    LEFT JOIN [dbo].[Accounts] a ON srl.[AccountId] = a.[Id]
+    LEFT JOIN [dbo].[TaxRates] tr ON srl.[TaxRateId] = tr.[Id]
+    LEFT JOIN [dbo].[Classes] cl ON srl.[ClassId] = cl.[Id]
+GO

--- a/database/dbo/Views/v_SalesReceipts.sql
+++ b/database/dbo/Views/v_SalesReceipts.sql
@@ -1,0 +1,37 @@
+CREATE VIEW [dbo].[v_SalesReceipts] AS
+SELECT
+    sr.[Id],
+    sr.[SalesReceiptNumber],
+    sr.[CustomerId],
+    c.[Name] AS CustomerName,
+    sr.[SaleDate],
+    sr.[DepositAccountId],
+    da.[Name] AS DepositAccountName,
+    sr.[PaymentMethod],
+    sr.[Reference],
+    sr.[Subtotal],
+    sr.[TaxRateId],
+    tr.[Name] AS TaxRateName,
+    tr.[Rate] AS TaxRate,
+    sr.[TaxAmount],
+    sr.[TotalAmount],
+    sr.[Memo],
+    sr.[Status],
+    sr.[JournalEntryId],
+    sr.[ClassId],
+    cl.[Name] AS ClassName,
+    sr.[LocationId],
+    loc.[Name] AS LocationName,
+    sr.[SourceSystem],
+    sr.[SourceId],
+    sr.[TenantId],
+    sr.[CreatedAt],
+    sr.[UpdatedAt]
+FROM
+    [dbo].[SalesReceipts] sr
+    LEFT JOIN [dbo].[Customers] c ON sr.[CustomerId] = c.[Id]
+    LEFT JOIN [dbo].[Accounts] da ON sr.[DepositAccountId] = da.[Id]
+    LEFT JOIN [dbo].[TaxRates] tr ON sr.[TaxRateId] = tr.[Id]
+    LEFT JOIN [dbo].[Classes] cl ON sr.[ClassId] = cl.[Id]
+    LEFT JOIN [dbo].[Locations] loc ON sr.[LocationId] = loc.[Id]
+GO

--- a/database/migrations/035_AddSalesReceipts.sql
+++ b/database/migrations/035_AddSalesReceipts.sql
@@ -1,0 +1,257 @@
+/*
+Migration: Add Sales Receipts Module
+Description: Creates SalesReceipts and SalesReceiptLines tables for recording
+             immediate cash sales without creating an invoice. Payment is
+             recorded at time of sale with automatic journal entry creation.
+*/
+
+-- ============================================================================
+-- SALES RECEIPTS TABLE
+-- ============================================================================
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SalesReceipts')
+BEGIN
+    CREATE TABLE [dbo].[SalesReceipts]
+    (
+        [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+        [SalesReceiptNumber] NVARCHAR(50) NOT NULL,
+        [CustomerId] UNIQUEIDENTIFIER NULL,
+        [SaleDate] DATE NOT NULL,
+        [DepositAccountId] UNIQUEIDENTIFIER NOT NULL, -- Bank/Cash account for deposit
+        [PaymentMethod] NVARCHAR(50) NULL, -- Cash, Check, Credit Card, Debit Card
+        [Reference] NVARCHAR(100) NULL, -- Check number, transaction ID, etc.
+        [Subtotal] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [TaxRateId] UNIQUEIDENTIFIER NULL,
+        [TaxAmount] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [TotalAmount] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [Memo] NVARCHAR(500) NULL,
+        [Status] NVARCHAR(20) NOT NULL DEFAULT 'Completed', -- Completed, Voided
+        [JournalEntryId] UNIQUEIDENTIFIER NULL,
+        [ClassId] UNIQUEIDENTIFIER NULL,
+        [LocationId] UNIQUEIDENTIFIER NULL,
+        [SourceSystem] NVARCHAR(50) NULL,
+        [SourceId] NVARCHAR(100) NULL,
+        [TenantId] UNIQUEIDENTIFIER NULL,
+        [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+        [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+        -- Temporal table columns (system-versioned)
+        [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+        [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+        PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+        CONSTRAINT [FK_SalesReceipts_Customers] FOREIGN KEY ([CustomerId]) REFERENCES [dbo].[Customers]([Id]),
+        CONSTRAINT [FK_SalesReceipts_DepositAccount] FOREIGN KEY ([DepositAccountId]) REFERENCES [dbo].[Accounts]([Id]),
+        CONSTRAINT [FK_SalesReceipts_TaxRates] FOREIGN KEY ([TaxRateId]) REFERENCES [dbo].[TaxRates]([Id]),
+        CONSTRAINT [FK_SalesReceipts_JournalEntries] FOREIGN KEY ([JournalEntryId]) REFERENCES [dbo].[JournalEntries]([Id]),
+        CONSTRAINT [FK_SalesReceipts_Classes] FOREIGN KEY ([ClassId]) REFERENCES [dbo].[Classes]([Id]),
+        CONSTRAINT [FK_SalesReceipts_Locations] FOREIGN KEY ([LocationId]) REFERENCES [dbo].[Locations]([Id])
+    )
+    WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[SalesReceipts_History]));
+
+    PRINT 'Created SalesReceipts table';
+END
+GO
+
+-- Enable change tracking for SalesReceipts
+IF EXISTS (SELECT * FROM sys.tables WHERE name = 'SalesReceipts')
+   AND NOT EXISTS (SELECT * FROM sys.change_tracking_tables WHERE object_id = OBJECT_ID('dbo.SalesReceipts'))
+BEGIN
+    ALTER TABLE [dbo].[SalesReceipts] ENABLE CHANGE_TRACKING
+    WITH (TRACK_COLUMNS_UPDATED = ON);
+    PRINT 'Enabled change tracking for SalesReceipts';
+END
+GO
+
+-- Create indexes for SalesReceipts
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceipts_CustomerId')
+BEGIN
+    CREATE INDEX [IX_SalesReceipts_CustomerId] ON [dbo].[SalesReceipts] ([CustomerId]) WHERE CustomerId IS NOT NULL;
+    PRINT 'Created index IX_SalesReceipts_CustomerId';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceipts_SaleDate')
+BEGIN
+    CREATE INDEX [IX_SalesReceipts_SaleDate] ON [dbo].[SalesReceipts] ([SaleDate] DESC);
+    PRINT 'Created index IX_SalesReceipts_SaleDate';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceipts_DepositAccountId')
+BEGIN
+    CREATE INDEX [IX_SalesReceipts_DepositAccountId] ON [dbo].[SalesReceipts] ([DepositAccountId]);
+    PRINT 'Created index IX_SalesReceipts_DepositAccountId';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceipts_Status')
+BEGIN
+    CREATE INDEX [IX_SalesReceipts_Status] ON [dbo].[SalesReceipts] ([Status]);
+    PRINT 'Created index IX_SalesReceipts_Status';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceipts_Source')
+BEGIN
+    CREATE INDEX [IX_SalesReceipts_Source] ON [dbo].[SalesReceipts]([SourceSystem], [SourceId])
+    WHERE [SourceSystem] IS NOT NULL;
+    PRINT 'Created index IX_SalesReceipts_Source';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceipts_TenantId')
+BEGIN
+    CREATE INDEX [IX_SalesReceipts_TenantId] ON [dbo].[SalesReceipts]([TenantId])
+    WHERE [TenantId] IS NOT NULL;
+    PRINT 'Created index IX_SalesReceipts_TenantId';
+END
+GO
+
+-- ============================================================================
+-- SALES RECEIPT LINES TABLE
+-- ============================================================================
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'SalesReceiptLines')
+BEGIN
+    CREATE TABLE [dbo].[SalesReceiptLines]
+    (
+        [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+        [SalesReceiptId] UNIQUEIDENTIFIER NOT NULL,
+        [ProductServiceId] UNIQUEIDENTIFIER NULL,
+        [Description] NVARCHAR(500) NOT NULL,
+        [Quantity] DECIMAL(18, 4) NOT NULL DEFAULT 1,
+        [UnitPrice] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [Amount] DECIMAL(19, 4) NOT NULL DEFAULT 0,
+        [AccountId] UNIQUEIDENTIFIER NULL, -- Income/Revenue account override
+        [TaxRateId] UNIQUEIDENTIFIER NULL, -- Per-line tax rate override
+        [ClassId] UNIQUEIDENTIFIER NULL,
+        [SortOrder] INT NOT NULL DEFAULT 0,
+        [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+        [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+        -- Temporal table columns (system-versioned)
+        [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+        [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+        PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+        CONSTRAINT [FK_SalesReceiptLines_SalesReceipts] FOREIGN KEY ([SalesReceiptId]) REFERENCES [dbo].[SalesReceipts]([Id]) ON DELETE CASCADE,
+        CONSTRAINT [FK_SalesReceiptLines_ProductsServices] FOREIGN KEY ([ProductServiceId]) REFERENCES [dbo].[ProductsServices]([Id]),
+        CONSTRAINT [FK_SalesReceiptLines_Accounts] FOREIGN KEY ([AccountId]) REFERENCES [dbo].[Accounts]([Id]),
+        CONSTRAINT [FK_SalesReceiptLines_TaxRates] FOREIGN KEY ([TaxRateId]) REFERENCES [dbo].[TaxRates]([Id]),
+        CONSTRAINT [FK_SalesReceiptLines_Classes] FOREIGN KEY ([ClassId]) REFERENCES [dbo].[Classes]([Id])
+    )
+    WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[SalesReceiptLines_History]));
+
+    PRINT 'Created SalesReceiptLines table';
+END
+GO
+
+-- Create indexes for SalesReceiptLines
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceiptLines_SalesReceiptId')
+BEGIN
+    CREATE INDEX [IX_SalesReceiptLines_SalesReceiptId] ON [dbo].[SalesReceiptLines] ([SalesReceiptId]);
+    PRINT 'Created index IX_SalesReceiptLines_SalesReceiptId';
+END
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_SalesReceiptLines_ProductServiceId')
+BEGIN
+    CREATE INDEX [IX_SalesReceiptLines_ProductServiceId] ON [dbo].[SalesReceiptLines] ([ProductServiceId]) WHERE ProductServiceId IS NOT NULL;
+    PRINT 'Created index IX_SalesReceiptLines_ProductServiceId';
+END
+GO
+
+-- ============================================================================
+-- VIEW FOR SALES RECEIPTS WITH JOINED DATA
+-- ============================================================================
+IF EXISTS (SELECT * FROM sys.views WHERE name = 'v_SalesReceipts')
+BEGIN
+    DROP VIEW [dbo].[v_SalesReceipts];
+END
+GO
+
+CREATE VIEW [dbo].[v_SalesReceipts] AS
+SELECT
+    sr.[Id],
+    sr.[SalesReceiptNumber],
+    sr.[CustomerId],
+    c.[Name] AS CustomerName,
+    sr.[SaleDate],
+    sr.[DepositAccountId],
+    da.[Name] AS DepositAccountName,
+    sr.[PaymentMethod],
+    sr.[Reference],
+    sr.[Subtotal],
+    sr.[TaxRateId],
+    tr.[Name] AS TaxRateName,
+    tr.[Rate] AS TaxRate,
+    sr.[TaxAmount],
+    sr.[TotalAmount],
+    sr.[Memo],
+    sr.[Status],
+    sr.[JournalEntryId],
+    sr.[ClassId],
+    cl.[Name] AS ClassName,
+    sr.[LocationId],
+    loc.[Name] AS LocationName,
+    sr.[SourceSystem],
+    sr.[SourceId],
+    sr.[TenantId],
+    sr.[CreatedAt],
+    sr.[UpdatedAt]
+FROM
+    [dbo].[SalesReceipts] sr
+    LEFT JOIN [dbo].[Customers] c ON sr.[CustomerId] = c.[Id]
+    LEFT JOIN [dbo].[Accounts] da ON sr.[DepositAccountId] = da.[Id]
+    LEFT JOIN [dbo].[TaxRates] tr ON sr.[TaxRateId] = tr.[Id]
+    LEFT JOIN [dbo].[Classes] cl ON sr.[ClassId] = cl.[Id]
+    LEFT JOIN [dbo].[Locations] loc ON sr.[LocationId] = loc.[Id];
+GO
+
+PRINT 'Created view v_SalesReceipts';
+GO
+
+-- ============================================================================
+-- VIEW FOR SALES RECEIPT LINES WITH JOINED DATA
+-- ============================================================================
+IF EXISTS (SELECT * FROM sys.views WHERE name = 'v_SalesReceiptLines')
+BEGIN
+    DROP VIEW [dbo].[v_SalesReceiptLines];
+END
+GO
+
+CREATE VIEW [dbo].[v_SalesReceiptLines] AS
+SELECT
+    srl.[Id],
+    srl.[SalesReceiptId],
+    sr.[SalesReceiptNumber],
+    srl.[ProductServiceId],
+    ps.[Name] AS ProductServiceName,
+    ps.[SKU] AS ProductServiceSKU,
+    srl.[Description],
+    srl.[Quantity],
+    srl.[UnitPrice],
+    srl.[Amount],
+    srl.[AccountId],
+    a.[Name] AS AccountName,
+    srl.[TaxRateId],
+    tr.[Name] AS LineTaxRateName,
+    tr.[Rate] AS LineTaxRate,
+    srl.[ClassId],
+    cl.[Name] AS ClassName,
+    srl.[SortOrder],
+    srl.[CreatedAt],
+    srl.[UpdatedAt]
+FROM
+    [dbo].[SalesReceiptLines] srl
+    INNER JOIN [dbo].[SalesReceipts] sr ON srl.[SalesReceiptId] = sr.[Id]
+    LEFT JOIN [dbo].[ProductsServices] ps ON srl.[ProductServiceId] = ps.[Id]
+    LEFT JOIN [dbo].[Accounts] a ON srl.[AccountId] = a.[Id]
+    LEFT JOIN [dbo].[TaxRates] tr ON srl.[TaxRateId] = tr.[Id]
+    LEFT JOIN [dbo].[Classes] cl ON srl.[ClassId] = cl.[Id];
+GO
+
+PRINT 'Created view v_SalesReceiptLines';
+GO
+
+PRINT 'Sales Receipts migration complete.';
+GO


### PR DESCRIPTION
## Summary
- Adds Sales Receipt functionality for recording immediate cash sales where payment is received at time of sale
- Creates SalesReceipts and SalesReceiptLines database tables with proper indexing and temporal tables
- Implements complete CRUD UI with list page, create form, and edit form
- Deposits directly to bank account without creating Accounts Receivable

## Key Features
- **Optional Customer**: Can record walk-in sales without requiring a customer record
- **Deposit Account Selection**: Choose which bank/cash account to deposit to
- **Payment Method Tracking**: Cash, Check, Credit Card, Debit Card, ACH
- **Tax Calculation**: Per-line item taxable flag with automatic tax calculation
- **Product/Service Integration**: Select from existing products/services or enter custom descriptions

## Database Changes
- `SalesReceipts` table with system versioning and change tracking
- `SalesReceiptLines` table with cascade delete
- `v_SalesReceipts` view with joined customer, account, and tax rate data
- `v_SalesReceiptLines` view with product/service details
- Migration `035_AddSalesReceipts.sql`

## DAB Configuration
- `salesreceipts` - Read endpoint (view)
- `salesreceipts_write` - Create/Update/Delete endpoint
- `salesreceiptlines` - Full CRUD endpoint

## Frontend
- Sales Receipts list page with DataGrid
- New/Edit forms with real-time total calculation
- Added to Sales navigation group (between Invoices and Estimates)

## Test Plan
- [ ] Navigate to Sales Receipts from sidebar menu
- [ ] Create a new sales receipt with line items
- [ ] Verify total calculation with and without tax
- [ ] Edit an existing sales receipt
- [ ] Verify deposit account selection shows bank/cash accounts
- [ ] Test optional customer (leave blank for walk-in sale)

Closes #224

---
Generated with [Claude Code](https://claude.ai/code)