### PR TITLE
fix: Display 'Milton' instead of 'Assistant' in chat messages

### DIFF
--- a/client/src/components/ChatInterface.tsx
+++ b/client/src/components/ChatInterface.tsx
@@ -332,7 +332,7 @@ function CopyAllButton({ messages }: { messages: Array<{ role: string; content: 
     const formattedMessages = messages.map(msg => {
       const date = msg.timestamp.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
       const time = msg.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-      const speaker = msg.role === 'user' ? 'You' : 'Assistant';
+      const speaker = msg.role === 'user' ? 'You' : 'Milton';
       return `[${date} ${time}] ${speaker}:\n${msg.content}`;
     }).join('\n\n---\n\n');
 


### PR DESCRIPTION
## Summary
When copying the conversation, messages from the AI assistant are now labeled as "Milton" instead of "Assistant".

## Context
Milton is the name of the AI accounting assistant, inspired by Milton Friedman, the Nobel Prize-winning economist.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)