### PR TITLE
feat: Add Azure Automation for off-hours App Service scheduling

### DIFF
--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -1,0 +1,296 @@
+# Azure Deployment Guide for Modern Accounting
+
+This guide covers deploying Modern Accounting to Azure for A CTO, LLC.
+
+## Target Environment
+
+| Setting | Value |
+|---------|-------|
+| Tenant | A CTO, LLC (`f8ac75ce-d250-407e-b8cb-e05f5b4cd913`) |
+| Subscription | MCPP Subscription (`a6f5a418-461f-42c0-a07a-90142521e5fb`) |
+| Environment | prod |
+| Region | East US |
+| Timezone | Pacific Time (America/Los_Angeles) |
+
+## Cost Estimate
+
+| Resource | Tier | Monthly Cost |
+|----------|------|--------------|
+| App Service | B1 Basic | ~$13 (or ~$4 with off-hours stop) |
+| SQL Database | Serverless GP_S_Gen5_1 | ~$5-15 |
+| Storage Account | Standard_LRS | ~$0.50 |
+| Key Vault | Standard | ~$0.03 |
+| Azure OpenAI | S0 (pay-per-use) | ~$0-5 |
+| SendGrid | Free | $0 |
+| App Insights | Free tier | $0 |
+| Azure Automation | Free tier | $0 (500 min/month free) |
+| **Total (24/7)** | | **~$19-34/month** |
+| **Total (off-hours stop)** | | **~$10-25/month** |
+
+## Prerequisites
+
+1. Azure CLI installed and authenticated
+2. Contributor access to the subscription
+3. Node.js 20+ installed
+4. PowerShell (for runbook scripts)
+
+## Deployment Steps
+
+### Step 1: Login to Azure
+
+```powershell
+az login --tenant f8ac75ce-d250-407e-b8cb-e05f5b4cd913
+az account set --subscription a6f5a418-461f-42c0-a07a-90142521e5fb
+```
+
+### Step 2: Generate SQL Password
+
+```powershell
+# Generate a 32-character secure random password
+$sqlPassword = -join ((65..90) + (97..122) + (48..57) | Get-Random -Count 32 | ForEach-Object {[char]$_})
+Write-Output "SQL Password: $sqlPassword"
+# IMPORTANT: Save this password securely - you'll need it for deployment and database access
+```
+
+### Step 3: Deploy Infrastructure
+
+```powershell
+az deployment sub create `
+  --name "modern-accounting-prod-$(Get-Date -Format yyyyMMdd)" `
+  --location eastus `
+  --template-file infra/azure/main.bicep `
+  --parameters infra/azure/parameters/prod.bicepparam `
+  --parameters sqlAdminLogin=sqladmin sqlAdminPassword=$sqlPassword
+```
+
+This deploys:
+- Resource Group: `rg-modern-accounting-prod`
+- Key Vault: `kv-modern-accounting-prod`
+- Storage Account: `stmodernaccountingprod`
+- SQL Server: `sql-modern-accounting-prod`
+- SQL Database: `AccountingDB`
+- App Service Plan: `plan-modern-accounting-prod`
+- App Service: `app-modern-accounting-prod`
+- MCP Service: `mcp-ma-modern-accounting-prod`
+- Azure OpenAI: `oai-modern-accounting-prod`
+- SendGrid: `sendgrid-modern-accounting-prod`
+- Automation Account: `auto-modern-accounting-prod`
+
+### Step 4: Upload Runbook Scripts
+
+After infrastructure deployment, upload the PowerShell runbook scripts:
+
+```powershell
+# Upload and publish Stop runbook
+az automation runbook replace-content `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name StopAppServices `
+  --content @infra/scripts/Stop-AppServices.ps1
+
+az automation runbook publish `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name StopAppServices
+
+# Upload and publish Start runbook
+az automation runbook replace-content `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name StartAppServices `
+  --content @infra/scripts/Start-AppServices.ps1
+
+az automation runbook publish `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name StartAppServices
+```
+
+### Step 5: Link Runbooks to Schedules
+
+After publishing runbooks, link them to the schedules:
+
+```powershell
+# Link Stop runbook to Stop schedule
+az automation job-schedule create `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --runbook-name StopAppServices `
+  --schedule-name StopSchedule-Weekdays
+
+# Link Start runbook to Start schedule
+az automation job-schedule create `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --runbook-name StartAppServices `
+  --schedule-name StartSchedule-Weekdays
+```
+
+### Step 6: Deploy Database Schema
+
+Add your IP to the SQL Server firewall:
+
+```powershell
+$myIp = (Invoke-WebRequest -Uri "https://ifconfig.me/ip").Content.Trim()
+az sql server firewall-rule create `
+  --resource-group rg-modern-accounting-prod `
+  --server sql-modern-accounting-prod `
+  --name AllowMyIP `
+  --start-ip-address $myIp `
+  --end-ip-address $myIp
+```
+
+Deploy the database schema:
+
+```powershell
+$env:SQL_SERVER = "sql-modern-accounting-prod.database.windows.net"
+$env:SQL_PORT = "1433"
+$env:SQL_USER = "sqladmin"
+$env:SQL_SA_PASSWORD = $sqlPassword
+$env:SQL_DATABASE = "AccountingDB"
+
+node scripts/deploy-db.js --node
+```
+
+### Step 7: Deploy Application
+
+Build and deploy the application:
+
+```powershell
+# Build client
+cd client
+npm ci
+npm run build
+
+# Prepare API
+cd ../chat-api
+npm ci --production
+
+# Create deployment package
+cd ..
+Compress-Archive -Path chat-api/* -DestinationPath deploy.zip -Force
+
+# Deploy to App Service
+az webapp deployment source config-zip `
+  --resource-group rg-modern-accounting-prod `
+  --name app-modern-accounting-prod `
+  --src deploy.zip
+```
+
+## Schedule Summary (Pacific Time)
+
+| Day | Start (PT) | Stop (PT) | Hours Running |
+|-----|-----------|-----------|---------------|
+| Mon-Fri | 7:00 AM | 6:00 PM | 11 hours |
+| Sat-Sun | (stopped) | (stopped) | 0 hours |
+
+**Weekly hours:** 55 hours (vs 168 hours 24/7) = **67% cost reduction on App Service**
+
+## Verification
+
+### Check Infrastructure
+
+```powershell
+# List all resources in the resource group
+az resource list --resource-group rg-modern-accounting-prod --output table
+
+# Check automation account
+az automation account show `
+  --name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod
+
+# List schedules
+az automation schedule list `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --output table
+```
+
+### Check Application
+
+```powershell
+# Get App Service URL
+az webapp show `
+  --name app-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --query "defaultHostName" -o tsv
+
+# Test health endpoint
+curl https://app-modern-accounting-prod.azurewebsites.net/health
+```
+
+## Manual Operations
+
+### Manual Start/Stop
+
+```powershell
+# Manual stop
+az webapp stop --resource-group rg-modern-accounting-prod --name app-modern-accounting-prod
+az webapp stop --resource-group rg-modern-accounting-prod --name mcp-ma-modern-accounting-prod
+
+# Manual start
+az webapp start --resource-group rg-modern-accounting-prod --name app-modern-accounting-prod
+az webapp start --resource-group rg-modern-accounting-prod --name mcp-ma-modern-accounting-prod
+```
+
+### Check Automation Jobs
+
+```powershell
+# List recent jobs
+az automation job list `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --output table
+
+# Get job details
+az automation job show `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name <job-name>
+```
+
+### Test Runbooks Manually
+
+```powershell
+# Test stop runbook
+az automation runbook start `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name StopAppServices
+
+# Test start runbook
+az automation runbook start `
+  --automation-account-name auto-modern-accounting-prod `
+  --resource-group rg-modern-accounting-prod `
+  --name StartAppServices
+```
+
+## Troubleshooting
+
+### App Service Not Starting
+
+1. Check the automation job output in Azure Portal
+2. Verify the managed identity has Website Contributor role
+3. Check App Service logs: `az webapp log tail --name app-modern-accounting-prod --resource-group rg-modern-accounting-prod`
+
+### Schedule Not Running
+
+1. Verify schedule is enabled in Azure Portal
+2. Check that runbook is published (not draft)
+3. Verify job schedule link exists
+
+### Database Connection Issues
+
+1. Verify firewall rules allow App Service IP
+2. Check connection string in Key Vault
+3. Wake up serverless database: `az sql db show --name AccountingDB --server sql-modern-accounting-prod --resource-group rg-modern-accounting-prod`
+
+## Resource Cleanup
+
+To delete all resources:
+
+```powershell
+az group delete --name rg-modern-accounting-prod --yes --no-wait
+```
+
+**Warning:** This is irreversible and will delete all data.

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -185,6 +185,29 @@ module sendGrid 'modules/sendgrid.bicep' = {
 }
 
 // -----------------------------------------------------------------------------
