### PR TITLE
feat: Add Simple/Advanced mode for invoice and PO state management

### DIFF
--- a/client/src/contexts/CompanySettingsContext.tsx
+++ b/client/src/contexts/CompanySettingsContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
+export type InvoicePostingMode = 'simple' | 'advanced';
+
 export interface CompanySettings {
   name: string;
   logoUrl: string;
@@ -12,6 +14,10 @@ export interface CompanySettings {
   website: string;
   taxId: string; // EIN (Employer Identification Number)
   stateEmployerId: string; // State employer ID for W-2 forms
+  // Invoice/Bill Posting Mode:
+  // - 'simple': QBO-like behavior - documents post to GL immediately on save
+  // - 'advanced': Draft documents don't create journal entries until explicitly posted
+  invoicePostingMode: InvoicePostingMode;
 }
 
 const defaultSettings: CompanySettings = {
@@ -26,6 +32,7 @@ const defaultSettings: CompanySettings = {
   website: '',
   taxId: '',
   stateEmployerId: '',
+  invoicePostingMode: 'simple', // Default to QBO-like simple mode
 };
 
 interface CompanySettingsContextType {

--- a/client/src/lib/autoPostingService.ts
+++ b/client/src/lib/autoPostingService.ts
@@ -1,0 +1,345 @@
+/**
+ * Auto-Posting Service
+ *
+ * Handles automatic creation of journal entries when invoices/bills are saved
+ * in "Simple" mode (QBO-like behavior).
+ *
+ * Simple Mode:
+ * - Invoices: Debit AR, Credit Revenue on save
+ * - Bills: Debit Expense, Credit AP on save
+ *
+ * Advanced Mode:
+ * - Documents remain in Draft until explicitly posted
+ * - User has control over when GL impact occurs
+ */
+
+import api from './api';
+
+interface AccountDefault {
+  Id: string;
+  AccountType: string;
+  AccountId: string;
+  Description: string | null;
+}
+
+interface Account {
+  Id: string;
+  Name: string;
+  Type: string;
+}
+
+interface JournalEntryLine {
+  AccountId: string;
+  Description: string;
+  DebitAmount: number;
+  CreditAmount: number;
+}
+
+interface JournalEntry {
+  Id: string;
+  EntryNumber: string;
+  EntryDate: string;
+  Description: string;
+  Status: string;
+}
+
+// Cache for account defaults
+let accountDefaultsCache: AccountDefault[] | null = null;
+let accountsCacheByType: Record<string, Account[]> | null = null;
+
+/**
+ * Fetches account defaults from the database
+ */
+async function getAccountDefaults(): Promise<AccountDefault[]> {
+  if (accountDefaultsCache) {
+    return accountDefaultsCache;
+  }
+
+  try {
+    const response = await api.get<{ value: AccountDefault[] }>('/accountdefaults');
+    accountDefaultsCache = response.data.value;
+    return accountDefaultsCache;
+  } catch (error) {
+    console.error('Failed to fetch account defaults:', error);
+    return [];
+  }
+}
+
+/**
+ * Fetches accounts by type
+ */
+async function getAccountsByType(type: string): Promise<Account[]> {
+  if (accountsCacheByType && accountsCacheByType[type]) {
+    return accountsCacheByType[type];
+  }
+
+  try {
+    const response = await api.get<{ value: Account[] }>(`/accounts?$filter=Type eq '${type}'`);
+    if (!accountsCacheByType) accountsCacheByType = {};
+    accountsCacheByType[type] = response.data.value;
+    return accountsCacheByType[type];
+  } catch (error) {
+    console.error(`Failed to fetch ${type} accounts:`, error);
+    return [];
+  }
+}
+
+/**
+ * Gets the default account for a specific type
+ */
+async function getDefaultAccount(accountType: string): Promise<string | null> {
+  const defaults = await getAccountDefaults();
+  const defaultAccount = defaults.find(d => d.AccountType === accountType);
+  return defaultAccount?.AccountId || null;
+}
+
+/**
+ * Finds or creates an AR account
+ */
+async function getARAccountId(): Promise<string | null> {
+  // First check for configured default
+  const defaultId = await getDefaultAccount('AccountsReceivable');
+  if (defaultId) return defaultId;
+
+  // Fallback: find any AR account
+  const arAccounts = await getAccountsByType('Accounts Receivable');
+  return arAccounts[0]?.Id || null;
+}
+
+/**
+ * Finds or creates an AP account
+ */
+async function getAPAccountId(): Promise<string | null> {
+  // First check for configured default
+  const defaultId = await getDefaultAccount('AccountsPayable');
+  if (defaultId) return defaultId;
+
+  // Fallback: find any AP account
+  const apAccounts = await getAccountsByType('Accounts Payable');
+  return apAccounts[0]?.Id || null;
+}
+
+/**
+ * Finds or gets a default revenue account
+ */
+async function getRevenueAccountId(): Promise<string | null> {
+  // First check for configured default
+  const defaultId = await getDefaultAccount('DefaultRevenue');
+  if (defaultId) return defaultId;
+
+  // Fallback: find any income account
+  const incomeAccounts = await getAccountsByType('Income');
+  return incomeAccounts[0]?.Id || null;
+}
+
+/**
+ * Generates the next journal entry number
+ */
+async function generateNextEntryNumber(): Promise<string> {
+  try {
+    const response = await api.get<{ value: JournalEntry[] }>('/journalentries?$orderby=CreatedAt desc&$top=1');
+    const lastEntry = response.data.value[0];
+
+    if (lastEntry?.EntryNumber) {
+      const match = lastEntry.EntryNumber.match(/^JE-(\d+)$/);
+      if (match) {
+        const nextNum = parseInt(match[1], 10) + 1;
+        return `JE-${nextNum.toString().padStart(5, '0')}`;
+      }
+    }
+
+    return 'JE-00001';
+  } catch {
+    return `JE-${Date.now()}`;
+  }
+}
+
+/**
+ * Creates a journal entry for an invoice (AR posting)
+ *
+ * Debit: Accounts Receivable (for total amount)
+ * Credit: Revenue (for each line item or total)
+ * Credit: Sales Tax Payable (if applicable)
+ */
+export async function createInvoiceJournalEntry(
+  invoiceId: string,
+  totalAmount: number,
+  taxAmount: number,
+  invoiceNumber: string,
+  customerName: string,
+  issueDate: string,
+  userName?: string
+): Promise<{ journalEntryId: string } | null> {
+  try {
+    const arAccountId = await getARAccountId();
+    const revenueAccountId = await getRevenueAccountId();
+
+    if (!arAccountId || !revenueAccountId) {
+      console.warn('Cannot auto-post invoice: Missing AR or Revenue account');
+      return null;
+    }
+
+    const entryNumber = await generateNextEntryNumber();
+    const description = `Invoice ${invoiceNumber} - ${customerName}`;
+    const subtotal = totalAmount - taxAmount;
+
+    // Create journal entry lines
+    const lines: JournalEntryLine[] = [
+      {
+        AccountId: arAccountId,
+        Description: `AR - ${invoiceNumber}`,
+        DebitAmount: totalAmount,
+        CreditAmount: 0
+      },
+      {
+        AccountId: revenueAccountId,
+        Description: `Revenue - ${invoiceNumber}`,
+        DebitAmount: 0,
+        CreditAmount: subtotal
+      }
+    ];
+
+    // Add tax line if applicable
+    if (taxAmount > 0) {
+      const taxAccountId = await getDefaultAccount('SalesTaxPayable');
+      if (taxAccountId) {
+        lines.push({
+          AccountId: taxAccountId,
+          Description: `Sales Tax - ${invoiceNumber}`,
+          DebitAmount: 0,
+          CreditAmount: taxAmount
+        });
+      } else {
+        // If no tax account, add to revenue
+        lines[1].CreditAmount = totalAmount;
+      }
+    }
+
+    // Create the journal entry
+    const journalEntryResponse = await api.post<JournalEntry>('/journalentries', {
+      EntryNumber: entryNumber,
+      EntryDate: issueDate,
+      Description: description,
+      Status: 'Posted'
+    });
+
+    const journalEntry = journalEntryResponse.data;
+
+    // Create journal entry lines
+    await Promise.all(
+      lines.map(line =>
+        api.post('/journalentrylines', {
+          JournalEntryId: journalEntry.Id,
+          AccountId: line.AccountId,
+          Description: line.Description,
+          DebitAmount: line.DebitAmount,
+          CreditAmount: line.CreditAmount
+        })
+      )
+    );
+
+    // Update the invoice with the journal entry reference
+    await api.patch(`/invoices_write/Id/${invoiceId}`, {
+      JournalEntryId: journalEntry.Id,
+      PostedAt: new Date().toISOString(),
+      PostedBy: userName || 'System'
+    });
+
+    return { journalEntryId: journalEntry.Id };
+  } catch (error) {
+    console.error('Failed to create invoice journal entry:', error);
+    return null;
+  }
+}
+
+/**
+ * Creates a journal entry for a bill (AP posting)
+ *
+ * Debit: Expense accounts (from bill lines)
+ * Credit: Accounts Payable (for total amount)
+ */
+export async function createBillJournalEntry(
+  billId: string,
+  totalAmount: number,
+  billNumber: string,
+  vendorName: string,
+  billDate: string,
+  lineItems: Array<{ AccountId: string; Amount: number; Description?: string }>,
+  userName?: string
+): Promise<{ journalEntryId: string } | null> {
+  try {
+    const apAccountId = await getAPAccountId();
+
+    if (!apAccountId) {
+      console.warn('Cannot auto-post bill: Missing AP account');
+      return null;
+    }
+
+    const entryNumber = await generateNextEntryNumber();
+    const description = `Bill ${billNumber || 'N/A'} - ${vendorName}`;
+
+    // Create journal entry lines
+    const lines: JournalEntryLine[] = [];
+
+    // Debit expense accounts for each line item
+    for (const item of lineItems) {
+      lines.push({
+        AccountId: item.AccountId,
+        Description: item.Description || `Expense - ${billNumber || 'Bill'}`,
+        DebitAmount: item.Amount,
+        CreditAmount: 0
+      });
+    }
+
+    // Credit AP for total
+    lines.push({
+      AccountId: apAccountId,
+      Description: `AP - ${billNumber || 'Bill'}`,
+      DebitAmount: 0,
+      CreditAmount: totalAmount
+    });
+
+    // Create the journal entry
+    const journalEntryResponse = await api.post<JournalEntry>('/journalentries', {
+      EntryNumber: entryNumber,
+      EntryDate: billDate,
+      Description: description,
+      Status: 'Posted'
+    });
+
+    const journalEntry = journalEntryResponse.data;
+
+    // Create journal entry lines
+    await Promise.all(
+      lines.map(line =>
+        api.post('/journalentrylines', {
+          JournalEntryId: journalEntry.Id,
+          AccountId: line.AccountId,
+          Description: line.Description,
+          DebitAmount: line.DebitAmount,
+          CreditAmount: line.CreditAmount
+        })
+      )
+    );
+
+    // Update the bill with the journal entry reference
+    await api.patch(`/bills_write/Id/${billId}`, {
+      JournalEntryId: journalEntry.Id,
+      PostedAt: new Date().toISOString(),
+      PostedBy: userName || 'System'
+    });
+
+    return { journalEntryId: journalEntry.Id };
+  } catch (error) {
+    console.error('Failed to create bill journal entry:', error);
+    return null;
+  }
+}
+
+/**
+ * Clears the account defaults cache (useful after settings change)
+ */
+export function clearAccountDefaultsCache(): void {
+  accountDefaultsCache = null;
+  accountsCacheByType = null;
+}

--- a/client/src/pages/CompanySettings.tsx
+++ b/client/src/pages/CompanySettings.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
-import { Building2, Upload, Save, X, Sun, Moon, Monitor, Mail, AlertCircle } from 'lucide-react';
-import { useCompanySettings } from '../contexts/CompanySettingsContext';
+import { Building2, Upload, Save, X, Sun, Moon, Monitor, Mail, AlertCircle, Zap, ClipboardCheck, HelpCircle } from 'lucide-react';
+import { useCompanySettings, InvoicePostingMode } from '../contexts/CompanySettingsContext';
 import { useTheme, ThemePreference } from '../contexts/ThemeContext';
 import EmailSettingsForm from '../components/EmailSettingsForm';
 import OnboardingSettings from '../components/onboarding/OnboardingSettings';
@@ -111,6 +111,101 @@ export default function CompanySettings() {
               Choose how the application appears. System will follow your device settings.
             </p>
           </div>
+        </div>
+
+        {/* Transaction Posting Mode Section */}
+        <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-8">
+          <div className="flex items-center gap-2 mb-2">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Transaction Posting Mode</h2>
+            <div className="relative group">
+              <HelpCircle className="h-4 w-4 text-gray-400 cursor-help" />
+              <div className="absolute left-0 bottom-full mb-2 w-72 p-3 bg-gray-900 text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
+                <p className="mb-2"><strong>Simple Mode</strong> (like QuickBooks): Invoices and bills immediately affect your accounting records when saved.</p>
+                <p><strong>Advanced Mode</strong>: Documents stay as drafts until you explicitly post them, giving you more control over your books.</p>
+              </div>
+            </div>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+            Choose how invoices and bills affect your general ledger.
+          </p>
+
+          <div className="space-y-4">
+            {/* Simple Mode Option */}
+            <label
+              className={`flex items-start gap-4 p-4 rounded-lg border-2 cursor-pointer transition-all ${
+                formData.invoicePostingMode === 'simple'
+                  ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+              }`}
+            >
+              <input
+                type="radio"
+                name="invoicePostingMode"
+                value="simple"
+                checked={formData.invoicePostingMode === 'simple'}
+                onChange={() => setFormData(prev => ({ ...prev, invoicePostingMode: 'simple' as InvoicePostingMode }))}
+                className="mt-1 h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+              />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <Zap className="h-5 w-5 text-amber-500" />
+                  <span className="font-semibold text-gray-900 dark:text-white">Simple Mode</span>
+                  <span className="text-xs bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 px-2 py-0.5 rounded-full">Recommended</span>
+                </div>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  Like QuickBooks Online. Invoices and bills immediately post to your general ledger when saved.
+                  Perfect for small businesses that want straightforward accounting.
+                </p>
+                <ul className="mt-2 text-xs text-gray-500 dark:text-gray-400 space-y-1">
+                  <li>- Invoices: Save = Post to AR & Revenue</li>
+                  <li>- Bills: Save = Post to AP & Expense</li>
+                  <li>- Corrections via credit memos or adjusting entries</li>
+                </ul>
+              </div>
+            </label>
+
+            {/* Advanced Mode Option */}
+            <label
+              className={`flex items-start gap-4 p-4 rounded-lg border-2 cursor-pointer transition-all ${
+                formData.invoicePostingMode === 'advanced'
+                  ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+              }`}
+            >
+              <input
+                type="radio"
+                name="invoicePostingMode"
+                value="advanced"
+                checked={formData.invoicePostingMode === 'advanced'}
+                onChange={() => setFormData(prev => ({ ...prev, invoicePostingMode: 'advanced' as InvoicePostingMode }))}
+                className="mt-1 h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
+              />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <ClipboardCheck className="h-5 w-5 text-blue-500" />
+                  <span className="font-semibold text-gray-900 dark:text-white">Advanced Mode</span>
+                </div>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  For businesses needing review steps. Documents remain as drafts until explicitly posted.
+                  Ideal for approval workflows and accountant review.
+                </p>
+                <ul className="mt-2 text-xs text-gray-500 dark:text-gray-400 space-y-1">
+                  <li>- Draft documents don't affect GL</li>
+                  <li>- Edit freely before posting</li>
+                  <li>- Supports approval workflows</li>
+                </ul>
+              </div>
+            </label>
+          </div>
+
+          {formData.invoicePostingMode !== settings.invoicePostingMode && (
+            <div className="mt-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+              <p className="text-sm text-amber-700 dark:text-amber-400">
+                <strong>Note:</strong> Changing this setting only affects new transactions.
+                Existing documents will retain their current posting status.
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Logo Section */}

--- a/client/tests/posting-mode.spec.ts
+++ b/client/tests/posting-mode.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Invoice Posting Mode Settings', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage to ensure fresh settings
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.removeItem('company-settings');
+    });
+  });
+
+  test('company settings shows posting mode toggle', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Check that the posting mode section exists
+    await expect(page.getByText('Transaction Posting Mode')).toBeVisible();
+
+    // Verify Simple Mode option is visible
+    await expect(page.getByText('Simple Mode')).toBeVisible();
+    await expect(page.getByText('Like QuickBooks Online')).toBeVisible();
+
+    // Verify Advanced Mode option is visible
+    await expect(page.getByText('Advanced Mode')).toBeVisible();
+    await expect(page.getByText('For businesses needing review steps')).toBeVisible();
+  });
+
+  test('simple mode is selected by default', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Check that Simple Mode radio is checked by default
+    const simpleRadio = page.locator('input[value="simple"]');
+    await expect(simpleRadio).toBeChecked();
+  });
+
+  test('can switch to advanced mode', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Click on Advanced Mode
+    await page.locator('label:has-text("Advanced Mode")').click();
+
+    // Verify Advanced Mode is now selected
+    const advancedRadio = page.locator('input[value="advanced"]');
+    await expect(advancedRadio).toBeChecked();
+
+    // Check that warning message appears
+    await expect(page.getByText('Changing this setting only affects new transactions')).toBeVisible();
+
+    // Save settings
+    await page.getByRole('button', { name: /Save Settings/i }).click();
+
+    // Verify success message
+    await expect(page.getByText('Settings saved successfully')).toBeVisible();
+  });
+
+  test('posting mode persists after page reload', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Switch to Advanced Mode
+    await page.locator('label:has-text("Advanced Mode")').click();
+    await page.getByRole('button', { name: /Save Settings/i }).click();
+    await expect(page.getByText('Settings saved successfully')).toBeVisible();
+
+    // Reload the page
+    await page.reload();
+
+    // Verify Advanced Mode is still selected
+    const advancedRadio = page.locator('input[value="advanced"]');
+    await expect(advancedRadio).toBeChecked();
+  });
+});
+
+test.describe('Invoice Form Posting Indicator', () => {
+  test.beforeEach(async ({ page }) => {
+    // Set up simple mode in localStorage
+    await page.goto('/');
+    await page.evaluate(() => {
+      const settings = {
+        name: 'Test Company',
+        invoicePostingMode: 'simple'
+      };
+      localStorage.setItem('company-settings', JSON.stringify(settings));
+    });
+  });
+
+  test('shows auto-post indicator for non-draft invoices in simple mode', async ({ page }) => {
+    await page.goto('/invoices/new');
+
+    // Wait for the form to load
+    await expect(page.getByLabel('Invoice Number')).toBeVisible();
+
+    // Change status to Sent (non-draft)
+    await page.getByLabel('Status').selectOption('Sent');
+
+    // Check that the auto-post indicator is visible
+    await expect(page.getByText('This invoice will post to your books when saved')).toBeVisible();
+  });
+
+  test('shows draft indicator for draft invoices', async ({ page }) => {
+    await page.goto('/invoices/new');
+
+    // Wait for the form to load
+    await expect(page.getByLabel('Invoice Number')).toBeVisible();
+
+    // Status should be Draft by default
+    await expect(page.getByLabel('Status')).toHaveValue('Draft');
+
+    // Check that the draft indicator is visible
+    await expect(page.getByText("Draft invoices don't affect your books")).toBeVisible();
+  });
+});
+
+test.describe('Bill Form Posting Indicator', () => {
+  test.beforeEach(async ({ page }) => {
+    // Set up simple mode in localStorage
+    await page.goto('/');
+    await page.evaluate(() => {
+      const settings = {
+        name: 'Test Company',
+        invoicePostingMode: 'simple'
+      };
+      localStorage.setItem('company-settings', JSON.stringify(settings));
+    });
+  });
+
+  test('shows auto-post indicator for non-draft bills in simple mode', async ({ page }) => {
+    await page.goto('/bills/new');
+
+    // Wait for the form to load
+    await expect(page.getByLabel('Bill Number')).toBeVisible();
+
+    // Status should be Open by default (non-draft)
+    await expect(page.getByLabel('Status')).toHaveValue('Open');
+
+    // Check that the auto-post indicator is visible
+    await expect(page.getByText('This bill will post to your books when saved')).toBeVisible();
+  });
+
+  test('shows draft indicator for draft bills', async ({ page }) => {
+    await page.goto('/bills/new');
+
+    // Wait for the form to load
+    await expect(page.getByLabel('Bill Number')).toBeVisible();
+
+    // Change status to Draft
+    await page.getByLabel('Status').selectOption('Draft');
+
+    // Check that the draft indicator is visible
+    await expect(page.getByText("Draft bills don't affect your books")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a company-level setting to switch between Simple mode (QBO-like) and Advanced mode for invoice and bill state management, as described in issue #250.

- **Simple Mode (default)**: Invoices and bills post to the general ledger immediately when saved (non-Draft status). This is familiar to QuickBooks Online users.
- **Advanced Mode**: Draft documents don't create journal entries until explicitly posted, supporting approval workflows.

### Key Changes

- Added `invoicePostingMode` setting to `CompanySettingsContext` with types `'simple' | 'advanced'`
- Added Transaction Posting Mode toggle in Company Settings UI with clear explanations
- Created `autoPostingService.ts` for automatic GL posting:
  - Invoice posting creates AR debit and Revenue credit
  - Bill posting creates Expense debit and AP credit
- Updated invoice and bill forms to show visual indicator of posting behavior
- Added auto-posting logic to NewInvoice, EditInvoice, NewBill, and EditBill pages
- Added Playwright tests for the posting mode settings and form indicators

### Screenshots

The Company Settings page now includes a Transaction Posting Mode section with radio buttons for Simple and Advanced modes. The invoice and bill forms show an indicator explaining whether saving will post to the GL.

## Test plan

- [ ] Verify Company Settings shows Transaction Posting Mode section
- [ ] Verify Simple Mode is selected by default
- [ ] Verify switching to Advanced Mode shows warning about existing documents
- [ ] Verify invoice form shows auto-post indicator when status is not Draft (Simple mode)
- [ ] Verify bill form shows auto-post indicator when status is not Draft (Simple mode)
- [ ] Verify settings persist after page reload
- [ ] Run Playwright tests: npx playwright test posting-mode.spec.ts

Closes #250

Generated with [Claude Code](https://claude.com/claude-code)