### PR TITLE
fix(#395): Fix duplicate invoice 400 error

### DIFF
--- a/client/src/pages/Invoices.tsx
+++ b/client/src/pages/Invoices.tsx
@@ -82,8 +82,18 @@ export default function Invoices() {
         Status: 'Draft'
       };
 
-      const createResponse = await api.post<Invoice>('/invoices_write', newInvoice);
-      const createdInvoice = createResponse.data;
+      await api.post('/invoices_write', newInvoice);
+
+      // DAB doesn't return the created entity, so query for it by InvoiceNumber
+      const escapedInvoiceNumber = newInvoiceNumber.replace(/'/g, "''");
+      const queryResponse = await api.get<{ value: Invoice[] }>(
+        `/invoices?$filter=InvoiceNumber eq '${escapedInvoiceNumber}'`
+      );
+      const createdInvoice = queryResponse.data.value[0];
+
+      if (!createdInvoice?.Id) {
+        throw new Error('Failed to retrieve duplicated invoice');
+      }
 
       await Promise.all(
         originalLines.map(line =>

--- a/dab-config.json
+++ b/dab-config.json
@@ -557,6 +557,7 @@
                 {
                     "role": "authenticated",
                     "actions": [
+                        "create",
                         "read"
                     ]
                 },


### PR DESCRIPTION
## Summary
- **400 fix:** DAB REST POST doesn't return the created entity, so the duplicate flow was getting `undefined` for the new invoice ID. The subsequent `POST /invoicelines` with `InvoiceId: undefined` caused the 400. Fixed by querying for the created invoice by InvoiceNumber after creation, matching the pattern used by NewInvoice and Estimates→Invoice flows.
- **403 fix:** The `invoicelines` DAB entity only granted `read` to the `authenticated` role, while `invoices_write` granted `*`. This caused 403 on `POST /invoicelines` for any MSAL-authenticated user (affects all invoice creation flows, not just duplicate). Fixed by adding `create` to the `authenticated` role.

## Test plan
- [x] Duplicate an invoice from the Invoices list page — creates a new Draft invoice with copied line items
- [ ] Duplicate from the Edit Invoice page — same result
- [ ] Create a new invoice normally — confirm no regression
- [ ] Verify the duplicated invoice has correct customer, line items, and tax settings

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)