+// Azure Automation Module (Start/Stop Scheduling)
+// Reduces costs by stopping App Services during off-hours (6 PM - 7 AM PT)
+// Only deployed for non-dev environments
+// -----------------------------------------------------------------------------
+
+module automation 'modules/automation.bicep' = if (environment != 'dev') {
+  name: 'automation-${uniqueSuffix}'
+  scope: resourceGroup
+  params: {
+    name: 'auto-${baseName}-${environment}'
+    location: location
+    tags: tags
+    appServiceResourceGroup: resourceGroupName
+    appServiceNames: [
+      'app-${baseName}-${environment}'
+      'mcp-ma-${baseName}-${environment}'
+    ]
+    startTime: '07:00'
+    stopTime: '18:00'
+  }
+}
+
+// -----------------------------------------------------------------------------
 // Outputs
 // -----------------------------------------------------------------------------
 
@@ -199,3 +222,4 @@ output appServicePrincipalId string = appService.outputs.principalId
 output maMcpServerUrl string = maMcpServer.outputs.serviceUrl
 output openAIEndpoint string = openAI.outputs.openAIEndpoint
 output openAIDeploymentName string = openAI.outputs.gpt4oDeploymentName
+output automationAccountName string = automation.?outputs.?automationAccountName ?? ''

