### PR TITLE
feat(reports): Add Statement of Cash Flows report

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,6 +45,7 @@ import EditAccount from './pages/EditAccount';
 import Reports from './pages/Reports';
 import ProfitAndLoss from './pages/reports/ProfitAndLoss';
 import BalanceSheet from './pages/reports/BalanceSheet';
+import CashFlowStatement from './pages/reports/CashFlowStatement';
 import TrialBalance from './pages/reports/TrialBalance';
 import ARAgingSummary from './pages/reports/ARAgingSummary';
 import APAgingSummary from './pages/reports/APAgingSummary';
@@ -209,6 +210,7 @@ function AppContent() {
             <Route path="reports" element={<Reports />} />
             <Route path="reports/profit-loss" element={<ProfitAndLoss />} />
             <Route path="reports/balance-sheet" element={<BalanceSheet />} />
+            <Route path="reports/cash-flow" element={<CashFlowStatement />} />
             <Route path="reports/trial-balance" element={<TrialBalance />} />
             <Route path="reports/ar-aging" element={<ARAgingSummary />} />
             <Route path="reports/ap-aging" element={<APAgingSummary />} />

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { TrendingUp, Scale, List, Clock, ClipboardList, DollarSign, Receipt, CreditCard, FileText, Users, FileSearch, Car, BookOpen, Package, AlertTriangle, Clipboard, ShoppingCart } from 'lucide-react';
+import { TrendingUp, Scale, List, Clock, ClipboardList, DollarSign, Receipt, CreditCard, FileText, Users, FileSearch, Car, BookOpen, Package, AlertTriangle, Clipboard, ShoppingCart, ArrowRightLeft } from 'lucide-react';
 
 const reports = [
   {
@@ -15,6 +15,13 @@ const reports = [
     href: '/reports/balance-sheet',
     icon: Scale,
     color: 'bg-blue-100 text-blue-600',
+  },
+  {
+    name: 'Statement of Cash Flows',
+    description: 'Cash inflows and outflows from operating, investing, and financing activities',
+    href: '/reports/cash-flow',
+    icon: ArrowRightLeft,
+    color: 'bg-emerald-100 text-emerald-600',
   },
   {
     name: 'Trial Balance',

--- a/client/src/pages/reports/CashFlowStatement.tsx
+++ b/client/src/pages/reports/CashFlowStatement.tsx
@@ -1,0 +1,553 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { DateRangePicker, ReportHeader, ReportTable, formatCurrency, exportToCSV } from '../../components/reports';
+import type { ReportColumn, ReportRow } from '../../components/reports';
+
+interface Account {
+  Id: string;
+  Name: string;
+  Type: string;
+  Subtype: string | null;
+  CashFlowCategory: string | null;
+}
+
+interface JournalEntry {
+  Id: string;
+  TransactionDate: string;
+}
+
+interface JournalEntryLine {
+  Id: string;
+  JournalEntryId: string;
+  AccountId: string;
+  Debit: number;
+  Credit: number;
+}
+
+/**
+ * Statement of Cash Flows Report
+ *
+ * Uses the indirect method:
+ * 1. Start with Net Income
+ * 2. Add back non-cash expenses (depreciation)
+ * 3. Adjust for changes in operating assets/liabilities
+ * 4. Show investing activities (fixed asset changes)
+ * 5. Show financing activities (equity, loans)
+ * 6. Reconcile to change in cash
+ */
+export default function CashFlowStatement() {
+  const today = new Date();
+  const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const [startDate, setStartDate] = useState(firstDayOfMonth.toISOString().split('T')[0]);
+  const [endDate, setEndDate] = useState(today.toISOString().split('T')[0]);
+
+  const {
+    data: accounts,
+    isLoading: accountsLoading,
+    error: accountsError,
+  } = useQuery({
+    queryKey: ['accounts'],
+    queryFn: async () => {
+      const r = await fetch('/api/accounts');
+      if (!r.ok) {
+        throw new Error('Failed to load accounts');
+      }
+      const d = await r.json();
+      return d.value as Account[];
+    },
+  });
+
+  const {
+    data: journalEntries,
+    isLoading: journalEntriesLoading,
+    error: journalEntriesError,
+  } = useQuery({
+    queryKey: ['journal-entries'],
+    queryFn: async () => {
+      const r = await fetch('/api/journalentries');
+      if (!r.ok) {
+        throw new Error('Failed to load journal entries');
+      }
+      const d = await r.json();
+      return d.value as JournalEntry[];
+    },
+  });
+
+  const {
+    data: lines,
+    isLoading: linesLoading,
+    error: linesError,
+  } = useQuery({
+    queryKey: ['journal-entry-lines'],
+    queryFn: async () => {
+      const r = await fetch('/api/journalentrylines');
+      if (!r.ok) {
+        throw new Error('Failed to load journal entry lines');
+      }
+      const d = await r.json();
+      return d.value as JournalEntryLine[];
+    },
+  });
+
+  const isLoading = accountsLoading || journalEntriesLoading || linesLoading;
+  const error = accountsError || journalEntriesError || linesError;
+
+  const reportData = useMemo(() => {
+    if (!accounts || !journalEntries || !lines) {
+      return {
+        netIncome: 0,
+        depreciationAdjustment: 0,
+        operatingItems: [] as { name: string; amount: number }[],
+        netOperatingCashFlow: 0,
+        investingItems: [] as { name: string; amount: number }[],
+        netInvestingCashFlow: 0,
+        financingItems: [] as { name: string; amount: number }[],
+        netFinancingCashFlow: 0,
+        netCashChange: 0,
+        beginningCash: 0,
+        endingCash: 0,
+        actualCashChange: 0,
+      };
+    }
+
+    const accountMap = new Map(accounts.map((a) => [a.Id, a]));
+    const entryDateMap = new Map(
+      journalEntries.map((e) => [e.Id, new Date(e.TransactionDate)])
+    );
+
+    // Parse dates explicitly to avoid timezone issues
+    const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
+    const start = new Date(startYear, startMonth - 1, startDay, 0, 0, 0, 0);
+
+    const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
+    const end = new Date(endYear, endMonth - 1, endDay, 23, 59, 59, 999);
+
+    // Get period start for beginning balance calculation
+    const periodStart = new Date(start);
+    periodStart.setMilliseconds(periodStart.getMilliseconds() - 1);
+
+    // Filter lines for the period
+    const periodLines = lines.filter((line) => {
+      const date = entryDateMap.get(line.JournalEntryId);
+      return date && date >= start && date <= end;
+    });
+
+    // Filter lines for before period (for beginning balances)
+    const beforePeriodLines = lines.filter((line) => {
+      const date = entryDateMap.get(line.JournalEntryId);
+      return date && date < start;
+    });
+
+    // Calculate Net Income for the period
+    let netIncome = 0;
+    periodLines.forEach((line) => {
+      const account = accountMap.get(line.AccountId);
+      if (!account) return;
+
+      if (account.Type === 'Revenue') {
+        netIncome += line.Credit - line.Debit;
+      } else if (account.Type === 'Expense') {
+        netIncome -= line.Debit - line.Credit;
+      }
+    });
+
+    // Calculate depreciation adjustment (non-cash expense added back)
+    let depreciationAdjustment = 0;
+    periodLines.forEach((line) => {
+      const account = accountMap.get(line.AccountId);
+      if (!account) return;
+
+      if (account.Type === 'Expense' &&
+          (account.Name.toLowerCase().includes('depreciation') ||
+           account.Name.toLowerCase().includes('amortization'))) {
+        depreciationAdjustment += line.Debit - line.Credit;
+      }
+    });
+
+    // Helper to calculate account balance change
+    const calculateBalanceChange = (accountId: string): number => {
+      const account = accountMap.get(accountId);
+      if (!account) return 0;
+
+      let beginningBalance = 0;
+      let endingBalance = 0;
+
+      // Calculate beginning balance
+      beforePeriodLines.forEach((line) => {
+        if (line.AccountId !== accountId) return;
+        if (account.Type === 'Asset') {
+          beginningBalance += line.Debit - line.Credit;
+        } else {
+          beginningBalance += line.Credit - line.Debit;
+        }
+      });
+
+      // Calculate ending balance
+      endingBalance = beginningBalance;
+      periodLines.forEach((line) => {
+        if (line.AccountId !== accountId) return;
+        if (account.Type === 'Asset') {
+          endingBalance += line.Debit - line.Credit;
+        } else {
+          endingBalance += line.Credit - line.Debit;
+        }
+      });
+
+      return endingBalance - beginningBalance;
+    };
+
+    // Identify cash accounts
+    const cashAccounts = accounts.filter((a) =>
+      a.Subtype === 'Bank' ||
+      a.Subtype === 'Cash' ||
+      a.Name.toLowerCase().includes('cash') ||
+      a.Name.toLowerCase().includes('checking') ||
+      a.Name.toLowerCase().includes('savings')
+    );
+
+    const cashAccountIds = new Set(cashAccounts.map((a) => a.Id));
+
+    // Calculate beginning and ending cash
+    let beginningCash = 0;
+    let endingCash = 0;
+
+    cashAccounts.forEach((account) => {
+      let balance = 0;
+      beforePeriodLines.forEach((line) => {
+        if (line.AccountId !== account.Id) return;
+        balance += line.Debit - line.Credit; // Assets increase with debit
+      });
+      beginningCash += balance;
+
+      periodLines.forEach((line) => {
+        if (line.AccountId !== account.Id) return;
+        balance += line.Debit - line.Credit;
+      });
+      endingCash += balance;
+    });
+
+    const actualCashChange = endingCash - beginningCash;
+
+    // Operating Activities - Changes in current assets and liabilities
+    const operatingItems: { name: string; amount: number }[] = [];
+
+    accounts.forEach((account) => {
+      // Skip cash accounts, revenue, expense, and accounts with no operating activity
+      if (cashAccountIds.has(account.Id)) return;
+      if (account.Type === 'Revenue' || account.Type === 'Expense') return;
+
+      // Operating accounts: current assets (except cash) and current liabilities
+      const isOperating =
+        account.CashFlowCategory === 'Operating' ||
+        (account.Type === 'Asset' && ['Receivable', 'Inventory', 'OtherCurrentAsset', 'PrepaidExpense'].includes(account.Subtype || '')) ||
+        (account.Type === 'Liability' && ['Payable', 'CreditCard', 'OtherCurrentLiability', 'AccruedLiability'].includes(account.Subtype || ''));
+
+      if (!isOperating) return;
+
+      // Skip depreciation contra accounts (already handled)
+      if (account.Name.toLowerCase().includes('accumulated depreciation')) return;
+
+      const change = calculateBalanceChange(account.Id);
+      if (Math.abs(change) < 0.01) return;
+
+      // For assets: increase = cash used (negative), decrease = cash provided (positive)
+      // For liabilities: increase = cash provided (positive), decrease = cash used (negative)
+      let cashImpact: number;
+      if (account.Type === 'Asset') {
+        cashImpact = -change; // Asset increase uses cash
+      } else {
+        cashImpact = change; // Liability increase provides cash
+      }
+
+      operatingItems.push({
+        name: `Change in ${account.Name}`,
+        amount: cashImpact,
+      });
+    });
+
+    // Sort operating items by absolute value
+    operatingItems.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+    const netOperatingCashFlow = netIncome + depreciationAdjustment +
+      operatingItems.reduce((sum, item) => sum + item.amount, 0);
+
+    // Investing Activities - Fixed assets and investments
+    const investingItems: { name: string; amount: number }[] = [];
+
+    accounts.forEach((account) => {
+      if (cashAccountIds.has(account.Id)) return;
+
+      const isInvesting =
+        account.CashFlowCategory === 'Investing' ||
+        (account.Type === 'Asset' && ['FixedAsset', 'Investment', 'OtherAsset'].includes(account.Subtype || '')) ||
+        account.Name.toLowerCase().includes('equipment') ||
+        account.Name.toLowerCase().includes('vehicle') ||
+        account.Name.toLowerCase().includes('building') ||
+        account.Name.toLowerCase().includes('property') ||
+        account.Name.toLowerCase().includes('investment');
+
+      if (!isInvesting) return;
+
+      // Skip accumulated depreciation (it's a contra-asset, handled in operating)
+      if (account.Name.toLowerCase().includes('accumulated')) return;
+
+      const change = calculateBalanceChange(account.Id);
+      if (Math.abs(change) < 0.01) return;
+
+      // Asset increase = purchase (negative cash flow)
+      // Asset decrease = sale (positive cash flow)
+      const cashImpact = -change;
+
+      const label = change > 0
+        ? `Purchase of ${account.Name}`
+        : `Sale of ${account.Name}`;
+
+      investingItems.push({
+        name: label,
+        amount: cashImpact,
+      });
+    });
+
+    investingItems.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+    const netInvestingCashFlow = investingItems.reduce((sum, item) => sum + item.amount, 0);
+
+    // Financing Activities - Equity and long-term liabilities
+    const financingItems: { name: string; amount: number }[] = [];
+
+    accounts.forEach((account) => {
+      if (cashAccountIds.has(account.Id)) return;
+
+      const isFinancing =
+        account.CashFlowCategory === 'Financing' ||
+        account.Type === 'Equity' ||
+        (account.Type === 'Liability' && ['LongTermLiability', 'NotesPayable', 'Loan'].includes(account.Subtype || '')) ||
+        account.Name.toLowerCase().includes('loan') ||
+        account.Name.toLowerCase().includes('note') ||
+        account.Name.toLowerCase().includes('mortgage');
+
+      if (!isFinancing) return;
+
+      const change = calculateBalanceChange(account.Id);
+      if (Math.abs(change) < 0.01) return;
+
+      let cashImpact: number;
+      let label: string;
+
+      if (account.Type === 'Equity') {
+        // Owner's equity/investment increase = cash in (positive)
+        // Owner's draw increase = cash out (but draw is usually recorded as decrease in equity)
+        if (account.Name.toLowerCase().includes('draw') ||
+            account.Name.toLowerCase().includes('distribution')) {
+          // Draws: increase in draw account (which is usually contra-equity) = cash out
+          cashImpact = -Math.abs(change);
+          label = `Owner Withdrawals/Distributions`;
+        } else if (account.Name.toLowerCase().includes('retained')) {
+          // Skip retained earnings - already reflected in net income
+          return;
+        } else {
+          // Capital contributions
+          cashImpact = change;
+          label = change > 0 ? `Capital Contribution` : `Capital Distribution`;
+        }
+      } else {
+        // Liabilities: increase = borrowing (positive), decrease = repayment (negative)
+        cashImpact = change;
+        label = change > 0
+          ? `Proceeds from ${account.Name}`
+          : `Repayment of ${account.Name}`;
+      }
+
+      financingItems.push({
+        name: label,
+        amount: cashImpact,
+      });
+    });
+
+    financingItems.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+    const netFinancingCashFlow = financingItems.reduce((sum, item) => sum + item.amount, 0);
+
+    const netCashChange = netOperatingCashFlow + netInvestingCashFlow + netFinancingCashFlow;
+
+    return {
+      netIncome,
+      depreciationAdjustment,
+      operatingItems,
+      netOperatingCashFlow,
+      investingItems,
+      netInvestingCashFlow,
+      financingItems,
+      netFinancingCashFlow,
+      netCashChange,
+      beginningCash,
+      endingCash,
+      actualCashChange,
+    };
+  }, [accounts, journalEntries, lines, startDate, endDate]);
+
+  const columns: ReportColumn[] = [
+    { key: 'name', header: 'Description', align: 'left' },
+    {
+      key: 'amount',
+      header: 'Amount',
+      align: 'right',
+      format: (value) => (value !== undefined ? formatCurrency(value) : ''),
+    },
+  ];
+
+  const tableData: ReportRow[] = useMemo(() => {
+    const rows: ReportRow[] = [
+      { name: 'CASH FLOWS FROM OPERATING ACTIVITIES', amount: undefined, isHeader: true },
+      { name: 'Net Income', amount: reportData.netIncome, indent: 1 },
+      { name: 'Adjustments to reconcile net income to net cash:', amount: undefined, indent: 1 },
+    ];
+
+    // Add depreciation if any
+    if (Math.abs(reportData.depreciationAdjustment) >= 0.01) {
+      rows.push({
+        name: 'Depreciation & Amortization',
+        amount: reportData.depreciationAdjustment,
+        indent: 2,
+      });
+    }
+
+    // Add changes in operating assets/liabilities
+    if (reportData.operatingItems.length > 0) {
+      rows.push({ name: 'Changes in operating assets and liabilities:', amount: undefined, indent: 1 });
+      reportData.operatingItems.forEach((item) => {
+        rows.push({ name: item.name, amount: item.amount, indent: 2 });
+      });
+    }
+
+    rows.push(
+      { name: 'Net cash provided by operating activities', amount: reportData.netOperatingCashFlow, isSubtotal: true },
+      { name: '', amount: undefined },
+      { name: 'CASH FLOWS FROM INVESTING ACTIVITIES', amount: undefined, isHeader: true }
+    );
+
+    if (reportData.investingItems.length > 0) {
+      reportData.investingItems.forEach((item) => {
+        rows.push({ name: item.name, amount: item.amount, indent: 1 });
+      });
+    } else {
+      rows.push({ name: 'No investing activities', amount: undefined, indent: 1 });
+    }
+
+    rows.push(
+      { name: 'Net cash used in investing activities', amount: reportData.netInvestingCashFlow, isSubtotal: true },
+      { name: '', amount: undefined },
+      { name: 'CASH FLOWS FROM FINANCING ACTIVITIES', amount: undefined, isHeader: true }
+    );
+
+    if (reportData.financingItems.length > 0) {
+      reportData.financingItems.forEach((item) => {
+        rows.push({ name: item.name, amount: item.amount, indent: 1 });
+      });
+    } else {
+      rows.push({ name: 'No financing activities', amount: undefined, indent: 1 });
+    }
+
+    rows.push(
+      { name: 'Net cash provided by financing activities', amount: reportData.netFinancingCashFlow, isSubtotal: true },
+      { name: '', amount: undefined },
+      { name: 'NET INCREASE (DECREASE) IN CASH', amount: reportData.netCashChange, isTotal: true },
+      { name: '', amount: undefined },
+      { name: 'Cash at beginning of period', amount: reportData.beginningCash, indent: 1 },
+      { name: 'CASH AT END OF PERIOD', amount: reportData.endingCash, isTotal: true }
+    );
+
+    return rows;
+  }, [reportData]);
+
+  const handleExportCSV = () =>
+    exportToCSV(`cash-flow-statement-${startDate}-to-${endDate}`, columns, tableData);
+
+  const formatDateRange = () =>
+    `For the period ${new Date(startDate).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })} through ${new Date(endDate).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+
+  // Check if the calculated cash change matches actual cash change
+  const isReconciled =
+    Math.abs(reportData.netCashChange - reportData.actualCashChange) < 0.01;
+
+  if (isLoading) {
+    return <div className="max-w-4xl mx-auto p-4">Loading statement of cash flows...</div>;
+  }
+
+  if (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'An unexpected error occurred while loading the report.';
+    return (
+      <div className="max-w-4xl mx-auto p-4">
+        <p className="text-red-600 font-medium">Unable to load cash flow statement data.</p>
+        <p className="text-gray-600 mt-2">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-4 print:hidden">
+        <Link
+          to="/reports"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" />
+          Back to Reports
+        </Link>
+      </div>
+      <ReportHeader
+        title="Statement of Cash Flows"
+        subtitle="Indirect Method"
+        dateRange={formatDateRange()}
+        onExportCSV={handleExportCSV}
+      />
+      <div className="mb-6">
+        <DateRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          onStartDateChange={setStartDate}
+          onEndDateChange={setEndDate}
+        />
+      </div>
+      <div className="bg-white shadow rounded-lg overflow-hidden">
+        <ReportTable columns={columns} data={tableData} />
+      </div>
+      {!isReconciled && (
+        <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
+          <p className="text-sm text-yellow-800">
+            <strong>Warning:</strong> The calculated net change in cash (
+            {formatCurrency(reportData.netCashChange)}) does not match the actual change in
+            cash accounts ({formatCurrency(reportData.actualCashChange)}). This may indicate
+            transactions that need to be categorized or accounts that need CashFlowCategory
+            assignment.
+          </p>
+        </div>
+      )}
+      <div className="mt-6 text-center text-sm text-gray-500 print:mt-4 print:text-xs">
+        <p>
+          Generated on{' '}
+          {new Date().toLocaleDateString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/reports/index.ts
+++ b/client/src/pages/reports/index.ts
@@ -1,5 +1,6 @@
 export { default as ProfitAndLoss } from './ProfitAndLoss';
 export { default as BalanceSheet } from './BalanceSheet';
+export { default as CashFlowStatement } from './CashFlowStatement';
 export { default as TrialBalance } from './TrialBalance';
 export { default as ARAgingSummary } from './ARAgingSummary';
 export { default as APAgingSummary } from './APAgingSummary';

--- a/client/tests/cash-flow-statement.spec.ts
+++ b/client/tests/cash-flow-statement.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Statement of Cash Flows Report', () => {
+  test('can navigate to cash flow statement from reports', async ({ page }) => {
+    await page.goto('/reports');
+
+    // Verify reports page loaded
+    await expect(page.getByRole('heading', { name: 'Financial Reports' })).toBeVisible();
+
+    // Click on Statement of Cash Flows report
+    await page.getByRole('link', { name: /Statement of Cash Flows/i }).click();
+
+    // Verify navigation
+    await expect(page).toHaveURL(/.*\/reports\/cash-flow/);
+
+    // Verify page elements
+    await expect(page.getByText('Back to Reports')).toBeVisible();
+  });
+
+  test('shows report header and sections', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Verify page title
+    await expect(page.getByRole('heading', { name: 'Statement of Cash Flows' })).toBeVisible();
+    await expect(page.getByText('Indirect Method')).toBeVisible();
+
+    // Verify the three main sections are present
+    await expect(page.getByText('CASH FLOWS FROM OPERATING ACTIVITIES')).toBeVisible();
+    await expect(page.getByText('CASH FLOWS FROM INVESTING ACTIVITIES')).toBeVisible();
+    await expect(page.getByText('CASH FLOWS FROM FINANCING ACTIVITIES')).toBeVisible();
+  });
+
+  test('shows net income and reconciliation items', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Wait for data to load
+    await expect(page.getByText('CASH FLOWS FROM OPERATING ACTIVITIES')).toBeVisible({ timeout: 10000 });
+
+    // Verify key line items for indirect method
+    await expect(page.getByText('Net Income')).toBeVisible();
+    await expect(page.getByText('Net cash provided by operating activities')).toBeVisible();
+  });
+
+  test('shows cash position summary', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Wait for data to load
+    await expect(page.getByText('CASH FLOWS FROM OPERATING ACTIVITIES')).toBeVisible({ timeout: 10000 });
+
+    // Verify cash position section
+    await expect(page.getByText('NET INCREASE (DECREASE) IN CASH')).toBeVisible();
+    await expect(page.getByText('Cash at beginning of period')).toBeVisible();
+    await expect(page.getByText('CASH AT END OF PERIOD')).toBeVisible();
+  });
+
+  test('has date range picker', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Look for the date range picker button
+    const dateRangeButton = page.locator('button:has(svg.lucide-calendar)');
+    await expect(dateRangeButton).toBeVisible();
+
+    // Click to open dropdown
+    await dateRangeButton.click();
+
+    // Verify preset options appear
+    await expect(page.getByText('This Month')).toBeVisible();
+    await expect(page.getByText('Last Month')).toBeVisible();
+    await expect(page.getByText('This Quarter')).toBeVisible();
+    await expect(page.getByText('Last Quarter')).toBeVisible();
+    await expect(page.getByText('This Year')).toBeVisible();
+    await expect(page.getByText('Custom Range')).toBeVisible();
+  });
+
+  test('has print and export buttons', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Verify Print button
+    const printButton = page.getByRole('button', { name: /Print/i });
+    await expect(printButton).toBeVisible();
+    await expect(printButton).toBeEnabled();
+
+    // Verify Export CSV button
+    const exportButton = page.getByRole('button', { name: /Export CSV/i });
+    await expect(exportButton).toBeVisible();
+    await expect(exportButton).toBeEnabled();
+  });
+
+  test('shows table headers', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Wait for data to load
+    await expect(page.getByText('CASH FLOWS FROM OPERATING ACTIVITIES')).toBeVisible({ timeout: 10000 });
+
+    // Verify table headers
+    await expect(page.getByRole('columnheader', { name: 'Description' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Amount' })).toBeVisible();
+  });
+
+  test('date range affects report period display', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Wait for initial load
+    await expect(page.getByText('CASH FLOWS FROM OPERATING ACTIVITIES')).toBeVisible({ timeout: 10000 });
+
+    // Open date range picker
+    const dateRangeButton = page.locator('button:has(svg.lucide-calendar)');
+    await dateRangeButton.click();
+
+    // Select "This Year"
+    await page.getByText('This Year').click();
+
+    // Verify the date range is reflected in the header
+    const currentYear = new Date().getFullYear();
+    await expect(page.getByText(new RegExp(`January.*${currentYear}`))).toBeVisible();
+    await expect(page.getByText(new RegExp(`December.*${currentYear}`))).toBeVisible();
+  });
+
+  test('shows generated timestamp', async ({ page }) => {
+    await page.goto('/reports/cash-flow');
+
+    // Wait for data to load
+    await expect(page.getByText('CASH FLOWS FROM OPERATING ACTIVITIES')).toBeVisible({ timeout: 10000 });
+
+    // Verify generated timestamp appears
+    await expect(page.getByText(/Generated on/)).toBeVisible();
+  });
+});

--- a/database/dbo/Tables/Accounts.sql
+++ b/database/dbo/Tables/Accounts.sql
@@ -5,6 +5,7 @@ CREATE TABLE [dbo].[Accounts]
     [Name] NVARCHAR(200) NOT NULL,
     [Type] NVARCHAR(50) NOT NULL, -- Asset, Liability, Equity, Revenue, Expense
     [Subtype] NVARCHAR(50) NULL,
+    [CashFlowCategory] NVARCHAR(50) NULL, -- Operating, Investing, Financing, or NULL for cash accounts
     [AccountNumber] NVARCHAR(50) NULL,
     [Description] NVARCHAR(MAX) NULL,
     [IsActive] BIT NOT NULL DEFAULT 1,

--- a/database/migrations/037_SeedCashFlowCategories.sql
+++ b/database/migrations/037_SeedCashFlowCategories.sql
@@ -1,0 +1,91 @@
+/*
+Migration: 037_SeedCashFlowCategories.sql
+Purpose: Seed CashFlowCategory values for existing accounts based on their Type and Subtype.
+
+Cash Flow Categories:
+- Operating: Day-to-day business activities (AR, AP, Inventory, most expenses/revenue)
+- Investing: Long-term asset purchases/sales (Fixed Assets, Investments)
+- Financing: Capital structure changes (Loans, Equity, Owner's Draw)
+- NULL: Cash accounts themselves (not adjustments, they ARE the cash)
+
+According to the indirect method, we start with net income and adjust for:
+1. Non-cash items (depreciation, amortization)
+2. Changes in operating assets/liabilities (AR, AP, Inventory, Prepaid, Accrued)
+3. Gains/losses from investing/financing activities
+*/
+
+-- Update existing accounts with CashFlowCategory based on Type and Subtype
+-- Cash and Bank accounts don't have a category - they are cash itself
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = NULL
+WHERE [Subtype] IN ('Bank', 'Cash')
+   OR [Name] LIKE '%Cash%'
+   OR [Name] LIKE '%Checking%'
+   OR [Name] LIKE '%Savings%';
+GO
+
+-- Operating Activities - Current Assets (non-cash)
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Operating'
+WHERE [Type] = 'Asset'
+  AND [Subtype] IN ('Receivable', 'Inventory', 'OtherCurrentAsset', 'PrepaidExpense')
+  AND [CashFlowCategory] IS NULL;
+GO
+
+-- Operating Activities - Current Liabilities
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Operating'
+WHERE [Type] = 'Liability'
+  AND [Subtype] IN ('Payable', 'CreditCard', 'OtherCurrentLiability', 'AccruedLiability');
+GO
+
+-- Operating Activities - All Revenue and Expense accounts
+-- (Net Income is calculated from these, but changes in related accounts are operating)
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Operating'
+WHERE [Type] IN ('Revenue', 'Expense')
+  AND [CashFlowCategory] IS NULL;
+GO
+
+-- Investing Activities - Fixed Assets and Investments
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Investing'
+WHERE [Type] = 'Asset'
+  AND ([Subtype] IN ('FixedAsset', 'Investment', 'OtherAsset')
+       OR [Name] LIKE '%Equipment%'
+       OR [Name] LIKE '%Vehicle%'
+       OR [Name] LIKE '%Building%'
+       OR [Name] LIKE '%Property%'
+       OR [Name] LIKE '%Investment%'
+       OR [Name] LIKE '%Depreciation%');
+GO
+
+-- Financing Activities - Long-term Liabilities
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Financing'
+WHERE [Type] = 'Liability'
+  AND ([Subtype] IN ('LongTermLiability', 'NotesPayable', 'Loan')
+       OR [Name] LIKE '%Loan%'
+       OR [Name] LIKE '%Note%'
+       OR [Name] LIKE '%Mortgage%');
+GO
+
+-- Financing Activities - Equity accounts
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Financing'
+WHERE [Type] = 'Equity'
+  AND [CashFlowCategory] IS NULL;
+GO
+
+-- Catch any remaining accounts - default to Operating
+UPDATE [dbo].[Accounts]
+SET [CashFlowCategory] = 'Operating'
+WHERE [CashFlowCategory] IS NULL
+  AND [Subtype] NOT IN ('Bank', 'Cash')
+  AND [Name] NOT LIKE '%Cash%'
+  AND [Name] NOT LIKE '%Checking%'
+  AND [Name] NOT LIKE '%Savings%';
+GO
+
+PRINT 'CashFlowCategory values seeded successfully.';
+GO


### PR DESCRIPTION
## Summary
- Adds Statement of Cash Flows report at `/reports/cash-flow`
- Implements the indirect method (starts with Net Income, adjusts for non-cash items)
- Shows three standard sections: Operating, Investing, and Financing activities
- Adds CashFlowCategory column to Accounts table for classification

## Features
- **Operating Activities**: Net income, depreciation add-back, changes in working capital
- **Investing Activities**: Fixed asset purchases/sales, investment changes
- **Financing Activities**: Loan proceeds/repayments, equity transactions
- **Cash Reconciliation**: Verifies calculated cash change matches actual cash account changes
- Date range picker with presets (This Month, Last Month, This Quarter, etc.)
- Print and CSV export functionality

## Database Changes
- Added `CashFlowCategory` column to `dbo.Accounts` table (schema change in sqlproj)
- Migration `037_SeedCashFlowCategories.sql` to populate default categories

## Test Plan
- [ ] Navigate to Reports > Statement of Cash Flows
- [ ] Verify all three sections display correctly
- [ ] Change date range and verify report updates
- [ ] Verify Print and Export CSV buttons work
- [ ] Run Playwright tests: `npx playwright test cash-flow-statement.spec.ts`

## Screenshots
N/A - Report follows existing report component patterns

Closes #209

---
Generated with [Claude Code](https://claude.com/claude-code)