### PR TITLE
fix: Consolidate MUI DataGrid theme and fix /transactions text colors (#298)

### DIFF
--- a/client/src/components/RestDataGrid.tsx
+++ b/client/src/components/RestDataGrid.tsx
@@ -8,7 +8,8 @@ import {
   GridRowParams,
   GridValidRowModel,
 } from '@mui/x-data-grid';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import dataGridTheme from '../lib/dataGridTheme';
 import api from '../lib/api';
 import { useNavigate } from 'react-router-dom';
 
@@ -136,20 +137,6 @@ export default function RestDataGrid<T extends GridValidRowModel>({
       </div>
     );
   }
-
-  // Create MUI theme forcing light mode
-  const dataGridTheme = createTheme({
-    colorSchemes: {
-      light: {
-        palette: {
-          text: {
-            primary: '#111827',
-            secondary: '#374151',
-          },
-        },
-      },
-    },
-  });
 
   return (
     <div>

--- a/client/src/components/ServerDataGrid.tsx
+++ b/client/src/components/ServerDataGrid.tsx
@@ -8,7 +8,8 @@ import {
   GridRowParams,
   GridValidRowModel,
 } from '@mui/x-data-grid';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import dataGridTheme from '../lib/dataGridTheme';
 import { graphql } from '../lib/api';
 import { useNavigate } from 'react-router-dom';
 
@@ -310,20 +311,6 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
       </div>
     );
   }
-
-  // Create MUI theme forcing light mode (prevents auto dark mode from system preferences)
-  const dataGridTheme = createTheme({
-    colorSchemes: {
-      light: {
-        palette: {
-          text: {
-            primary: '#111827',
-            secondary: '#374151',
-          },
-        },
-      },
-    },
-  });
 
   return (
     <div>

--- a/client/src/lib/dataGridTheme.ts
+++ b/client/src/lib/dataGridTheme.ts
@@ -1,0 +1,33 @@
+import { createTheme } from '@mui/material/styles';
+import type {} from '@mui/x-data-grid/themeAugmentation';
+
+/**
+ * Shared MUI DataGrid theme that forces light mode.
+ *
+ * MUI auto-detects system `prefers-color-scheme: dark` and applies dark mode
+ * colors (light text on light background), even when the app UI is in light mode.
+ * Defining only `colorSchemes.light` prevents the automatic dark mode switch.
+ */
+const dataGridTheme = createTheme({
+  colorSchemes: {
+    light: {
+      palette: {
+        text: {
+          primary: '#111827',   // Tailwind gray-900
+          secondary: '#374151', // Tailwind gray-700
+        },
+      },
+    },
+  },
+  components: {
+    MuiDataGrid: {
+      styleOverrides: {
+        root: { color: '#111827' },
+        cell: { color: '#111827' },
+        columnHeaderTitle: { color: '#374151', fontWeight: 600 },
+      },
+    },
+  },
+});
+
+export default dataGridTheme;

--- a/client/src/pages/AuditLog.tsx
+++ b/client/src/pages/AuditLog.tsx
@@ -20,8 +20,9 @@ import {
   Info
 } from 'lucide-react';
 import { GridColDef, GridRowParams } from '@mui/x-data-grid';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import { DataGrid, GridPaginationModel } from '@mui/x-data-grid';
+import dataGridTheme from '../lib/dataGridTheme';
 import api from '../lib/api';
 import { formatDate } from '../lib/dateUtils';
 
@@ -481,20 +482,6 @@ export default function AuditLog() {
       ),
     },
   ];
-
-  // MUI theme for DataGrid
-  const dataGridTheme = createTheme({
-    colorSchemes: {
-      light: {
-        palette: {
-          text: {
-            primary: '#111827',
-            secondary: '#374151',
-          },
-        },
-      },
-    },
-  });
 
   if (error) {
     return (

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -7,10 +7,12 @@ import {
   GridRowSelectionModel,
   GridRenderCellParams,
 } from '@mui/x-data-grid';
+import { ThemeProvider } from '@mui/material/styles';
 import { RefreshCw, Upload, Settings, CheckCircle, XCircle, Edit2, MinusCircle, FileText } from 'lucide-react';
 import { toast } from 'sonner';
 import api from '../lib/api';
 import { formatDate } from '../lib/dateUtils';
+import dataGridTheme from '../lib/dataGridTheme';
 import TransactionFilters, { TransactionFiltersState } from '../components/transactions/TransactionFilters';
 import BulkActionsBar from '../components/transactions/BulkActionsBar';
 import PlaidLinkButton from '../components/PlaidLinkButton';
@@ -610,24 +612,26 @@ export default function UnifiedTransactions() {
 
       {/* DataGrid */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow" style={{ height: 600, width: '100%' }}>
-        <DataGrid
-          rows={transactions}
-          columns={columns}
-          getRowId={(row) => row.Id}
-          loading={transactionsLoading}
-          checkboxSelection
-          disableRowSelectionOnClick
-          rowSelectionModel={selectedIds}
-          onRowSelectionModelChange={setSelectedIds}
-          pageSizeOptions={[10, 25, 50, 100]}
-          initialState={{
-            pagination: { paginationModel: { pageSize: 25 } },
-            sorting: { sortModel: [{ field: 'TransactionDate', sort: 'desc' }] },
-          }}
-          localeText={{
-            noRowsLabel: 'No transactions found. Sync your bank feed or import a CSV to get started.',
-          }}
-        />
+        <ThemeProvider theme={dataGridTheme}>
+          <DataGrid
+            rows={transactions}
+            columns={columns}
+            getRowId={(row) => row.Id}
+            loading={transactionsLoading}
+            checkboxSelection
+            disableRowSelectionOnClick
+            rowSelectionModel={selectedIds}
+            onRowSelectionModelChange={setSelectedIds}
+            pageSizeOptions={[10, 25, 50, 100]}
+            initialState={{
+              pagination: { paginationModel: { pageSize: 25 } },
+              sorting: { sortModel: [{ field: 'TransactionDate', sort: 'desc' }] },
+            }}
+            localeText={{
+              noRowsLabel: 'No transactions found. Sync your bank feed or import a CSV to get started.',
+            }}
+          />
+        </ThemeProvider>
       </div>
 
       {/* Post Confirmation Modal */}


### PR DESCRIPTION
## Summary
- Created a shared `dataGridTheme.ts` utility that forces MUI DataGrid into light mode by defining only `colorSchemes.light`, preventing auto dark mode detection from system preferences
- Replaced duplicated inline theme definitions in `ServerDataGrid.tsx`, `RestDataGrid.tsx`, and `AuditLog.tsx` with the shared theme import
- Added missing `ThemeProvider` wrapping to the `DataGrid` in `UnifiedTransactions.tsx` (the `/transactions` page), which was the root cause of faint/unreadable text

## Test plan
- [ ] Verify `/transactions` page shows dark, readable text in the DataGrid (both cell content and column headers)
- [ ] Verify `/products-services` page still renders correctly (uses `RestDataGrid`)
- [ ] Verify `/audit-log` page DataGrid text is readable
- [ ] Verify pages using `ServerDataGrid` (if any active) render correctly
- [ ] Test with system dark mode preference enabled to confirm light text override works

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)