--- a/infra/azure/modules/automation.bicep
+++ b/infra/azure/modules/automation.bicep
@@ -1,0 +1,163 @@
+// =============================================================================
+// Azure Automation Account Module
+// Start/Stop scheduling for App Services to reduce costs during off-hours
+// =============================================================================
+
+@description('Name of the automation account')
+param name string
+
+@description('Location for the automation account')
+param location string
+
+@description('Tags to apply')
+param tags object
+
+@description('App Service names to manage')
+param appServiceNames array
+
+@description('Resource group name for the App Services')
+param appServiceResourceGroup string
+
+@description('Start time in Pacific Time (HH:mm)')
+param startTime string = '07:00'
+
+@description('Stop time in Pacific Time (HH:mm)')
+param stopTime string = '18:00'
+
+@description('Base timestamp for schedule start (used to calculate tomorrow)')
+param baseTime string = utcNow('yyyy-MM-dd')
+
+// -----------------------------------------------------------------------------
+// Automation Account
+// Free tier includes 500 minutes/month of job runtime
+// -----------------------------------------------------------------------------
+
+resource automationAccount 'Microsoft.Automation/automationAccounts@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    sku: {
+      name: 'Free'
+    }
+    publicNetworkAccess: true
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Runbooks - Created as empty shells, content uploaded via Azure CLI
+// -----------------------------------------------------------------------------
+
+resource stopRunbook 'Microsoft.Automation/automationAccounts/runbooks@2023-11-01' = {
+  parent: automationAccount
+  name: 'StopAppServices'
+  location: location
+  properties: {
+    runbookType: 'PowerShell'
+    logProgress: true
+    logVerbose: false
+    description: 'Stops App Services during off-hours (6 PM PT weekdays)'
+  }
+}
+
+resource startRunbook 'Microsoft.Automation/automationAccounts/runbooks@2023-11-01' = {
+  parent: automationAccount
+  name: 'StartAppServices'
+  location: location
+  properties: {
+    runbookType: 'PowerShell'
+    logProgress: true
+    logVerbose: false
+    description: 'Starts App Services in the morning (7 AM PT weekdays)'
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Variables - Store configuration used by runbooks
+// -----------------------------------------------------------------------------
+
+resource resourceGroupVar 'Microsoft.Automation/automationAccounts/variables@2023-11-01' = {
+  parent: automationAccount
+  name: 'ResourceGroupName'
+  properties: {
+    value: '"${appServiceResourceGroup}"'
+    isEncrypted: false
+    description: 'Resource group containing the App Services'
+  }
+}
+
+resource appServiceNamesVar 'Microsoft.Automation/automationAccounts/variables@2023-11-01' = {
+  parent: automationAccount
+  name: 'AppServiceNames'
+  properties: {
+    value: '"${join(appServiceNames, ',')}"'
+    isEncrypted: false
+    description: 'Comma-separated list of App Service names to manage'
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Schedules - Pacific Time (America/Los_Angeles)
+// Note: Schedules are created but job links require published runbooks
+// -----------------------------------------------------------------------------
+
+// Calculate tomorrow's date for schedule start (must be in the future)
+var tomorrow = dateTimeAdd(baseTime, 'P1D')
+
+resource stopSchedule 'Microsoft.Automation/automationAccounts/schedules@2023-11-01' = {
+  parent: automationAccount
+  name: 'StopSchedule-Weekdays'
+  properties: {
+    startTime: '${tomorrow}T${stopTime}:00-08:00'
+    expiryTime: '9999-12-31T23:59:59+00:00'
+    interval: 1
+    frequency: 'Week'
+    timeZone: 'America/Los_Angeles'
+    advancedSchedule: {
+      weekDays: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+    }
+  }
+}
+
+resource startSchedule 'Microsoft.Automation/automationAccounts/schedules@2023-11-01' = {
+  parent: automationAccount
+  name: 'StartSchedule-Weekdays'
+  properties: {
+    startTime: '${tomorrow}T${startTime}:00-08:00'
+    expiryTime: '9999-12-31T23:59:59+00:00'
+    interval: 1
+    frequency: 'Week'
+    timeZone: 'America/Los_Angeles'
+    advancedSchedule: {
+      weekDays: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Role Assignment - Website Contributor for App Service start/stop
+// -----------------------------------------------------------------------------
+
+resource websiteContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, automationAccount.id, 'Website Contributor')
+  properties: {
+    principalId: automationAccount.identity.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772') // Website Contributor
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Outputs
+// -----------------------------------------------------------------------------
+
+output automationAccountId string = automationAccount.id
+output automationAccountName string = automationAccount.name
+output automationPrincipalId string = automationAccount.identity.principalId
+output stopRunbookName string = stopRunbook.name
+output startRunbookName string = startRunbook.name
+output stopScheduleName string = stopSchedule.name
+output startScheduleName string = startSchedule.name

--- a/infra/azure/parameters/prod.bicepparam
+++ b/infra/azure/parameters/prod.bicepparam
@@ -1,6 +1,6 @@
 // =============================================================================
 // Production Environment Parameters
-// Optimized for small team (~3 users) with reliability (~$20-35/month)
+// Optimized for small team (~3 users) with reliability (~$10-25/month with off-hours stop)
 // =============================================================================
 
 using '../main.bicep'
@@ -10,23 +10,26 @@ param location = 'eastus'
 param baseName = 'modern-accounting'
 
 // App Service - Basic tier (supports custom domains, SSL, Always On)
+// Cost: ~$13/month (24/7) or ~$4/month (with off-hours stop)
 param appServiceSku = 'B1'
 
-// SQL Database - Serverless with longer auto-pause
-// Auto-pauses after 4 hours to balance cost vs user experience
+// SQL Database - Serverless with auto-pause
+// Auto-pauses after 1 hour to minimize costs
 // First query after pause takes ~30 seconds to resume
+// Cost: ~$5-15/month depending on usage
 param sqlDatabaseSku = 'GP_S_Gen5_1'
-param sqlAutoPauseDelayMinutes = 240
+param sqlAutoPauseDelayMinutes = 60
 
-// SendGrid - Bronze tier for production (40k emails/month)
-param sendGridAdminEmail = 'admin@a-cto.com'
+// SendGrid - Free tier for low-volume production
+// Upgrade to 'bronze' for 40k emails/month if needed
+param sendGridAdminEmail = 'support@a-cto.com'
 
 // Tags
 param tags = {
   application: 'modern-accounting'
   environment: 'prod'
   managedBy: 'bicep'
-  costCenter: 'production'
+  company: 'A CTO LLC'
 }
 
 // Secrets - These should be provided at deployment time

--- a/infra/scripts/Start-AppServices.ps1
+++ b/infra/scripts/Start-AppServices.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+    Starts Azure App Services in the morning to prepare for business hours.
+
+.DESCRIPTION
+    This runbook is triggered by Azure Automation at 7 AM PT (Monday-Friday).
+    It starts the specified App Services and performs a warm-up request.
+
+.NOTES
+    Author: Modern Accounting Team
+    Schedule: 7 AM PT, Monday-Friday
+    Uses Azure Automation managed identity for authentication.
+#>
+
+# Import required modules
+Import-Module Az.Accounts
+Import-Module Az.Websites
+
+# Get automation variables (set during Bicep deployment)
+$ResourceGroup = Get-AutomationVariable -Name 'ResourceGroupName'
+$AppServiceNamesString = Get-AutomationVariable -Name 'AppServiceNames'
+
+Write-Output "=============================================="
+Write-Output "Start App Services Runbook"
+Write-Output "Started: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') UTC"
+Write-Output "=============================================="
+
+# Authenticate using managed identity
+try {
+    Write-Output "Connecting to Azure using managed identity..."
+    Connect-AzAccount -Identity -ErrorAction Stop
+    Write-Output "Successfully authenticated to Azure."
+}
+catch {
+    Write-Error "Failed to authenticate: $_"
+    throw
+}
+
+# Parse App Service names
+$AppServiceNames = $AppServiceNamesString -split ','
+Write-Output "Resource Group: $ResourceGroup"
+Write-Output "App Services to start: $($AppServiceNames -join ', ')"
+Write-Output "----------------------------------------------"
+
+$successCount = 0
+$failCount = 0
+$startedApps = @()
+
+foreach ($appName in $AppServiceNames) {
+    $appName = $appName.Trim()
+    if ([string]::IsNullOrWhiteSpace($appName)) {
+        continue
+    }
+
+    Write-Output ""
+    Write-Output "Processing: $appName"
+
+    try {
+        # Check current state
+        $app = Get-AzWebApp -ResourceGroupName $ResourceGroup -Name $appName -ErrorAction Stop
+        Write-Output "  Current state: $($app.State)"
+
+        if ($app.State -ne 'Running') {
+            Write-Output "  Starting $appName..."
+            Start-AzWebApp -ResourceGroupName $ResourceGroup -Name $appName -ErrorAction Stop
+            Write-Output "  Successfully started $appName at $(Get-Date -Format 'HH:mm:ss') UTC"
+            $startedApps += @{
+                Name = $appName
+                Hostname = $app.DefaultHostName
+            }
+            $successCount++
+        }
+        else {
+            Write-Output "  $appName is already running. Skipping."
+            $startedApps += @{
+                Name = $appName
+                Hostname = $app.DefaultHostName
+            }
+            $successCount++
+        }
+    }
+    catch {
+        Write-Warning "  Failed to start $appName : $_"
+        $failCount++
+    }
+}
+
+# Warm-up requests
+Write-Output ""
+Write-Output "----------------------------------------------"
+Write-Output "Sending warm-up requests..."
+Write-Output "----------------------------------------------"
+
+# Wait for App Services to fully start
+Start-Sleep -Seconds 30
+
+foreach ($app in $startedApps) {
+    $warmupUrl = "https://$($app.Hostname)/health"
+    Write-Output ""
+    Write-Output "Warming up: $($app.Name)"
+    Write-Output "  URL: $warmupUrl"
+
+    try {
+        $response = Invoke-WebRequest -Uri $warmupUrl -UseBasicParsing -TimeoutSec 60 -ErrorAction Stop
+        Write-Output "  Response: $($response.StatusCode) - Warm-up successful"
+    }
+    catch {
+        # Non-critical - just log and continue
+        Write-Output "  Warm-up request sent (response: $($_.Exception.Message))"
+    }
+}
+
+Write-Output ""
+Write-Output "=============================================="
+Write-Output "Summary"
+Write-Output "=============================================="
+Write-Output "Successful: $successCount"
+Write-Output "Failed: $failCount"
+Write-Output "Completed: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') UTC"
+
+if ($failCount -gt 0) {
+    Write-Warning "Some App Services failed to start. Check the logs above."
+}
+else {
+    Write-Output "All App Services started successfully."
+}

--- a/infra/scripts/Stop-AppServices.ps1
+++ b/infra/scripts/Stop-AppServices.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Stops Azure App Services during off-hours to reduce costs.
+
+.DESCRIPTION
+    This runbook is triggered by Azure Automation at 6 PM PT (Monday-Friday).
+    It stops the specified App Services and logs the results.
+
+.NOTES
+    Author: Modern Accounting Team
+    Schedule: 6 PM PT, Monday-Friday
+    Uses Azure Automation managed identity for authentication.
+#>
+
+# Import required modules
+Import-Module Az.Accounts
+Import-Module Az.Websites
+
+# Get automation variables (set during Bicep deployment)
+$ResourceGroup = Get-AutomationVariable -Name 'ResourceGroupName'
+$AppServiceNamesString = Get-AutomationVariable -Name 'AppServiceNames'
+
+Write-Output "=============================================="
+Write-Output "Stop App Services Runbook"
+Write-Output "Started: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') UTC"
+Write-Output "=============================================="
+
+# Authenticate using managed identity
+try {
+    Write-Output "Connecting to Azure using managed identity..."
+    Connect-AzAccount -Identity -ErrorAction Stop
+    Write-Output "Successfully authenticated to Azure."
+}
+catch {
+    Write-Error "Failed to authenticate: $_"
+    throw
+}
+
+# Parse App Service names
+$AppServiceNames = $AppServiceNamesString -split ','
+Write-Output "Resource Group: $ResourceGroup"
+Write-Output "App Services to stop: $($AppServiceNames -join ', ')"
+Write-Output "----------------------------------------------"
+
+$successCount = 0
+$failCount = 0
+
+foreach ($appName in $AppServiceNames) {
+    $appName = $appName.Trim()
+    if ([string]::IsNullOrWhiteSpace($appName)) {
+        continue
+    }
+
+    Write-Output ""
+    Write-Output "Processing: $appName"
+
+    try {
+        # Check current state
+        $app = Get-AzWebApp -ResourceGroupName $ResourceGroup -Name $appName -ErrorAction Stop
+        Write-Output "  Current state: $($app.State)"
+
+        if ($app.State -eq 'Running') {
+            Write-Output "  Stopping $appName..."
+            Stop-AzWebApp -ResourceGroupName $ResourceGroup -Name $appName -ErrorAction Stop
+            Write-Output "  Successfully stopped $appName at $(Get-Date -Format 'HH:mm:ss') UTC"
+            $successCount++
+        }
+        else {
+            Write-Output "  $appName is already stopped. Skipping."
+            $successCount++
+        }
+    }
+    catch {
+        Write-Warning "  Failed to stop $appName : $_"
+        $failCount++
+    }
+}
+
+Write-Output ""
+Write-Output "=============================================="
+Write-Output "Summary"
+Write-Output "=============================================="
+Write-Output "Successful: $successCount"
+Write-Output "Failed: $failCount"
+Write-Output "Completed: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') UTC"
+
+if ($failCount -gt 0) {
+    Write-Warning "Some App Services failed to stop. Check the logs above."
+}
+else {
+    Write-Output "All App Services stopped successfully."
+}


### PR DESCRIPTION
## Summary

Adds cost-saving automation to stop App Services during off-hours, reducing compute costs by ~67%.

- **Azure Automation module** with Free tier (500 min/month included)
- **PowerShell runbooks** for start/stop using managed identity authentication
- **Pacific Time schedules**: 7 AM start, 6 PM stop (Monday-Friday)
- **Updated prod parameters**: B1 tier, 60-min SQL auto-pause, support@a-cto.com
- **Deployment documentation** with step-by-step instructions

## Cost Impact

| Scenario | Weekly Hours | Monthly App Service Cost |
|----------|--------------|-------------------------|
| 24/7 | 168 hours | ~$13 |
| Off-hours stop | 55 hours | ~$4 |
| **Savings** | **67%** | **~$9/month** |

## Files Changed

| File | Description |
|------|-------------|
| `infra/azure/modules/automation.bicep` | Azure Automation module |
| `infra/scripts/Stop-AppServices.ps1` | Stop runbook script |
| `infra/scripts/Start-AppServices.ps1` | Start runbook script |
| `infra/azure/main.bicep` | Added automation module reference |
| `infra/azure/parameters/prod.bicepparam` | Updated prod settings |
| `docs/azure-deployment.md` | Deployment guide |

## Security

- No secrets exposed in source code
- Uses Azure Managed Identity for authentication
- Passwords provided at deployment time (empty placeholders)
- `@secure()` decorators on sensitive parameters

## Test plan

- [ ] Validate Bicep templates: `az bicep build --file infra/azure/main.bicep`
- [ ] Deploy to dev/staging environment first
- [ ] Verify automation schedules created in Azure Portal
- [ ] Test manual runbook execution
- [ ] Verify App Services stop/start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)