### PR TITLE
feat: Add Credit Memos and Customer Refunds (#211)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -116,6 +116,9 @@ import BankImportHistory from './pages/BankImportHistory';
 import BankRules from './pages/BankRules';
 import VendorHierarchy from './pages/VendorHierarchy';
 import CustomerHierarchy from './pages/CustomerHierarchy';
+import CreditMemos from './pages/CreditMemos';
+import NewCreditMemo from './pages/NewCreditMemo';
+import ApplyCreditMemo from './pages/ApplyCreditMemo';
 import SalesReceipts from './pages/SalesReceipts';
 import NewSalesReceipt from './pages/NewSalesReceipt';
 import EditSalesReceipt from './pages/EditSalesReceipt';
@@ -250,6 +253,9 @@ function AppContent() {
             <Route path="customer-deposits/:id/apply" element={<ApplyDeposit />} />
             <Route path="bill-payments" element={<BillPayments />} />
             <Route path="bill-payments/new" element={<NewBillPayment />} />
+            <Route path="credit-memos" element={<CreditMemos />} />
+            <Route path="credit-memos/new" element={<NewCreditMemo />} />
+            <Route path="credit-memos/:id/apply" element={<ApplyCreditMemo />} />
             <Route path="vendor-credits" element={<VendorCredits />} />
             <Route path="vendor-credits/new" element={<NewVendorCredit />} />
             <Route path="vendor-credits/:id/edit" element={<EditVendorCredit />} />

--- a/client/src/components/CreditMemoForm.tsx
+++ b/client/src/components/CreditMemoForm.tsx
@@ -1,0 +1,370 @@
+import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import api from '../lib/api';
+
+export const creditMemoSchema = z.object({
+  CustomerId: z.string().uuid('Please select a customer'),
+  CreditMemoNumber: z.string().min(1, 'Credit memo number is required'),
+  CreditDate: z.string().min(1, 'Credit date is required'),
+  Reason: z.string().nullish(),
+  Subtotal: z.number().min(0, 'Subtotal must be positive'),
+  TaxAmount: z.number().min(0, 'Tax amount must be positive').nullish(),
+  TotalAmount: z.number().min(0, 'Total must be positive'),
+  AmountApplied: z.number().min(0).nullish(),
+  AmountRefunded: z.number().min(0).nullish(),
+  Status: z.enum(['Open', 'Applied', 'PartiallyApplied', 'Refunded', 'Voided']),
+  Lines: z.array(z.object({
+    Id: z.string().nullish(),
+    AccountId: z.string().uuid('Please select an account'),
+    ProductServiceId: z.string().nullish(),
+    Description: z.string().nullish(),
+    Quantity: z.number().min(0, 'Quantity must be positive'),
+    UnitPrice: z.number().min(0, 'Unit price must be positive'),
+    Amount: z.number().min(0, 'Amount must be positive')
+  })).min(1, 'At least one line item is required')
+});
+
+export type CreditMemoFormData = z.infer<typeof creditMemoSchema>;
+
+interface Customer {
+  Id: string;
+  Name: string;
+}
+
+interface Account {
+  Id: string;
+  Name: string;
+  Type: string;
+}
+
+interface ProductService {
+  Id: string;
+  Name: string;
+  SalesPrice: number | null;
+  IncomeAccountId: string | null;
+}
+
+interface CreditMemoFormProps {
+  initialValues?: Partial<CreditMemoFormData>;
+  onSubmit: (data: CreditMemoFormData) => Promise<void>;
+  title: string;
+  isSubmitting?: boolean;
+  submitButtonText?: string;
+}
+
+export default function CreditMemoForm({ initialValues, onSubmit, title, isSubmitting: externalIsSubmitting, submitButtonText = 'Save Credit Memo' }: CreditMemoFormProps) {
+  const navigate = useNavigate();
+
+  const { data: customers } = useQuery({
+    queryKey: ['customers'],
+    queryFn: async () => {
+      const response = await api.get<{ value: Customer[] }>('/customers');
+      return response.data.value;
+    },
+  });
+
+  const { data: accounts } = useQuery({
+    queryKey: ['accounts'],
+    queryFn: async () => {
+      const response = await api.get<{ value: Account[] }>('/accounts');
+      return response.data.value;
+    },
+  });
+
+  const { data: productsServices } = useQuery({
+    queryKey: ['productsservices'],
+    queryFn: async () => {
+      const response = await api.get<{ value: ProductService[] }>('/productsservices');
+      return response.data.value;
+    },
+  });
+
+  // Filter to revenue/income accounts for credit memo line items
+  const revenueAccounts = accounts?.filter(
+    (acc) => acc.Type === 'Revenue' || acc.Type === 'Income' || acc.Type === 'Other Income'
+  ) || [];
+
+  const { register, control, handleSubmit, setValue, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<CreditMemoFormData>({
+    resolver: zodResolver(creditMemoSchema),
+    defaultValues: {
+      Status: 'Open',
+      CreditDate: new Date().toISOString().split('T')[0],
+      Lines: [{ AccountId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 }],
+      Subtotal: 0,
+      TaxAmount: 0,
+      TotalAmount: 0,
+      AmountApplied: 0,
+      AmountRefunded: 0,
+      ...initialValues
+    }
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "Lines"
+  });
+
+  const lines = useWatch({
+    control,
+    name: "Lines"
+  });
+
+  // Update totals when lines change
+  useEffect(() => {
+    const subtotal = lines.reduce((sum, line) => {
+      return sum + (line.Amount || 0);
+    }, 0);
+    setValue('Subtotal', subtotal);
+    setValue('TotalAmount', subtotal);
+  }, [lines, setValue]);
+
+  // Update line amount when quantity or unit price changes
+  const updateLineAmount = (index: number, quantity: number, unitPrice: number) => {
+    const amount = quantity * unitPrice;
+    setValue(`Lines.${index}.Amount`, amount);
+  };
+
+  // Handle product selection - auto-fill price and account
+  const handleProductChange = (index: number, productId: string) => {
+    if (!productId || !productsServices) return;
+
+    const product = productsServices.find(p => p.Id === productId);
+    if (product) {
+      if (product.SalesPrice) {
+        setValue(`Lines.${index}.UnitPrice`, product.SalesPrice);
+        const quantity = lines[index]?.Quantity || 1;
+        setValue(`Lines.${index}.Amount`, quantity * product.SalesPrice);
+      }
+      if (product.IncomeAccountId) {
+        setValue(`Lines.${index}.AccountId`, product.IncomeAccountId);
+      }
+    }
+  };
+
+  const isSubmitting = externalIsSubmitting || formIsSubmitting;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6 flex items-center">
+        <button onClick={() => navigate('/credit-memos')} className="mr-4 text-gray-500 hover:text-gray-700">
+          <ArrowLeft className="w-6 h-6" />
+        </button>
+        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <div>
+            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700">Customer</label>
+            <select
+              id="CustomerId"
+              {...register('CustomerId')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="">Select a customer...</option>
+              {customers?.map((customer) => (
+                <option key={customer.Id} value={customer.Id}>
+                  {customer.Name}
+                </option>
+              ))}
+            </select>
+            {errors.CustomerId && <p className="mt-1 text-sm text-red-600">{errors.CustomerId.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="CreditMemoNumber" className="block text-sm font-medium text-gray-700">Credit Memo Number</label>
+            <input
+              id="CreditMemoNumber"
+              type="text"
+              {...register('CreditMemoNumber')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              placeholder="CM-001"
+            />
+            {errors.CreditMemoNumber && <p className="mt-1 text-sm text-red-600">{errors.CreditMemoNumber.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="CreditDate" className="block text-sm font-medium text-gray-700">Credit Date</label>
+            <input
+              id="CreditDate"
+              type="date"
+              {...register('CreditDate')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            />
+            {errors.CreditDate && <p className="mt-1 text-sm text-red-600">{errors.CreditDate.message}</p>}
+          </div>
+
+          <div>
+            <label htmlFor="Status" className="block text-sm font-medium text-gray-700">Status</label>
+            <select
+              id="Status"
+              {...register('Status')}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            >
+              <option value="Open">Open</option>
+              <option value="Applied">Applied</option>
+              <option value="PartiallyApplied">Partially Applied</option>
+              <option value="Refunded">Refunded</option>
+              <option value="Voided">Voided</option>
+            </select>
+            {errors.Status && <p className="mt-1 text-sm text-red-600">{errors.Status.message}</p>}
+          </div>
+
+          <div className="sm:col-span-2">
+            <label htmlFor="Reason" className="block text-sm font-medium text-gray-700">Reason / Notes</label>
+            <textarea
+              id="Reason"
+              {...register('Reason')}
+              rows={2}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              placeholder="Reason for credit memo (e.g., returned goods, price adjustment, billing error)..."
+            />
+          </div>
+        </div>
+
+        {/* Line Items */}
+        <div className="mt-8">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-medium text-gray-900">Line Items</h3>
+            <button
+              type="button"
+              onClick={() => append({ AccountId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 })}
+              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              Add Item
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            {fields.map((field, index) => (
+              <div key={field.id} className="flex gap-4 items-start bg-gray-50 p-4 rounded-md flex-wrap">
+                <div className="w-40">
+                  <label className="block text-xs font-medium text-gray-500">Product/Service</label>
+                  <select
+                    {...register(`Lines.${index}.ProductServiceId`)}
+                    onChange={(e) => handleProductChange(index, e.target.value)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                  >
+                    <option value="">Optional...</option>
+                    {productsServices?.map((ps) => (
+                      <option key={ps.Id} value={ps.Id}>
+                        {ps.Name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="w-40">
+                  <label className="block text-xs font-medium text-gray-500">Account</label>
+                  <select
+                    {...register(`Lines.${index}.AccountId`)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                  >
+                    <option value="">Select account...</option>
+                    {revenueAccounts.map((account) => (
+                      <option key={account.Id} value={account.Id}>
+                        {account.Name}
+                      </option>
+                    ))}
+                  </select>
+                  {errors.Lines?.[index]?.AccountId && (
+                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.AccountId?.message}</p>
+                  )}
+                </div>
+                <div className="flex-grow min-w-32">
+                  <label className="block text-xs font-medium text-gray-500">Description</label>
+                  <input
+                    {...register(`Lines.${index}.Description`)}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                    placeholder="Item description"
+                  />
+                </div>
+                <div className="w-20">
+                  <label className="block text-xs font-medium text-gray-500">Qty</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...register(`Lines.${index}.Quantity`, {
+                      valueAsNumber: true,
+                      onChange: (e) => {
+                        const qty = parseFloat(e.target.value) || 0;
+                        const price = lines[index]?.UnitPrice || 0;
+                        updateLineAmount(index, qty, price);
+                      }
+                    })}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                  />
+                </div>
+                <div className="w-24">
+                  <label className="block text-xs font-medium text-gray-500">Unit Price</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...register(`Lines.${index}.UnitPrice`, {
+                      valueAsNumber: true,
+                      onChange: (e) => {
+                        const price = parseFloat(e.target.value) || 0;
+                        const qty = lines[index]?.Quantity || 0;
+                        updateLineAmount(index, qty, price);
+                      }
+                    })}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                  />
+                </div>
+                <div className="w-24">
+                  <label className="block text-xs font-medium text-gray-500">Amount</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    {...register(`Lines.${index}.Amount`, { valueAsNumber: true })}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 bg-gray-100"
+                    readOnly
+                  />
+                  {errors.Lines?.[index]?.Amount && (
+                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Amount?.message}</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  className="mt-6 text-red-600 hover:text-red-800"
+                  disabled={fields.length === 1}
+                >
+                  <Trash2 className="w-5 h-5" />
+                </button>
+              </div>
+            ))}
+          </div>
+          {errors.Lines && typeof errors.Lines === 'object' && 'message' in errors.Lines && (
+            <p className="mt-2 text-sm text-red-600">{errors.Lines.message}</p>
+          )}
+        </div>
+
+        <div className="flex justify-end items-center border-t pt-4">
+          <div className="text-xl font-bold text-gray-900 mr-6">
+            Total Credit: ${lines.reduce((sum, line) => sum + (line.Amount || 0), 0).toFixed(2)}
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/credit-memos')}
+            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Saving...' : submitButtonText}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/navigation/navConfig.ts
+++ b/client/src/components/navigation/navConfig.ts
@@ -1,4 +1,4 @@
-import { LucideIcon, LayoutDashboard, FileText, ClipboardList, Users, Package, Warehouse, Truck, UserCheck, DollarSign, Receipt, FolderOpen, Clock, Tag, MapPin, RefreshCw, Layers, Building2, BookOpen, Upload, Database, Scale, BarChart3, MessageSquare, Sparkles, Settings, ShoppingCart, Percent, CreditCard, FileMinus, Car, ListFilter, Banknote, Mail, History, Calendar, PiggyBank } from 'lucide-react';
+import { LucideIcon, LayoutDashboard, FileText, ClipboardList, Users, Package, Warehouse, Truck, UserCheck, DollarSign, Receipt, FolderOpen, Clock, Tag, MapPin, RefreshCw, Layers, Building2, BookOpen, Upload, Database, Scale, BarChart3, MessageSquare, Sparkles, Settings, ShoppingCart, Percent, CreditCard, FileMinus, Car, ListFilter, Banknote, Mail, History, Calendar, PiggyBank, FileX } from 'lucide-react';
 import { FeatureKey } from '../../contexts/FeatureFlagsContext';
 
 export interface NavItem {
@@ -48,6 +48,7 @@ export const navigationConfig: NavEntry[] = [
       { id: 'sales-receipts', name: 'Sales Receipts', href: '/sales-receipts', icon: Banknote, featureKey: 'sales_receipts', visibilityFlag: 'sales_receipts' },
       { id: 'estimates', name: 'Estimates', href: '/estimates', icon: ClipboardList, featureKey: 'estimates' },
       { id: 'customer-deposits', name: 'Customer Deposits', href: '/customer-deposits', icon: PiggyBank },
+      { id: 'credit-memos', name: 'Credit Memos', href: '/credit-memos', icon: FileX },
     ],
   },
 

--- a/client/src/pages/ApplyCreditMemo.tsx
+++ b/client/src/pages/ApplyCreditMemo.tsx
@@ -1,0 +1,413 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
+import { useState, useMemo } from 'react';
+import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
+import api from '../lib/api';
+import { formatDate } from '../lib/dateUtils';
+
+interface CreditMemo {
+  Id: string;
+  CreditMemoNumber: string;
+  CustomerId: string;
+  CustomerName: string;
+  CreditDate: string;
+  TotalAmount: number;
+  AmountApplied: number;
+  AmountRefunded: number;
+  BalanceRemaining: number;
+  Status: string;
+  Reason: string;
+}
+
+interface Invoice {
+  Id: string;
+  InvoiceNumber: string;
+  CustomerId: string;
+  TotalAmount: number;
+  AmountPaid: number;
+  Status: string;
+  DueDate: string;
+}
+
+interface ApplicationLine {
+  InvoiceId: string;
+  InvoiceNumber: string;
+  InvoiceTotalAmount: number;
+  InvoiceBalanceDue: number;
+  AmountToApply: number;
+}
+
+export default function ApplyCreditMemo() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [applications, setApplications] = useState<ApplicationLine[]>([]);
+  const [applicationDate, setApplicationDate] = useState(new Date().toISOString().split('T')[0]);
+
+  // Fetch the credit memo
+  const { data: creditMemo, isLoading: isLoadingCreditMemo } = useQuery({
+    queryKey: ['creditmemo', id],
+    queryFn: async (): Promise<CreditMemo | null> => {
+      if (!id) return null;
+      const response = await api.get<{ value: CreditMemo[] }>(`/creditmemos?$filter=Id eq ${id}`);
+      return response.data.value[0] || null;
+    },
+    enabled: !!id,
+  });
+
+  // Fetch unpaid invoices for the same customer
+  const { data: unpaidInvoices, isLoading: isLoadingInvoices } = useQuery({
+    queryKey: ['invoices-unpaid', creditMemo?.CustomerId],
+    queryFn: async (): Promise<Invoice[]> => {
+      if (!creditMemo?.CustomerId) return [];
+      const response = await api.get<{ value: Invoice[] }>(
+        `/invoices?$filter=CustomerId eq ${creditMemo.CustomerId} and Status ne 'Paid' and Status ne 'Draft'&$orderby=DueDate`
+      );
+      return response.data.value;
+    },
+    enabled: !!creditMemo?.CustomerId,
+  });
+
+  // Calculate totals
+  const totalToApply = useMemo(() => {
+    return applications.reduce((sum, app) => sum + (app.AmountToApply || 0), 0);
+  }, [applications]);
+
+  const remainingBalance = useMemo(() => {
+    if (!creditMemo) return 0;
+    return creditMemo.BalanceRemaining - totalToApply;
+  }, [creditMemo, totalToApply]);
+
+  // Get invoices that haven't been added yet
+  const availableInvoices = useMemo(() => {
+    const appliedInvoiceIds = new Set(applications.map(a => a.InvoiceId));
+    return unpaidInvoices?.filter(inv => !appliedInvoiceIds.has(inv.Id)) || [];
+  }, [unpaidInvoices, applications]);
+
+  const handleAddInvoice = (invoice: Invoice) => {
+    const balanceDue = invoice.TotalAmount - (invoice.AmountPaid || 0);
+    const maxApplicable = Math.min(balanceDue, remainingBalance);
+
+    setApplications(prev => [...prev, {
+      InvoiceId: invoice.Id,
+      InvoiceNumber: invoice.InvoiceNumber,
+      InvoiceTotalAmount: invoice.TotalAmount,
+      InvoiceBalanceDue: balanceDue,
+      AmountToApply: maxApplicable,
+    }]);
+  };
+
+  const handleRemoveApplication = (index: number) => {
+    setApplications(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleAmountChange = (index: number, amount: number) => {
+    setApplications(prev => prev.map((app, i) => {
+      if (i === index) {
+        return { ...app, AmountToApply: Math.min(amount, app.InvoiceBalanceDue) };
+      }
+      return app;
+    }));
+  };
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!creditMemo || applications.length === 0) {
+        throw new Error('No applications to process');
+      }
+
+      // Create credit applications and update invoice amounts
+      for (const app of applications) {
+        // Create the credit application record
+        await api.post('/creditapplications_write', {
+          CreditMemoId: creditMemo.Id,
+          InvoiceId: app.InvoiceId,
+          AmountApplied: app.AmountToApply,
+          ApplicationDate: applicationDate,
+        });
+
+        // Update the invoice's AmountPaid
+        const invoiceResponse = await api.get<{ value: { Id: string; AmountPaid: number; TotalAmount: number }[] }>(
+          `/invoices?$filter=Id eq ${app.InvoiceId}`
+        );
+        const invoice = invoiceResponse.data.value[0];
+
+        if (invoice) {
+          const newAmountPaid = (invoice.AmountPaid || 0) + app.AmountToApply;
+          const newStatus = newAmountPaid >= invoice.TotalAmount ? 'Paid' : 'Partial';
+
+          await api.patch(`/invoices_write/Id/${app.InvoiceId}`, {
+            AmountPaid: newAmountPaid,
+            Status: newStatus,
+          });
+        }
+      }
+
+      // Update the credit memo's AmountApplied and Status
+      const newAmountApplied = creditMemo.AmountApplied + totalToApply;
+      const totalUsed = newAmountApplied + creditMemo.AmountRefunded;
+      const newStatus = totalUsed >= creditMemo.TotalAmount ? 'Applied' : 'PartiallyApplied';
+
+      await api.patch(`/creditmemos_write/Id/${creditMemo.Id}`, {
+        AmountApplied: newAmountApplied,
+        Status: newStatus,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['creditmemos'] });
+      queryClient.invalidateQueries({ queryKey: ['creditapplications'] });
+      queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      navigate('/credit-memos');
+    },
+    onError: (error) => {
+      console.error('Failed to apply credit memo:', error);
+      setErrorMessage('Failed to apply credit memo. Please try again.');
+    },
+  });
+
+  if (isLoadingCreditMemo) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center py-8">Loading credit memo...</div>
+      </div>
+    );
+  }
+
+  if (!creditMemo) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <div className="bg-red-50 border border-red-200 rounded-md p-4">
+          <p className="text-red-600">Credit memo not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (creditMemo.Status === 'Applied' || creditMemo.Status === 'Voided') {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <div className="bg-yellow-50 border border-yellow-200 rounded-md p-4">
+          <p className="text-yellow-700">
+            This credit memo has already been fully applied or voided and cannot receive additional applications.
+          </p>
+          <button
+            onClick={() => navigate('/credit-memos')}
+            className="mt-4 text-indigo-600 hover:text-indigo-800"
+          >
+            Return to Credit Memos
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6 flex items-center">
+        <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700">
+          <ArrowLeft className="w-6 h-6" />
+        </button>
+        <h1 className="text-2xl font-semibold text-gray-900">Apply Credit Memo to Invoices</h1>
+      </div>
+
+      {errorMessage && (
+        <div className="mb-4 bg-red-50 border border-red-200 rounded-md p-4 flex justify-between items-center">
+          <p className="text-red-600">{errorMessage}</p>
+          <button onClick={() => setErrorMessage(null)} className="text-red-600 hover:text-red-800">
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Credit Memo Summary */}
+      <div className="bg-white shadow rounded-lg p-6 mb-6">
+        <h2 className="text-lg font-medium text-gray-900 mb-4">Credit Memo Details</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <p className="text-sm text-gray-500">Credit Memo #</p>
+            <p className="text-lg font-medium text-gray-900">{creditMemo.CreditMemoNumber}</p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Customer</p>
+            <p className="text-lg font-medium text-gray-900">{creditMemo.CustomerName}</p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Total Amount</p>
+            <p className="text-lg font-medium text-gray-900">${creditMemo.TotalAmount.toFixed(2)}</p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Available Balance</p>
+            <p className="text-lg font-medium text-green-600">${creditMemo.BalanceRemaining.toFixed(2)}</p>
+          </div>
+        </div>
+        {creditMemo.Reason && (
+          <div className="mt-4">
+            <p className="text-sm text-gray-500">Reason</p>
+            <p className="text-sm text-gray-700">{creditMemo.Reason}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Application Form */}
+      <div className="bg-white shadow rounded-lg p-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 mb-6">
+          <div>
+            <label htmlFor="applicationDate" className="block text-sm font-medium text-gray-700">
+              Application Date
+            </label>
+            <input
+              id="applicationDate"
+              type="date"
+              value={applicationDate}
+              onChange={(e) => setApplicationDate(e.target.value)}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            />
+          </div>
+        </div>
+
+        {/* Available Invoices */}
+        {isLoadingInvoices ? (
+          <div className="text-center py-8 text-gray-500">Loading invoices...</div>
+        ) : availableInvoices.length > 0 && remainingBalance > 0 ? (
+          <div className="mb-6">
+            <h3 className="text-sm font-medium text-gray-700 mb-2">Available Invoices</h3>
+            <div className="bg-gray-50 rounded-md overflow-hidden">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-100">
+                  <tr>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">Invoice #</th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">Due Date</th>
+                    <th className="px-4 py-2 text-right text-xs font-medium text-gray-500">Total</th>
+                    <th className="px-4 py-2 text-right text-xs font-medium text-gray-500">Balance Due</th>
+                    <th className="px-4 py-2"></th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {availableInvoices.map(invoice => {
+                    const balanceDue = invoice.TotalAmount - (invoice.AmountPaid || 0);
+                    return (
+                      <tr key={invoice.Id}>
+                        <td className="px-4 py-2 text-sm text-gray-900">{invoice.InvoiceNumber}</td>
+                        <td className="px-4 py-2 text-sm text-gray-600">{formatDate(invoice.DueDate)}</td>
+                        <td className="px-4 py-2 text-sm text-gray-900 text-right">${invoice.TotalAmount.toFixed(2)}</td>
+                        <td className="px-4 py-2 text-sm font-medium text-gray-900 text-right">${balanceDue.toFixed(2)}</td>
+                        <td className="px-4 py-2 text-right">
+                          <button
+                            type="button"
+                            onClick={() => handleAddInvoice(invoice)}
+                            className="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-700 bg-indigo-100 hover:bg-indigo-200 rounded"
+                          >
+                            <Plus className="w-3 h-3 mr-1" />
+                            Apply
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Applications */}
+        {applications.length > 0 && (
+          <div className="mb-6">
+            <h3 className="text-sm font-medium text-gray-700 mb-2">Credit Applied To</h3>
+            <div className="space-y-3">
+              {applications.map((app, index) => (
+                <div key={app.InvoiceId} className="bg-indigo-50 p-4 rounded-md flex items-center gap-4">
+                  <div className="flex-grow">
+                    <div className="text-sm font-medium text-gray-900">
+                      Invoice #{app.InvoiceNumber}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      Balance due: ${app.InvoiceBalanceDue.toFixed(2)}
+                    </div>
+                  </div>
+                  <div className="w-40">
+                    <label className="block text-xs font-medium text-gray-500">Amount to Apply</label>
+                    <div className="relative rounded-md shadow-sm">
+                      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2">
+                        <span className="text-gray-500 text-sm">$</span>
+                      </div>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        max={app.InvoiceBalanceDue}
+                        value={app.AmountToApply}
+                        onChange={(e) => handleAmountChange(index, parseFloat(e.target.value) || 0)}
+                        className="block w-full rounded-md border-gray-300 pl-6 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      />
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveApplication(index)}
+                    className="text-red-600 hover:text-red-800 p-1"
+                  >
+                    <Trash2 className="w-5 h-5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {applications.length === 0 && availableInvoices.length === 0 && (
+          <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md mb-6">
+            No unpaid invoices found for this customer
+          </div>
+        )}
+
+        {/* Totals */}
+        <div className="border-t pt-4">
+          <div className="flex justify-end">
+            <div className="w-72 space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Total to Apply:</span>
+                <span className="font-medium text-gray-900">${totalToApply.toFixed(2)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600">Remaining Balance:</span>
+                <span className={`font-medium ${remainingBalance < 0 ? 'text-red-600' : 'text-green-600'}`}>
+                  ${remainingBalance.toFixed(2)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Warning if over-applied */}
+        {remainingBalance < 0 && (
+          <div className="mt-4 bg-red-50 border border-red-200 rounded-md p-4">
+            <p className="text-sm text-red-600">
+              The total amount to apply exceeds the available credit balance. Please reduce the application amounts.
+            </p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end items-center border-t pt-4 mt-4">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || applications.length === 0 || remainingBalance < 0}
+            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Applying...' : 'Apply Credit'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/CreditMemos.tsx
+++ b/client/src/pages/CreditMemos.tsx
@@ -1,0 +1,117 @@
+import { Link } from 'react-router-dom';
+import { Plus } from 'lucide-react';
+import { GridColDef } from '@mui/x-data-grid';
+import RestDataGrid from '../components/RestDataGrid';
+import { formatDate } from '../lib/dateUtils';
+
+interface CreditMemo {
+  Id: string;
+  CreditMemoNumber: string;
+  CustomerId: string;
+  CustomerName: string;
+  CreditDate: string;
+  Reason: string;
+  TotalAmount: number;
+  AmountApplied: number;
+  AmountRefunded: number;
+  BalanceRemaining: number;
+  Status: string;
+}
+
+const getStatusColor = (status: string) => {
+  switch (status) {
+    case 'Applied': return 'bg-green-100 text-green-800';
+    case 'PartiallyApplied': return 'bg-yellow-100 text-yellow-800';
+    case 'Refunded': return 'bg-purple-100 text-purple-800';
+    case 'Voided': return 'bg-red-100 text-red-800';
+    case 'Open': return 'bg-blue-100 text-blue-800';
+    default: return 'bg-gray-100 text-gray-800';
+  }
+};
+
+export default function CreditMemos() {
+  const columns: GridColDef[] = [
+    { field: 'CreditMemoNumber', headerName: 'Credit Memo #', width: 140, filterable: true },
+    { field: 'CustomerName', headerName: 'Customer', width: 180, filterable: true },
+    { field: 'CreditDate', headerName: 'Date', width: 120, filterable: true, renderCell: (params) => formatDate(params.value) },
+    {
+      field: 'TotalAmount',
+      headerName: 'Amount',
+      width: 120,
+      type: 'number',
+      filterable: true,
+      renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
+    },
+    {
+      field: 'AmountApplied',
+      headerName: 'Applied',
+      width: 120,
+      type: 'number',
+      filterable: true,
+      renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
+    },
+    {
+      field: 'BalanceRemaining',
+      headerName: 'Balance',
+      width: 120,
+      type: 'number',
+      filterable: true,
+      renderCell: (params) => `$${(params.value || 0).toFixed(2)}`,
+    },
+    {
+      field: 'Status',
+      headerName: 'Status',
+      width: 130,
+      filterable: true,
+      renderCell: (params) => (
+        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getStatusColor(params.value)}`}>
+          {params.value}
+        </span>
+      ),
+    },
+    { field: 'Reason', headerName: 'Reason', width: 200, filterable: true },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      width: 100,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => {
+        const row = params.row as CreditMemo;
+        if (row.Status === 'Open' || row.Status === 'PartiallyApplied') {
+          return (
+            <Link
+              to={`/credit-memos/${row.Id}/apply`}
+              className="text-indigo-600 hover:text-indigo-900 text-sm font-medium"
+            >
+              Apply
+            </Link>
+          );
+        }
+        return null;
+      },
+    },
+  ];
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">Credit Memos</h1>
+        <Link
+          to="/credit-memos/new"
+          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          New Credit Memo
+        </Link>
+      </div>
+
+      <RestDataGrid<CreditMemo>
+        endpoint="/creditmemos"
+        columns={columns}
+        initialPageSize={25}
+        emptyMessage="No credit memos found."
+      />
+    </div>
+  );
+}

--- a/client/src/pages/NewCreditMemo.tsx
+++ b/client/src/pages/NewCreditMemo.tsx
@@ -1,0 +1,86 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import api from '../lib/api';
+import CreditMemoForm, { CreditMemoFormData } from '../components/CreditMemoForm';
+
+interface CreditMemo {
+  Id: string;
+  CreditMemoNumber: string;
+}
+
+export default function NewCreditMemo() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async (data: CreditMemoFormData) => {
+      // Create the credit memo first
+      const { Lines, ...creditData } = data;
+      await api.post('/creditmemos_write', creditData);
+
+      // DAB doesn't return the created entity, so we need to query for it
+      const escapedNumber = String(creditData.CreditMemoNumber).replace(/'/g, "''");
+      const queryResponse = await api.get<{ value: CreditMemo[] }>(
+        `/creditmemos?$filter=CreditMemoNumber eq '${escapedNumber}'`
+      );
+      const credit = queryResponse.data.value[0];
+
+      if (!credit?.Id) {
+        throw new Error('Failed to retrieve created credit memo');
+      }
+
+      // Then create the line items
+      if (Lines && Lines.length > 0) {
+        await Promise.all(
+          Lines.map((line) =>
+            api.post('/creditmemolines_write', {
+              CreditMemoId: credit.Id,
+              AccountId: line.AccountId,
+              ProductServiceId: line.ProductServiceId || null,
+              Description: line.Description || '',
+              Quantity: line.Quantity,
+              UnitPrice: line.UnitPrice,
+              Amount: line.Amount,
+            })
+          )
+        );
+      }
+
+      return credit;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['creditmemos'] });
+      navigate('/credit-memos');
+    },
+    onError: (error) => {
+      console.error('Failed to create credit memo:', error);
+      setErrorMessage('Failed to create credit memo. Please try again.');
+    },
+  });
+
+  return (
+    <div>
+      {errorMessage && (
+        <div className="max-w-4xl mx-auto mb-4">
+          <div className="bg-red-50 border border-red-200 rounded-md p-4 flex justify-between items-center">
+            <p className="text-red-600">{errorMessage}</p>
+            <button
+              onClick={() => setErrorMessage(null)}
+              className="text-red-600 hover:text-red-800"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+      <CreditMemoForm
+        title="New Credit Memo"
+        onSubmit={async (data) => { await mutation.mutateAsync(data); }}
+        isSubmitting={mutation.isPending}
+        submitButtonText="Create Credit Memo"
+      />
+    </div>
+  );
+}

--- a/dab-config.json
+++ b/dab-config.json
@@ -2999,6 +2999,259 @@
             "key-fields": [
                 "Id"
             ]
+        },
+        "creditmemos": {
+            "source": {
+                "object": "dbo.v_CreditMemos",
+                "type": "view",
+                "key-fields": [
+                    "Id"
+                ]
+            },
+            "graphql": {
+                "enabled": true
+            },
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "CreditMemoNumber": "CreditMemoNumber",
+                "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName",
+                "CreditDate": "CreditDate",
+                "Reason": "Reason",
+                "Subtotal": "Subtotal",
+                "TaxAmount": "TaxAmount",
+                "TotalAmount": "TotalAmount",
+                "AmountApplied": "AmountApplied",
+                "AmountRefunded": "AmountRefunded",
+                "BalanceRemaining": "BalanceRemaining",
+                "Status": "Status",
+                "JournalEntryId": "JournalEntryId",
+                "JournalEntryReference": "JournalEntryReference",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            }
+        },
+        "creditmemos_write": {
+            "source": "dbo.CreditMemos",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "create",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "CreditMemoNumber": "CreditMemoNumber",
+                "CustomerId": "CustomerId",
+                "CreditDate": "CreditDate",
+                "Reason": "Reason",
+                "Subtotal": "Subtotal",
+                "TaxAmount": "TaxAmount",
+                "TotalAmount": "TotalAmount",
+                "AmountApplied": "AmountApplied",
+                "AmountRefunded": "AmountRefunded",
+                "Status": "Status",
+                "JournalEntryId": "JournalEntryId"
+            },
+            "key-fields": [
+                "Id"
+            ]
+        },
+        "creditmemolines": {
+            "source": {
+                "object": "dbo.v_CreditMemoLines",
+                "type": "view",
+                "key-fields": [
+                    "Id"
+                ]
+            },
+            "graphql": {
+                "enabled": true
+            },
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "CreditMemoId": "CreditMemoId",
+                "CreditMemoNumber": "CreditMemoNumber",
+                "ProductServiceId": "ProductServiceId",
+                "ProductServiceName": "ProductServiceName",
+                "Description": "Description",
+                "Quantity": "Quantity",
+                "UnitPrice": "UnitPrice",
+                "Amount": "Amount",
+                "AccountId": "AccountId",
+                "AccountName": "AccountName",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            }
+        },
+        "creditmemolines_write": {
+            "source": "dbo.CreditMemoLines",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "create",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "CreditMemoId": "CreditMemoId",
+                "ProductServiceId": "ProductServiceId",
+                "Description": "Description",
+                "Quantity": "Quantity",
+                "UnitPrice": "UnitPrice",
+                "Amount": "Amount",
+                "AccountId": "AccountId"
+            },
+            "key-fields": [
+                "Id"
+            ]
+        },
+        "creditapplications": {
+            "source": {
+                "object": "dbo.v_CreditApplications",
+                "type": "view",
+                "key-fields": [
+                    "Id"
+                ]
+            },
+            "graphql": {
+                "enabled": true
+            },
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "CreditMemoId": "CreditMemoId",
+                "CreditMemoNumber": "CreditMemoNumber",
+                "InvoiceId": "InvoiceId",
+                "InvoiceNumber": "InvoiceNumber",
+                "AmountApplied": "AmountApplied",
+                "ApplicationDate": "ApplicationDate",
+                "JournalEntryId": "JournalEntryId",
+                "CreatedAt": "CreatedAt",
+                "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName"
+            }
+        },
+        "creditapplications_write": {
+            "source": "dbo.CreditApplications",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "create",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "CreditMemoId": "CreditMemoId",
+                "InvoiceId": "InvoiceId",
+                "AmountApplied": "AmountApplied",
+                "ApplicationDate": "ApplicationDate",
+                "JournalEntryId": "JournalEntryId"
+            },
+            "key-fields": [
+                "Id"
+            ]
+        },
+        "refunds": {
+            "source": {
+                "object": "dbo.v_Refunds",
+                "type": "view",
+                "key-fields": [
+                    "Id"
+                ]
+            },
+            "graphql": {
+                "enabled": true
+            },
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "RefundNumber": "RefundNumber",
+                "CustomerId": "CustomerId",
+                "CustomerName": "CustomerName",
+                "CreditMemoId": "CreditMemoId",
+                "CreditMemoNumber": "CreditMemoNumber",
+                "RefundDate": "RefundDate",
+                "Amount": "Amount",
+                "PaymentMethod": "PaymentMethod",
+                "PaymentAccountId": "PaymentAccountId",
+                "PaymentAccountName": "PaymentAccountName",
+                "Memo": "Memo",
+                "Status": "Status",
+                "JournalEntryId": "JournalEntryId",
+                "CreatedAt": "CreatedAt"
+            }
+        },
+        "refunds_write": {
+            "source": "dbo.Refunds",
+            "permissions": [
+                {
+                    "role": "anonymous",
+                    "actions": [
+                        "create",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "RefundNumber": "RefundNumber",
+                "CustomerId": "CustomerId",
+                "CreditMemoId": "CreditMemoId",
+                "RefundDate": "RefundDate",
+                "Amount": "Amount",
+                "PaymentMethod": "PaymentMethod",
+                "PaymentAccountId": "PaymentAccountId",
+                "Memo": "Memo",
+                "Status": "Status",
+                "JournalEntryId": "JournalEntryId"
+            },
+            "key-fields": [
+                "Id"
+            ]
         }
     }
 }

--- a/database/AccountingDB.sqlproj
+++ b/database/AccountingDB.sqlproj
@@ -40,6 +40,9 @@
     <Build Include="dbo\Tables\Classes.sql" />
     <Build Include="dbo\Tables\Companies.sql" />
     <Build Include="dbo\Tables\CompanyFeatureFlags.sql" />
+    <Build Include="dbo\Tables\CreditApplications.sql" />
+    <Build Include="dbo\Tables\CreditMemoLines.sql" />
+    <Build Include="dbo\Tables\CreditMemos.sql" />
     <Build Include="dbo\Tables\CustomerDeposits.sql" />
     <Build Include="dbo\Tables\Customers.sql" />
     <Build Include="dbo\Tables\DepositApplications.sql" />
@@ -86,6 +89,7 @@
     <Build Include="dbo\Tables\ReconciliationItems.sql" />
     <Build Include="dbo\Tables\RecurringSchedules.sql" />
     <Build Include="dbo\Tables\RecurringTemplates.sql" />
+    <Build Include="dbo\Tables\Refunds.sql" />
     <Build Include="dbo\Tables\Roles.sql" />
     <Build Include="dbo\Tables\StateTaxReciprocity.sql" />
     <Build Include="dbo\Tables\SubmissionAttachments.sql" />
@@ -107,6 +111,9 @@
     <Build Include="dbo\Views\v_BankTransactionImports.sql" />
     <Build Include="dbo\Views\v_BankTransactionMatches.sql" />
     <Build Include="dbo\Views\v_BillPaymentApplications.sql" />
+    <Build Include="dbo\Views\v_CreditApplications.sql" />
+    <Build Include="dbo\Views\v_CreditMemoLines.sql" />
+    <Build Include="dbo\Views\v_CreditMemos.sql" />
     <Build Include="dbo\Views\v_BillPayments.sql" />
     <Build Include="dbo\Views\v_CustomerDeposits.sql" />
     <Build Include="dbo\Views\v_DepositApplications.sql" />
@@ -125,6 +132,7 @@
     <Build Include="dbo\Views\v_Projects.sql" />
     <Build Include="dbo\Views\v_PurchaseOrders.sql" />
     <Build Include="dbo\Views\v_Receipts.sql" />
+    <Build Include="dbo\Views\v_Refunds.sql" />
     <Build Include="dbo\Views\v_TimeEntries.sql" />
     <Build Include="dbo\Views\v_VendorCreditApplications.sql" />
     <Build Include="dbo\Views\v_VendorCredits.sql" />

--- a/database/dbo/Tables/CreditApplications.sql
+++ b/database/dbo/Tables/CreditApplications.sql
@@ -1,0 +1,25 @@
+CREATE TABLE [dbo].[CreditApplications]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [CreditMemoId] UNIQUEIDENTIFIER NOT NULL,
+    [InvoiceId] UNIQUEIDENTIFIER NOT NULL,
+    [AmountApplied] DECIMAL(19,4) NOT NULL,
+    [ApplicationDate] DATE NOT NULL,
+    [JournalEntryId] UNIQUEIDENTIFIER NULL,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_CreditApplications_CreditMemos] FOREIGN KEY ([CreditMemoId]) REFERENCES [dbo].[CreditMemos]([Id]),
+    CONSTRAINT [FK_CreditApplications_Invoices] FOREIGN KEY ([InvoiceId]) REFERENCES [dbo].[Invoices]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[CreditApplications_History]))
+GO
+
+CREATE INDEX [IX_CreditApplications_CreditMemoId] ON [dbo].[CreditApplications]([CreditMemoId])
+GO
+
+CREATE INDEX [IX_CreditApplications_InvoiceId] ON [dbo].[CreditApplications]([InvoiceId])
+GO

--- a/database/dbo/Tables/CreditMemoLines.sql
+++ b/database/dbo/Tables/CreditMemoLines.sql
@@ -1,0 +1,29 @@
+CREATE TABLE [dbo].[CreditMemoLines]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [CreditMemoId] UNIQUEIDENTIFIER NOT NULL,
+    [ProductServiceId] UNIQUEIDENTIFIER NULL,
+    [Description] NVARCHAR(500) NULL,
+    [Quantity] DECIMAL(18,4) NOT NULL DEFAULT 1,
+    [UnitPrice] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [Amount] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [AccountId] UNIQUEIDENTIFIER NULL,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_CreditMemoLines_CreditMemos] FOREIGN KEY ([CreditMemoId]) REFERENCES [dbo].[CreditMemos]([Id]) ON DELETE CASCADE,
+    CONSTRAINT [FK_CreditMemoLines_ProductsServices] FOREIGN KEY ([ProductServiceId]) REFERENCES [dbo].[ProductsServices]([Id]),
+    CONSTRAINT [FK_CreditMemoLines_Accounts] FOREIGN KEY ([AccountId]) REFERENCES [dbo].[Accounts]([Id])
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[CreditMemoLines_History]))
+GO
+
+CREATE INDEX [IX_CreditMemoLines_CreditMemoId] ON [dbo].[CreditMemoLines]([CreditMemoId])
+GO
+
+CREATE INDEX [IX_CreditMemoLines_AccountId] ON [dbo].[CreditMemoLines]([AccountId])
+GO

--- a/database/dbo/Tables/CreditMemos.sql
+++ b/database/dbo/Tables/CreditMemos.sql
@@ -1,0 +1,39 @@
+CREATE TABLE [dbo].[CreditMemos]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [CreditMemoNumber] NVARCHAR(50) NOT NULL,
+    [CustomerId] UNIQUEIDENTIFIER NOT NULL,
+    [CreditDate] DATE NOT NULL,
+    [Reason] NVARCHAR(500) NULL,
+    [Subtotal] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [TaxAmount] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [TotalAmount] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [AmountApplied] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [AmountRefunded] DECIMAL(19,4) NOT NULL DEFAULT 0,
+    [Status] NVARCHAR(20) NOT NULL DEFAULT 'Open',
+    [JournalEntryId] UNIQUEIDENTIFIER NULL,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_CreditMemos_Customers] FOREIGN KEY ([CustomerId]) REFERENCES [dbo].[Customers]([Id]),
+    CONSTRAINT [FK_CreditMemos_JournalEntries] FOREIGN KEY ([JournalEntryId]) REFERENCES [dbo].[JournalEntries]([Id]),
+    CONSTRAINT [CK_CreditMemos_Status] CHECK ([Status] IN ('Open', 'Applied', 'PartiallyApplied', 'Refunded', 'Voided'))
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[CreditMemos_History]))
+GO
+
+CREATE INDEX [IX_CreditMemos_CustomerId] ON [dbo].[CreditMemos]([CustomerId])
+GO
+
+CREATE INDEX [IX_CreditMemos_Status] ON [dbo].[CreditMemos]([Status])
+GO
+
+CREATE INDEX [IX_CreditMemos_CreditDate] ON [dbo].[CreditMemos]([CreditDate])
+GO
+
+CREATE UNIQUE INDEX [IX_CreditMemos_CreditMemoNumber] ON [dbo].[CreditMemos]([CreditMemoNumber])
+GO

--- a/database/dbo/Tables/Refunds.sql
+++ b/database/dbo/Tables/Refunds.sql
@@ -1,0 +1,36 @@
+CREATE TABLE [dbo].[Refunds]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [RefundNumber] NVARCHAR(50) NOT NULL,
+    [CustomerId] UNIQUEIDENTIFIER NOT NULL,
+    [CreditMemoId] UNIQUEIDENTIFIER NOT NULL,
+    [RefundDate] DATE NOT NULL,
+    [Amount] DECIMAL(19,4) NOT NULL,
+    [PaymentMethod] NVARCHAR(50) NULL,
+    [PaymentAccountId] UNIQUEIDENTIFIER NULL,
+    [Memo] NVARCHAR(500) NULL,
+    [Status] NVARCHAR(20) NOT NULL DEFAULT 'Pending',
+    [JournalEntryId] UNIQUEIDENTIFIER NULL,
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    CONSTRAINT [FK_Refunds_Customers] FOREIGN KEY ([CustomerId]) REFERENCES [dbo].[Customers]([Id]),
+    CONSTRAINT [FK_Refunds_CreditMemos] FOREIGN KEY ([CreditMemoId]) REFERENCES [dbo].[CreditMemos]([Id]),
+    CONSTRAINT [FK_Refunds_PaymentAccount] FOREIGN KEY ([PaymentAccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_Refunds_JournalEntries] FOREIGN KEY ([JournalEntryId]) REFERENCES [dbo].[JournalEntries]([Id]),
+    CONSTRAINT [CK_Refunds_Status] CHECK ([Status] IN ('Pending', 'Completed', 'Voided'))
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[Refunds_History]))
+GO
+
+CREATE INDEX [IX_Refunds_CustomerId] ON [dbo].[Refunds]([CustomerId])
+GO
+
+CREATE INDEX [IX_Refunds_CreditMemoId] ON [dbo].[Refunds]([CreditMemoId])
+GO
+
+CREATE UNIQUE INDEX [IX_Refunds_RefundNumber] ON [dbo].[Refunds]([RefundNumber])
+GO

--- a/database/dbo/Views/v_CreditApplications.sql
+++ b/database/dbo/Views/v_CreditApplications.sql
@@ -1,0 +1,19 @@
+CREATE VIEW [dbo].[v_CreditApplications]
+AS
+SELECT
+    ca.[Id],
+    ca.[CreditMemoId],
+    cm.[CreditMemoNumber],
+    ca.[InvoiceId],
+    i.[InvoiceNumber],
+    ca.[AmountApplied],
+    ca.[ApplicationDate],
+    ca.[JournalEntryId],
+    ca.[CreatedAt],
+    cm.[CustomerId],
+    c.[Name] AS CustomerName
+FROM [dbo].[CreditApplications] ca
+INNER JOIN [dbo].[CreditMemos] cm ON ca.[CreditMemoId] = cm.[Id]
+INNER JOIN [dbo].[Invoices] i ON ca.[InvoiceId] = i.[Id]
+LEFT JOIN [dbo].[Customers] c ON cm.[CustomerId] = c.[Id]
+GO

--- a/database/dbo/Views/v_CreditMemoLines.sql
+++ b/database/dbo/Views/v_CreditMemoLines.sql
@@ -1,0 +1,21 @@
+CREATE VIEW [dbo].[v_CreditMemoLines]
+AS
+SELECT
+    cml.[Id],
+    cml.[CreditMemoId],
+    cm.[CreditMemoNumber],
+    cml.[ProductServiceId],
+    ps.[Name] AS ProductServiceName,
+    cml.[Description],
+    cml.[Quantity],
+    cml.[UnitPrice],
+    cml.[Amount],
+    cml.[AccountId],
+    a.[Name] AS AccountName,
+    cml.[CreatedAt],
+    cml.[UpdatedAt]
+FROM [dbo].[CreditMemoLines] cml
+INNER JOIN [dbo].[CreditMemos] cm ON cml.[CreditMemoId] = cm.[Id]
+LEFT JOIN [dbo].[ProductsServices] ps ON cml.[ProductServiceId] = ps.[Id]
+LEFT JOIN [dbo].[Accounts] a ON cml.[AccountId] = a.[Id]
+GO

--- a/database/dbo/Views/v_CreditMemos.sql
+++ b/database/dbo/Views/v_CreditMemos.sql
@@ -1,0 +1,24 @@
+CREATE VIEW [dbo].[v_CreditMemos]
+AS
+SELECT
+    cm.[Id],
+    cm.[CreditMemoNumber],
+    cm.[CustomerId],
+    c.[Name] AS CustomerName,
+    cm.[CreditDate],
+    cm.[Reason],
+    cm.[Subtotal],
+    cm.[TaxAmount],
+    cm.[TotalAmount],
+    cm.[AmountApplied],
+    cm.[AmountRefunded],
+    (cm.[TotalAmount] - cm.[AmountApplied] - cm.[AmountRefunded]) AS BalanceRemaining,
+    cm.[Status],
+    cm.[JournalEntryId],
+    je.[Reference] AS JournalEntryReference,
+    cm.[CreatedAt],
+    cm.[UpdatedAt]
+FROM [dbo].[CreditMemos] cm
+LEFT JOIN [dbo].[Customers] c ON cm.[CustomerId] = c.[Id]
+LEFT JOIN [dbo].[JournalEntries] je ON cm.[JournalEntryId] = je.[Id]
+GO

--- a/database/dbo/Views/v_Refunds.sql
+++ b/database/dbo/Views/v_Refunds.sql
@@ -1,0 +1,23 @@
+CREATE VIEW [dbo].[v_Refunds]
+AS
+SELECT
+    r.[Id],
+    r.[RefundNumber],
+    r.[CustomerId],
+    c.[Name] AS CustomerName,
+    r.[CreditMemoId],
+    cm.[CreditMemoNumber],
+    r.[RefundDate],
+    r.[Amount],
+    r.[PaymentMethod],
+    r.[PaymentAccountId],
+    a.[Name] AS PaymentAccountName,
+    r.[Memo],
+    r.[Status],
+    r.[JournalEntryId],
+    r.[CreatedAt]
+FROM [dbo].[Refunds] r
+LEFT JOIN [dbo].[Customers] c ON r.[CustomerId] = c.[Id]
+LEFT JOIN [dbo].[CreditMemos] cm ON r.[CreditMemoId] = cm.[Id]
+LEFT JOIN [dbo].[Accounts] a ON r.[PaymentAccountId] = a.[Id]
+GO


### PR DESCRIPTION
## Summary
- Add database tables for CreditMemos, CreditMemoLines, CreditApplications, and Refunds with system versioning, foreign keys, and indexes
- Add SQL views (v_CreditMemos, v_CreditMemoLines, v_CreditApplications, v_Refunds) joining related data for display
- Add DAB API endpoints (read-only views + _write tables for CRUD) for all four entities
- Add frontend pages: CreditMemos list (MUI DataGrid), NewCreditMemo form with line items, and ApplyCreditMemo page to apply credits to open invoices
- Add Credit Memos navigation item under Sales section

## Test plan
- [ ] Verify database tables deploy correctly via SqlPackage
- [ ] Verify DAB endpoints respond correctly for all eight entities (creditmemos, creditmemos_write, creditmemolines, creditmemolines_write, creditapplications, creditapplications_write, refunds, refunds_write)
- [ ] Create a new credit memo with line items and verify it saves
- [ ] Apply a credit memo to an open invoice and verify amounts update correctly
- [ ] Verify the Credit Memos list page displays data with proper formatting
- [ ] Verify TypeScript compiles without errors (npx tsc --noEmit passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)