### PR TITLE
fix(#414,#399,#398,#411): Fix all theming issues across client

### DIFF
--- a/client/src/components/CustomerSelector.tsx
+++ b/client/src/components/CustomerSelector.tsx
@@ -1,7 +1,12 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronDown, Search, Loader2, RefreshCw, Plus } from 'lucide-react';
-import { customersApi } from '../lib/api';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import Paper from '@mui/material/Paper';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import { Plus } from 'lucide-react';
+import { customersApi, Customer } from '../lib/api';
 import QuickAddCustomerModal from './QuickAddCustomerModal';
 
 export interface CustomerSelectorProps {
@@ -21,249 +26,89 @@ export default function CustomerSelector({
   error,
   className = '',
 }: CustomerSelectorProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listItemsRef = useRef<(HTMLButtonElement | null)[]>([]);
 
-  // Fetch customers
-  const { data: customers, isLoading, isError, refetch } = useQuery({
+  const { data: customers, isLoading } = useQuery({
     queryKey: ['customers'],
     queryFn: customersApi.getAll,
   });
 
-  // Find selected customer
   const selectedCustomer = useMemo(() => {
-    return customers?.find((c) => c.Id === value);
+    return customers?.find((c: Customer) => c.Id === value) ?? null;
   }, [customers, value]);
-
-  // Filter customers based on search term
-  const filteredCustomers = useMemo(() => {
-    if (!customers) return [];
-    if (!searchTerm) return customers;
-
-    const lowerSearch = searchTerm.toLowerCase();
-    return customers.filter(
-      (customer) =>
-        customer.Name.toLowerCase().includes(lowerSearch) ||
-        (customer.Email && customer.Email.toLowerCase().includes(lowerSearch))
-    );
-  }, [customers, searchTerm]);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-        setSearchTerm('');
-        setFocusedIndex(-1);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // Focus search input when dropdown opens
-  useEffect(() => {
-    if (isOpen && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [isOpen]);
-
-  // Reset focused index when filtered list changes
-  useEffect(() => {
-    setFocusedIndex(-1);
-  }, [searchTerm]);
-
-  const handleSelect = (customerId: string) => {
-    onChange(customerId);
-    setIsOpen(false);
-    setSearchTerm('');
-    setFocusedIndex(-1);
-  };
 
   const handleCustomerCreated = (customerId: string) => {
     onChange(customerId);
-    setIsOpen(false);
-    setSearchTerm('');
-    setFocusedIndex(-1);
-  };
-
-  const handleOpenAddModal = () => {
-    setIsAddModalOpen(true);
-    setIsOpen(false);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      setIsOpen(false);
-      setSearchTerm('');
-      setFocusedIndex(-1);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      setFocusedIndex((prev) => {
-        const next = prev < filteredCustomers.length - 1 ? prev + 1 : prev;
-        if (next < listItemsRef.current.length) {
-          listItemsRef.current[next]?.scrollIntoView({ block: 'nearest' });
-        }
-        return next;
-      });
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      setFocusedIndex((prev) => {
-        const next = prev > 0 ? prev - 1 : -1;
-        if (next === -1) {
-          inputRef.current?.focus();
-        } else if (next >= 0 && next < listItemsRef.current.length) {
-          listItemsRef.current[next]?.scrollIntoView({ block: 'nearest' });
-        }
-        return next;
-      });
-    } else if (event.key === 'Enter' && focusedIndex >= 0 && focusedIndex < filteredCustomers.length) {
-      event.preventDefault();
-      handleSelect(filteredCustomers[focusedIndex].Id);
-    }
   };
 
   return (
-    <div ref={containerRef} className={`relative ${className}`}>
-      {/* Trigger button */}
-      <button
-        type="button"
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+    <div className={className}>
+      <Autocomplete
+        options={customers ?? []}
+        getOptionLabel={(option: Customer) =>
+          option.Name + (option.Email ? ` (${option.Email})` : '')
+        }
+        value={selectedCustomer}
+        onChange={(_event, newValue: Customer | null) => {
+          onChange(newValue?.Id ?? '');
+        }}
+        isOptionEqualToValue={(option: Customer, val: Customer) => option.Id === val.Id}
+        loading={isLoading}
         disabled={disabled}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        aria-controls="customer-listbox"
-        aria-required={required}
-        className={`
-          w-full flex items-center justify-between
-          mt-1 rounded-md border shadow-sm
-          focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
-          sm:text-sm p-2 text-left
-          ${disabled ? 'bg-gray-100 cursor-not-allowed' : 'bg-white cursor-pointer hover:bg-gray-50'}
-          ${error ? 'border-red-300' : 'border-gray-300'}
-        `}
-      >
-        <span className={selectedCustomer ? 'text-gray-900' : 'text-gray-500'}>
-          {isLoading ? (
-            <span className="flex items-center">
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              Loading customers...
-            </span>
-          ) : isError ? (
-            <span className="flex items-center text-red-600">
-              Error loading customers
-            </span>
-          ) : selectedCustomer ? (
-            <span>
-              {selectedCustomer.Name}
-              {selectedCustomer.Email && (
-                <span className="text-gray-500 ml-2">({selectedCustomer.Email})</span>
-              )}
-            </span>
-          ) : (
-            'Select a customer...'
-          )}
-        </span>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
-
-      {/* Dropdown */}
-      {isOpen && !disabled && (
-        <div
-          id="customer-listbox"
-          role="listbox"
-          aria-label="Customer selection"
-          className="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-gray-200 max-h-60 overflow-hidden"
-          onKeyDown={handleKeyDown}
-        >
-          {/* Search input */}
-          <div className="p-2 border-b border-gray-200">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-              <input
-                ref={inputRef}
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder="Search customers..."
-                aria-label="Search customers"
-                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-              />
-            </div>
-          </div>
-
-          {/* Customer list */}
-          <div className="max-h-48 overflow-y-auto">
-            {isLoading ? (
-              <div className="px-4 py-3 text-sm text-gray-500 flex items-center justify-center">
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                Loading...
+        size="small"
+        slots={{
+          paper: (props) => (
+            <Paper {...props}>
+              {props.children}
+              <Button
+                fullWidth
+                startIcon={<Plus className="w-4 h-4" />}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  setIsAddModalOpen(true);
+                }}
+                sx={{ justifyContent: 'center', py: 1, borderTop: 1, borderColor: 'divider' }}
+              >
+                Add New Customer
+              </Button>
+            </Paper>
+          ),
+        }}
+        renderOption={(props, option: Customer) => {
+          const { key, ...rest } = props;
+          return (
+            <li key={key} {...rest}>
+              <div>
+                <div className="font-medium">{option.Name}</div>
+                {option.Email && (
+                  <div className="text-xs opacity-60">{option.Email}</div>
+                )}
               </div>
-            ) : isError ? (
-              <div className="px-4 py-3 text-center">
-                <p className="text-sm text-red-600 mb-2">Error loading customers</p>
-                <button
-                  type="button"
-                  onClick={() => refetch()}
-                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 rounded-md transition-colors"
-                >
-                  <RefreshCw className="w-4 h-4 mr-1" />
-                  Retry
-                </button>
-              </div>
-            ) : filteredCustomers.length === 0 ? (
-              <div className="px-4 py-3 text-sm text-gray-500 text-center">
-                {searchTerm ? 'No customers found' : 'No customers available'}
-              </div>
-            ) : (
-              filteredCustomers.map((customer, index) => (
-                <button
-                  key={customer.Id}
-                  ref={(el) => (listItemsRef.current[index] = el)}
-                  type="button"
-                  role="option"
-                  aria-selected={customer.Id === value}
-                  onClick={() => handleSelect(customer.Id)}
-                  onMouseEnter={() => setFocusedIndex(index)}
-                  className={`
-                    w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-indigo-50 focus:bg-indigo-50 focus:outline-none
-                    ${customer.Id === value ? 'bg-indigo-100 text-indigo-900' : ''}
-                    ${focusedIndex === index ? 'bg-indigo-50' : ''}
-                  `}
-                >
-                  <div className="font-medium">{customer.Name}</div>
-                  {customer.Email && (
-                    <div className="text-xs text-gray-500">{customer.Email}</div>
-                  )}
-                </button>
-              ))
-            )}
-          </div>
+            </li>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            placeholder="Select a customer..."
+            required={required}
+            error={!!error}
+            helperText={error}
+            slotProps={{
+              input: {
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              },
+            }}
+          />
+        )}
+      />
 
-          {/* Add New Customer button */}
-          <div className="border-t border-gray-200 p-2">
-            <button
-              type="button"
-              onClick={handleOpenAddModal}
-              className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50 rounded-md transition-colors"
-            >
-              <Plus className="w-4 h-4" />
-              Add New Customer
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Error message */}
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
-
-      {/* Quick Add Customer Modal */}
       <QuickAddCustomerModal
         isOpen={isAddModalOpen}
         onClose={() => setIsAddModalOpen(false)}

--- a/client/src/components/EstimateForm.tsx
+++ b/client/src/components/EstimateForm.tsx
@@ -94,7 +94,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/estimates')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/estimates')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
           <ArrowLeft className="w-6 h-6" />
         </button>
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -199,7 +199,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
             <button
               type="button"
               onClick={() => append({ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0 })}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
+              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 dark:text-indigo-300 dark:bg-indigo-900/30 dark:hover:bg-indigo-800/50"
             >
               <Plus className="w-4 h-4 mr-1" />
               Add Item
@@ -220,10 +220,10 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
               };
 
               return (
-                <div key={field.id} className="bg-gray-50 p-4 rounded-md">
+                <div key={field.id} className="bg-gray-50 dark:bg-gray-700 p-4 rounded-md">
                   <div className="flex gap-4 items-start mb-3">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">Product/Service</label>
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">Product/Service</label>
                       <Controller
                         name={`Lines.${index}.ProductServiceId`}
                         control={control}
@@ -240,7 +240,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                   </div>
                   <div className="flex gap-4 items-start">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
                         Description <span className="text-red-500">*</span>
                       </label>
                       <input
@@ -249,11 +249,11 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                         placeholder="Item description"
                       />
                       {errors.Lines?.[index]?.Description && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Description?.message}</p>
+                        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errors.Lines[index]?.Description?.message}</p>
                       )}
                     </div>
                     <div className="w-24">
-                      <label className="block text-xs font-medium text-gray-500">
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
                         Qty <span className="text-red-500">*</span>
                       </label>
                       <input
@@ -264,11 +264,11 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                         className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
                       />
                       {errors.Lines?.[index]?.Quantity && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Quantity?.message}</p>
+                        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errors.Lines[index]?.Quantity?.message}</p>
                       )}
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
                         Unit Price <span className="text-red-500">*</span>
                       </label>
                       <input
@@ -279,12 +279,12 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                         className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
                       />
                       {errors.Lines?.[index]?.UnitPrice && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.UnitPrice?.message}</p>
+                        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errors.Lines[index]?.UnitPrice?.message}</p>
                       )}
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">Amount</label>
-                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium">
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">Amount</label>
+                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 dark:text-gray-300 font-medium">
                         ${((lines[index]?.Quantity || 0) * (lines[index]?.UnitPrice || 0)).toFixed(2)}
                       </div>
                     </div>
@@ -292,7 +292,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                       type="button"
                       onClick={() => remove(index)}
                       disabled={fields.length === 1}
-                      className="mt-6 text-red-600 hover:text-red-800 disabled:text-gray-300 disabled:cursor-not-allowed"
+                      className="mt-6 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 disabled:text-gray-300 dark:disabled:text-gray-500 disabled:cursor-not-allowed"
                       title={fields.length === 1 ? 'At least one line item is required' : 'Remove item'}
                     >
                       <Trash2 className="w-5 h-5" />
@@ -308,7 +308,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
         </div>
 
         <div className="flex justify-end items-center border-t pt-4">
-          <div className="text-xl font-bold text-gray-900 mr-6">
+          <div className="text-xl font-bold text-gray-900 dark:text-gray-100 mr-6">
             Total: ${lines.reduce((sum, line) => sum + (line.Quantity || 0) * (line.UnitPrice || 0), 0).toFixed(2)}
           </div>
           <button

--- a/client/src/components/ProductServiceSelector.tsx
+++ b/client/src/components/ProductServiceSelector.tsx
@@ -1,6 +1,9 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronDown, Search, Loader2, RefreshCw, Wrench, Box, Package } from 'lucide-react';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
+import { Wrench, Box, Package } from 'lucide-react';
 import Fuse from 'fuse.js';
 import api from '../lib/api';
 
@@ -32,6 +35,17 @@ const formatCurrency = (value: number | null) => {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
 };
 
+const getTypeIcon = (type: string) => {
+  switch (type) {
+    case 'Service':
+      return <Wrench className="w-4 h-4 text-blue-500 shrink-0" />;
+    case 'Inventory':
+      return <Box className="w-4 h-4 text-green-500 shrink-0" />;
+    default:
+      return <Package className="w-4 h-4 text-orange-500 shrink-0" />;
+  }
+};
+
 export default function ProductServiceSelector({
   value,
   onChange,
@@ -41,15 +55,7 @@ export default function ProductServiceSelector({
   className = '',
   placeholder = 'Select product/service...',
 }: ProductServiceSelectorProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listItemsRef = useRef<(HTMLButtonElement | null)[]>([]);
-
-  // Fetch products/services - only active ones
-  const { data: productsServices, isLoading, isError, refetch } = useQuery({
+  const { data: productsServices, isLoading } = useQuery({
     queryKey: ['productsservices-active'],
     queryFn: async (): Promise<ProductService[]> => {
       const response = await api.get('/productsservices?$filter=Status eq \'Active\'&$orderby=Name');
@@ -57,9 +63,8 @@ export default function ProductServiceSelector({
     },
   });
 
-  // Find selected product/service
   const selectedProductService = useMemo(() => {
-    return productsServices?.find((ps) => ps.Id === value);
+    return productsServices?.find((ps) => ps.Id === value) ?? null;
   }, [productsServices, value]);
 
   // Configure Fuse.js for fuzzy search
@@ -67,264 +72,87 @@ export default function ProductServiceSelector({
     if (!productsServices) return null;
     return new Fuse(productsServices, {
       keys: [
-        { name: 'Name', weight: 0.5 },      // Name matches weighted highest
-        { name: 'SKU', weight: 0.3 },       // SKU matches weighted medium
-        { name: 'Category', weight: 0.2 },  // Category matches weighted lower
+        { name: 'Name', weight: 0.5 },
+        { name: 'SKU', weight: 0.3 },
+        { name: 'Category', weight: 0.2 },
       ],
-      threshold: 0.4,        // 0 = exact match, 1 = match anything (0.4 is a good balance)
-      ignoreLocation: true,  // Match anywhere in string
-      includeScore: true,    // Include match score for debugging
+      threshold: 0.4,
+      ignoreLocation: true,
     });
   }, [productsServices]);
 
-  // Filter products/services based on search term using fuzzy search
-  const filteredProductsServices = useMemo(() => {
-    if (!productsServices) return [];
-    if (!searchTerm) return productsServices;
-    if (!fuse) return productsServices;
+  // Default MUI filter as fallback
+  const defaultFilter = createFilterOptions<ProductService>();
 
-    const results = fuse.search(searchTerm);
-    return results.map(result => result.item);
-  }, [productsServices, searchTerm, fuse]);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-        setSearchTerm('');
-        setFocusedIndex(-1);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // Focus search input when dropdown opens
-  useEffect(() => {
-    if (isOpen && inputRef.current) {
-      inputRef.current.focus();
+  const filterOptions = (options: ProductService[], state: Parameters<typeof defaultFilter>[1]) => {
+    if (!state.inputValue || !fuse) {
+      return defaultFilter(options, state);
     }
-  }, [isOpen]);
-
-  // Reset focused index when filtered list changes
-  useEffect(() => {
-    setFocusedIndex(-1);
-  }, [searchTerm]);
-
-  const handleSelect = (productService: ProductService) => {
-    onChange(productService.Id, productService);
-    setIsOpen(false);
-    setSearchTerm('');
-    setFocusedIndex(-1);
-  };
-
-  const handleClear = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onChange('', undefined);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      setIsOpen(false);
-      setSearchTerm('');
-      setFocusedIndex(-1);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      setFocusedIndex((prev) => {
-        const next = prev < filteredProductsServices.length - 1 ? prev + 1 : prev;
-        if (next < listItemsRef.current.length) {
-          listItemsRef.current[next]?.scrollIntoView({ block: 'nearest' });
-        }
-        return next;
-      });
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      setFocusedIndex((prev) => {
-        const next = prev > 0 ? prev - 1 : -1;
-        if (next === -1) {
-          inputRef.current?.focus();
-        } else if (next >= 0 && next < listItemsRef.current.length) {
-          listItemsRef.current[next]?.scrollIntoView({ block: 'nearest' });
-        }
-        return next;
-      });
-    } else if (event.key === 'Enter' && focusedIndex >= 0 && focusedIndex < filteredProductsServices.length) {
-      event.preventDefault();
-      handleSelect(filteredProductsServices[focusedIndex]);
-    }
-  };
-
-  const getTypeIcon = (type: string) => {
-    switch (type) {
-      case 'Service':
-        return <Wrench className="w-4 h-4 text-blue-500" />;
-      case 'Inventory':
-        return <Box className="w-4 h-4 text-green-500" />;
-      default:
-        return <Package className="w-4 h-4 text-orange-500" />;
-    }
+    return fuse.search(state.inputValue).map((result) => result.item);
   };
 
   return (
-    <div ref={containerRef} className={`relative ${className}`}>
-      {/* Trigger button */}
-      <button
-        type="button"
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+    <div className={className}>
+      <Autocomplete
+        options={productsServices ?? []}
+        getOptionLabel={(option: ProductService) => option.Name}
+        value={selectedProductService}
+        onChange={(_event, newValue: ProductService | null) => {
+          onChange(newValue?.Id ?? '', newValue ?? undefined);
+        }}
+        filterOptions={filterOptions}
+        isOptionEqualToValue={(option: ProductService, val: ProductService) => option.Id === val.Id}
+        loading={isLoading}
         disabled={disabled}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        aria-controls="product-service-listbox"
-        aria-required={required}
-        className={`
-          w-full flex items-center justify-between
-          rounded-md border shadow-sm
-          focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
-          sm:text-sm p-2 text-left
-          ${disabled ? 'bg-gray-100 cursor-not-allowed' : 'bg-white cursor-pointer hover:bg-gray-50'}
-          ${error ? 'border-red-300' : 'border-gray-300'}
-        `}
-      >
-        <span className={selectedProductService ? 'text-gray-900 flex items-center flex-1' : 'text-gray-500'}>
-          {isLoading ? (
-            <span className="flex items-center">
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              Loading...
-            </span>
-          ) : isError ? (
-            <span className="flex items-center text-red-600">
-              Error loading products
-            </span>
-          ) : selectedProductService ? (
-            <span className="flex items-center justify-between w-full">
-              <span className="flex items-center">
-                {getTypeIcon(selectedProductService.Type)}
-                <span className="ml-2">{selectedProductService.Name}</span>
-                {selectedProductService.SKU && (
-                  <span className="text-gray-500 ml-2 text-xs">({selectedProductService.SKU})</span>
-                )}
-              </span>
-              {selectedProductService.SalesPrice !== null && (
-                <span className="text-gray-500 text-xs">{formatCurrency(selectedProductService.SalesPrice)}</span>
-              )}
-            </span>
-          ) : (
-            placeholder
-          )}
-        </span>
-        <div className="flex items-center">
-          {selectedProductService && !disabled && (
-            <span
-              role="button"
-              tabIndex={0}
-              onClick={handleClear}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  (e.currentTarget as HTMLSpanElement).click();
-                }
-              }}
-              className="mr-1 text-gray-400 hover:text-gray-600 p-0.5 cursor-pointer"
-              aria-label="Clear selection"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </span>
-          )}
-          <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-        </div>
-      </button>
-
-      {/* Dropdown */}
-      {isOpen && !disabled && (
-        <div
-          id="product-service-listbox"
-          role="listbox"
-          aria-label="Product/Service selection"
-          className="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-gray-200 max-h-60 overflow-hidden"
-          onKeyDown={handleKeyDown}
-        >
-          {/* Search input */}
-          <div className="p-2 border-b border-gray-200">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-              <input
-                ref={inputRef}
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder="Search by name, SKU, or category..."
-                aria-label="Search products and services"
-                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-              />
-            </div>
-          </div>
-
-          {/* Product/Service list */}
-          <div className="max-h-48 overflow-y-auto">
-            {isLoading ? (
-              <div className="px-4 py-3 text-sm text-gray-500 flex items-center justify-center">
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                Loading...
-              </div>
-            ) : isError ? (
-              <div className="px-4 py-3 text-center">
-                <p className="text-sm text-red-600 mb-2">Error loading products/services</p>
-                <button
-                  type="button"
-                  onClick={() => refetch()}
-                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 rounded-md transition-colors"
-                >
-                  <RefreshCw className="w-4 h-4 mr-1" />
-                  Retry
-                </button>
-              </div>
-            ) : filteredProductsServices.length === 0 ? (
-              <div className="px-4 py-3 text-sm text-gray-500 text-center">
-                {searchTerm ? 'No products/services found' : 'No active products/services available'}
-              </div>
-            ) : (
-              filteredProductsServices.map((ps, index) => (
-                <button
-                  key={ps.Id}
-                  ref={(el) => (listItemsRef.current[index] = el)}
-                  type="button"
-                  role="option"
-                  aria-selected={ps.Id === value}
-                  onClick={() => handleSelect(ps)}
-                  onMouseEnter={() => setFocusedIndex(index)}
-                  className={`
-                    w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-indigo-50 focus:bg-indigo-50 focus:outline-none
-                    ${ps.Id === value ? 'bg-indigo-100 text-indigo-900' : ''}
-                    ${focusedIndex === index ? 'bg-indigo-50' : ''}
-                  `}
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center">
-                      {getTypeIcon(ps.Type)}
-                      <div className="ml-2">
-                        <div className="font-medium">{ps.Name}</div>
-                        {ps.SKU && (
-                          <div className="text-xs text-gray-500">SKU: {ps.SKU}</div>
-                        )}
-                      </div>
-                    </div>
-                    {ps.SalesPrice !== null && (
-                      <span className="text-sm text-gray-600">{formatCurrency(ps.SalesPrice)}</span>
+        size="small"
+        renderOption={(props, option: ProductService) => {
+          const { key, ...rest } = props;
+          return (
+            <li key={key} {...rest}>
+              <div className="flex items-center justify-between w-full">
+                <div className="flex items-center gap-2">
+                  {getTypeIcon(option.Type)}
+                  <div>
+                    <div className="font-medium">{option.Name}</div>
+                    {option.SKU && (
+                      <div className="text-xs opacity-60">SKU: {option.SKU}</div>
                     )}
                   </div>
-                </button>
-              ))
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Error message */}
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+                </div>
+                {option.SalesPrice !== null && (
+                  <span className="text-sm opacity-60 ml-2">{formatCurrency(option.SalesPrice)}</span>
+                )}
+              </div>
+            </li>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            placeholder={placeholder}
+            required={required}
+            error={!!error}
+            helperText={error}
+            slotProps={{
+              input: {
+                ...params.InputProps,
+                startAdornment: (
+                  <>
+                    {selectedProductService && getTypeIcon(selectedProductService.Type)}
+                    {params.InputProps.startAdornment}
+                  </>
+                ),
+                endAdornment: (
+                  <>
+                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              },
+            }}
+          />
+        )}
+      />
     </div>
   );
 }

--- a/client/src/components/VendorSelector.tsx
+++ b/client/src/components/VendorSelector.tsx
@@ -1,6 +1,8 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronDown, Search, Loader2, RefreshCw } from 'lucide-react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
 import api from '../lib/api';
 
 interface Vendor {
@@ -26,15 +28,7 @@ export default function VendorSelector({
   error,
   className = '',
 }: VendorSelectorProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listItemsRef = useRef<(HTMLButtonElement | null)[]>([]);
-
-  // Fetch vendors
-  const { data: vendors, isLoading, isError, refetch } = useQuery({
+  const { data: vendors, isLoading } = useQuery({
     queryKey: ['vendors'],
     queryFn: async (): Promise<Vendor[]> => {
       const response = await api.get("/vendors?$filter=Status eq 'Active'&$orderby=Name");
@@ -42,209 +36,59 @@ export default function VendorSelector({
     }
   });
 
-  // Find selected vendor
   const selectedVendor = useMemo(() => {
-    return vendors?.find((v) => v.Id === value);
+    return vendors?.find((v) => v.Id === value) ?? null;
   }, [vendors, value]);
 
-  // Filter vendors based on search term
-  const filteredVendors = useMemo(() => {
-    if (!vendors) return [];
-    if (!searchTerm) return vendors;
-
-    const lowerSearch = searchTerm.toLowerCase();
-    return vendors.filter(
-      (vendor) =>
-        vendor.Name.toLowerCase().includes(lowerSearch) ||
-        (vendor.Email && vendor.Email.toLowerCase().includes(lowerSearch))
-    );
-  }, [vendors, searchTerm]);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-        setSearchTerm('');
-        setFocusedIndex(-1);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // Focus search input when dropdown opens
-  useEffect(() => {
-    if (isOpen && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [isOpen]);
-
-  // Reset focused index when filtered list changes
-  useEffect(() => {
-    setFocusedIndex(-1);
-  }, [searchTerm]);
-
-  const handleSelect = (vendorId: string) => {
-    onChange(vendorId);
-    setIsOpen(false);
-    setSearchTerm('');
-    setFocusedIndex(-1);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      setIsOpen(false);
-      setSearchTerm('');
-      setFocusedIndex(-1);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      setFocusedIndex((prev) => {
-        const next = prev < filteredVendors.length - 1 ? prev + 1 : prev;
-        if (next < listItemsRef.current.length) {
-          listItemsRef.current[next]?.scrollIntoView({ block: 'nearest' });
-        }
-        return next;
-      });
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      setFocusedIndex((prev) => {
-        const next = prev > 0 ? prev - 1 : -1;
-        if (next === -1) {
-          inputRef.current?.focus();
-        } else if (next >= 0 && next < listItemsRef.current.length) {
-          listItemsRef.current[next]?.scrollIntoView({ block: 'nearest' });
-        }
-        return next;
-      });
-    } else if (event.key === 'Enter' && focusedIndex >= 0 && focusedIndex < filteredVendors.length) {
-      event.preventDefault();
-      handleSelect(filteredVendors[focusedIndex].Id);
-    }
-  };
-
   return (
-    <div ref={containerRef} className={`relative ${className}`}>
-      {/* Trigger button */}
-      <button
-        type="button"
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+    <div className={className}>
+      <Autocomplete
+        options={vendors ?? []}
+        getOptionLabel={(option: Vendor) =>
+          option.Name + (option.Email ? ` (${option.Email})` : '')
+        }
+        value={selectedVendor}
+        onChange={(_event, newValue: Vendor | null) => {
+          onChange(newValue?.Id ?? '');
+        }}
+        isOptionEqualToValue={(option: Vendor, val: Vendor) => option.Id === val.Id}
+        loading={isLoading}
         disabled={disabled}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
-        aria-controls="vendor-listbox"
-        aria-required={required}
-        className={`
-          w-full flex items-center justify-between
-          mt-1 rounded-md border shadow-sm
-          focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
-          sm:text-sm p-2 text-left
-          ${disabled ? 'bg-gray-100 cursor-not-allowed' : 'bg-white cursor-pointer hover:bg-gray-50'}
-          ${error ? 'border-red-300' : 'border-gray-300'}
-        `}
-      >
-        <span className={selectedVendor ? 'text-gray-900' : 'text-gray-500'}>
-          {isLoading ? (
-            <span className="flex items-center">
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              Loading vendors...
-            </span>
-          ) : isError ? (
-            <span className="flex items-center text-red-600">
-              Error loading vendors
-            </span>
-          ) : selectedVendor ? (
-            <span>
-              {selectedVendor.Name}
-              {selectedVendor.Email && (
-                <span className="text-gray-500 ml-2">({selectedVendor.Email})</span>
-              )}
-            </span>
-          ) : (
-            'Select a vendor...'
-          )}
-        </span>
-        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-      </button>
-
-      {/* Dropdown */}
-      {isOpen && !disabled && (
-        <div
-          id="vendor-listbox"
-          role="listbox"
-          aria-label="Vendor selection"
-          className="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md border border-gray-200 max-h-60 overflow-hidden"
-          onKeyDown={handleKeyDown}
-        >
-          {/* Search input */}
-          <div className="p-2 border-b border-gray-200">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-              <input
-                ref={inputRef}
-                type="text"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder="Search vendors..."
-                aria-label="Search vendors"
-                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
-              />
-            </div>
-          </div>
-
-          {/* Vendor list */}
-          <div className="max-h-48 overflow-y-auto">
-            {isLoading ? (
-              <div className="px-4 py-3 text-sm text-gray-500 flex items-center justify-center">
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                Loading...
+        size="small"
+        renderOption={(props, option: Vendor) => {
+          const { key, ...rest } = props;
+          return (
+            <li key={key} {...rest}>
+              <div>
+                <div className="font-medium">{option.Name}</div>
+                {option.Email && (
+                  <div className="text-xs opacity-60">{option.Email}</div>
+                )}
               </div>
-            ) : isError ? (
-              <div className="px-4 py-3 text-center">
-                <p className="text-sm text-red-600 mb-2">Error loading vendors</p>
-                <button
-                  type="button"
-                  onClick={() => refetch()}
-                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 rounded-md transition-colors"
-                >
-                  <RefreshCw className="w-4 h-4 mr-1" />
-                  Retry
-                </button>
-              </div>
-            ) : filteredVendors.length === 0 ? (
-              <div className="px-4 py-3 text-sm text-gray-500 text-center">
-                {searchTerm ? 'No vendors found' : 'No vendors available'}
-              </div>
-            ) : (
-              filteredVendors.map((vendor, index) => (
-                <button
-                  key={vendor.Id}
-                  ref={(el) => (listItemsRef.current[index] = el)}
-                  type="button"
-                  role="option"
-                  aria-selected={vendor.Id === value}
-                  onClick={() => handleSelect(vendor.Id)}
-                  onMouseEnter={() => setFocusedIndex(index)}
-                  className={`
-                    w-full px-4 py-2 text-left text-sm text-gray-900 hover:bg-indigo-50 focus:bg-indigo-50 focus:outline-none
-                    ${vendor.Id === value ? 'bg-indigo-100 text-indigo-900' : ''}
-                    ${focusedIndex === index ? 'bg-indigo-50' : ''}
-                  `}
-                >
-                  <div className="font-medium">{vendor.Name}</div>
-                  {vendor.Email && (
-                    <div className="text-xs text-gray-500">{vendor.Email}</div>
-                  )}
-                </button>
-              ))
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Error message */}
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+            </li>
+          );
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            placeholder="Select a vendor..."
+            required={required}
+            error={!!error}
+            helperText={error}
+            slotProps={{
+              input: {
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              },
+            }}
+          />
+        )}
+      />
     </div>
   );
 }

--- a/client/src/pages/Classes.tsx
+++ b/client/src/pages/Classes.tsx
@@ -403,30 +403,30 @@ export default function Classes() {
 
       {/* Table */}
       <div className="bg-white dark:bg-gray-800 shadow overflow-x-auto sm:rounded-lg">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900/50">
             <tr>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Name
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Parent
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Description
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Status
               </th>
@@ -435,17 +435,17 @@ export default function Classes() {
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {filteredClasses?.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">
+                <td colSpan={5} className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">
                   No classes found. Create your first class to get started.
                 </td>
               </tr>
             ) : (
               filteredClasses?.map((classItem) => (
                 <tr key={classItem.Id}>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
                     <div className="flex items-center">
                       {classItem.ParentClassId && (
                         <ChevronRight className="w-4 h-4 mr-1 text-gray-400" />
@@ -453,18 +453,18 @@ export default function Classes() {
                       {classItem.Name}
                     </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {getParentName(classItem.ParentClassId) || '-'}
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                  <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
                     {classItem.Description || '-'}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span
                       className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
                         classItem.Status === 'Active'
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-gray-100 text-gray-800'
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                          : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
                       }`}
                     >
                       {classItem.Status}
@@ -473,13 +473,13 @@ export default function Classes() {
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <button
                       onClick={() => handleEdit(classItem)}
-                      className="text-indigo-600 hover:text-indigo-900 mr-4"
+                      className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 mr-4"
                     >
                       Edit
                     </button>
                     <button
                       onClick={() => handleDelete(classItem.Id)}
-                      className="text-red-600 hover:text-red-900"
+                      className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300"
                     >
                       Delete
                     </button>
@@ -491,7 +491,7 @@ export default function Classes() {
         </table>
       </div>
 
-      <div className="mt-4 text-sm text-gray-500">
+      <div className="mt-4 text-sm text-gray-500 dark:text-gray-400">
         <p>
           Classes help you track transactions by department, division, product line, or any other category.
           Use parent classes to create a hierarchy.

--- a/client/src/pages/Inventory.tsx
+++ b/client/src/pages/Inventory.tsx
@@ -228,12 +228,12 @@ export default function Inventory() {
     const reorderPoint = item.ReorderPoint || 0;
 
     if (qty <= 0) {
-      return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Out of Stock</span>;
+      return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300">Out of Stock</span>;
     }
     if (qty <= reorderPoint) {
-      return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">Low Stock</span>;
+      return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">Low Stock</span>;
     }
-    return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">In Stock</span>;
+    return <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">In Stock</span>;
   };
 
   const getTransactionTypeIcon = (type: string) => {
@@ -327,7 +327,7 @@ export default function Inventory() {
           <div className="flex items-center">
             <Box className="w-8 h-8 text-indigo-500 mr-3" />
             <div>
-              <p className="text-sm text-gray-500">Total Items</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Total Items</p>
               <p className="text-2xl font-semibold">{stats.totalItems}</p>
             </div>
           </div>
@@ -336,7 +336,7 @@ export default function Inventory() {
           <div className="flex items-center">
             <TrendingDown className="w-8 h-8 text-yellow-500 mr-3" />
             <div>
-              <p className="text-sm text-gray-500">Low Stock</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Low Stock</p>
               <p className="text-2xl font-semibold">{stats.lowStockItems}</p>
             </div>
           </div>
@@ -345,7 +345,7 @@ export default function Inventory() {
           <div className="flex items-center">
             <AlertTriangle className="w-8 h-8 text-red-500 mr-3" />
             <div>
-              <p className="text-sm text-gray-500">Out of Stock</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Out of Stock</p>
               <p className="text-2xl font-semibold">{stats.outOfStockItems}</p>
             </div>
           </div>
@@ -354,7 +354,7 @@ export default function Inventory() {
           <div className="flex items-center">
             <Box className="w-8 h-8 text-green-500 mr-3" />
             <div>
-              <p className="text-sm text-gray-500">Total Value</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Total Value</p>
               <p className="text-2xl font-semibold">{formatCurrency(stats.totalValue)}</p>
             </div>
           </div>
@@ -363,14 +363,14 @@ export default function Inventory() {
 
       {/* View Mode Tabs */}
       <div className="bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
-        <div className="border-b border-gray-200">
+        <div className="border-b border-gray-200 dark:border-gray-700">
           <nav className="-mb-px flex" aria-label="Tabs">
             <button
               onClick={() => setViewMode('inventory')}
               className={`w-1/3 py-4 px-1 text-center border-b-2 font-medium text-sm ${
                 viewMode === 'inventory'
                   ? 'border-indigo-500 text-indigo-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
               }`}
             >
               Inventory Items
@@ -380,7 +380,7 @@ export default function Inventory() {
               className={`w-1/3 py-4 px-1 text-center border-b-2 font-medium text-sm ${
                 viewMode === 'transactions'
                   ? 'border-indigo-500 text-indigo-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
               }`}
             >
               Transactions
@@ -390,7 +390,7 @@ export default function Inventory() {
               className={`w-1/3 py-4 px-1 text-center border-b-2 font-medium text-sm ${
                 viewMode === 'locations'
                   ? 'border-indigo-500 text-indigo-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300'
               }`}
             >
               Locations
@@ -422,7 +422,7 @@ export default function Inventory() {
                 </select>
               </div>
               <div className="flex items-end">
-                <span className="text-sm text-gray-500">
+                <span className="text-sm text-gray-500 dark:text-gray-400">
                   Showing {filteredItems?.length || 0} of {inventoryItems?.length || 0} items
                 </span>
               </div>
@@ -431,28 +431,28 @@ export default function Inventory() {
 
           {/* Inventory Table */}
           <div className="bg-white dark:bg-gray-800 shadow overflow-x-auto sm:rounded-lg">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900/50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Product
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     SKU
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     On Hand
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Reorder Point
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Unit Cost
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Value
                   </th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Status
                   </th>
                   <th className="relative px-6 py-3">
@@ -460,12 +460,12 @@ export default function Inventory() {
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {filteredItems?.length === 0 ? (
                   <tr>
-                    <td colSpan={8} className="px-6 py-8 text-center text-gray-500">
+                    <td colSpan={8} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
                       No inventory items found.{' '}
-                      <Link to="/products-services/new" className="text-indigo-600 hover:text-indigo-900 ml-1">
+                      <Link to="/products-services/new" className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 ml-1">
                         Add your first inventory item.
                       </Link>
                     </td>
@@ -478,22 +478,22 @@ export default function Inventory() {
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
                             <Box className="w-4 h-4 text-green-500 mr-2" />
-                            <span className="text-sm font-medium text-gray-900">{item.Name}</span>
+                            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{item.Name}</span>
                           </div>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                           {item.SKU || '-'}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 text-right">
                           {formatNumber(item.QuantityOnHand)}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 text-right">
                           {formatNumber(item.ReorderPoint)}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 text-right">
                           {formatCurrency(item.PurchaseCost)}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 text-right">
                           {formatCurrency(value)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-center">
@@ -502,13 +502,13 @@ export default function Inventory() {
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                           <button
                             onClick={() => openAdjustmentModal(item)}
-                            className="text-indigo-600 hover:text-indigo-900 mr-4"
+                            className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 mr-4"
                           >
                             Adjust
                           </button>
                           <Link
                             to={`/products-services/${item.Id}/edit`}
-                            className="text-indigo-600 hover:text-indigo-900"
+                            className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300"
                           >
                             Edit
                           </Link>
@@ -529,64 +529,64 @@ export default function Inventory() {
           {loadingTransactions ? (
             <div className="p-4">Loading transactions...</div>
           ) : (
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900/50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Date
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Type
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Quantity
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Unit Cost
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Total
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Reference
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Notes
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {transactions?.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-8 text-center text-gray-500">
+                    <td colSpan={7} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
                       No inventory transactions found.
                     </td>
                   </tr>
                 ) : (
                   transactions?.map((tx) => (
                     <tr key={tx.Id}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {formatDate(tx.TransactionDate)}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
                         <div className="flex items-center">
                           {getTransactionTypeIcon(tx.TransactionType)}
-                          <span className="ml-2 text-sm text-gray-900">{tx.TransactionType}</span>
+                          <span className="ml-2 text-sm text-gray-900 dark:text-gray-100">{tx.TransactionType}</span>
                         </div>
                       </td>
                       <td className={`px-6 py-4 whitespace-nowrap text-sm text-right ${tx.Quantity >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                         {tx.Quantity >= 0 ? '+' : ''}{formatNumber(tx.Quantity)}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 text-right">
                         {formatCurrency(tx.UnitCost)}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 text-right">
                         {formatCurrency(tx.TotalCost)}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {tx.ReferenceType || '-'}
                       </td>
-                      <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
                         {tx.Notes || '-'}
                       </td>
                     </tr>
@@ -604,55 +604,55 @@ export default function Inventory() {
           {loadingLocations ? (
             <div className="p-4">Loading locations...</div>
           ) : (
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900/50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Name
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Code
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Address
                   </th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Default
                   </th>
-                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Status
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {locations?.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="px-6 py-8 text-center text-gray-500">
+                    <td colSpan={5} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
                       No inventory locations found. Locations can be used to track inventory across multiple warehouses or stores.
                     </td>
                   </tr>
                 ) : (
                   locations?.map((loc) => (
                     <tr key={loc.Id}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
                         {loc.Name}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {loc.Code || '-'}
                       </td>
-                      <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
                         {loc.Address || '-'}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-center">
                         {loc.IsDefault && (
-                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800">
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300">
                             Default
                           </span>
                         )}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-center">
                         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                          loc.Status === 'Active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'
+                          loc.Status === 'Active' ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
                         }`}>
                           {loc.Status}
                         </span>
@@ -673,14 +673,14 @@ export default function Inventory() {
             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
               Adjust Inventory: {selectedProduct.Name}
             </h3>
-            <p className="text-sm text-gray-500 mb-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
               Current quantity on hand: {formatNumber(selectedProduct.QuantityOnHand)}
             </p>
 
             {/* Error Messages */}
             {(validationError || adjustmentError) && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
-                <p className="text-sm text-red-700">
+              <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+                <p className="text-sm text-red-700 dark:text-red-400">
                   {validationError || adjustmentError}
                 </p>
               </div>
@@ -708,7 +708,7 @@ export default function Inventory() {
                   min={MIN_ADJUSTMENT_QUANTITY}
                   max={MAX_ADJUSTMENT_QUANTITY}
                 />
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   Use positive numbers to add, negative to subtract
                 </p>
               </div>
@@ -729,8 +729,8 @@ export default function Inventory() {
               {adjustmentQuantity !== 0 && (
                 <p className={`text-sm mb-4 ${
                   (selectedProduct.QuantityOnHand || 0) + adjustmentQuantity < 0
-                    ? 'text-red-600 font-medium'
-                    : 'text-gray-600'
+                    ? 'text-red-600 dark:text-red-400 font-medium'
+                    : 'text-gray-600 dark:text-gray-400'
                 }`}>
                   New quantity will be: {formatNumber((selectedProduct.QuantityOnHand || 0) + adjustmentQuantity)}
                   {(selectedProduct.QuantityOnHand || 0) + adjustmentQuantity < 0 && ' (invalid - cannot be negative)'}
@@ -740,7 +740,7 @@ export default function Inventory() {
                 <button
                   type="button"
                   onClick={() => setShowAdjustmentModal(false)}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200"
+                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600"
                 >
                   Cancel
                 </button>

--- a/client/src/pages/NewJournalEntry.tsx
+++ b/client/src/pages/NewJournalEntry.tsx
@@ -1,9 +1,18 @@
-import { useForm, useFieldArray } from 'react-hook-form';
+import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import api from '../lib/api';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+
+interface Account {
+  Id: string;
+  Code: string;
+  Name: string;
+}
 
 const lineSchema = z.object({
   AccountId: z.string().min(1, 'Account is required'),
@@ -11,7 +20,6 @@ const lineSchema = z.object({
   Debit: z.number().min(0),
   Credit: z.number().min(0),
 }).refine((line) => {
-  // Either debit or credit must be > 0, but not both
   const hasDebit = line.Debit > 0;
   const hasCredit = line.Credit > 0;
   return (hasDebit && !hasCredit) || (!hasDebit && hasCredit);
@@ -31,7 +39,7 @@ const journalEntrySchema = z.object({
   return Math.abs(totalDebit - totalCredit) < 0.01;
 }, {
   message: "Total Debits must equal Total Credits",
-  path: ["Lines"], // Attach error to the Lines field
+  path: ["Lines"],
 });
 
 type JournalEntryForm = z.infer<typeof journalEntrySchema>;
@@ -55,6 +63,14 @@ export default function NewJournalEntry() {
     name: "Lines"
   });
 
+  const { data: accounts = [] } = useQuery({
+    queryKey: ['accounts'],
+    queryFn: async (): Promise<Account[]> => {
+      const response = await api.get<{ value: Account[] }>('/accounts?$orderby=Code');
+      return response.data.value;
+    },
+  });
+
   const lines = watch("Lines");
   const totalDebit = lines?.reduce((sum, line) => sum + (Number(line.Debit) || 0), 0) || 0;
   const totalCredit = lines?.reduce((sum, line) => sum + (Number(line.Credit) || 0), 0) || 0;
@@ -62,15 +78,14 @@ export default function NewJournalEntry() {
 
   const onSubmit = async (data: JournalEntryForm) => {
     try {
-      // 1. Create Header
       const headerResponse = await api.post('/journalentries', {
-        Reference: data.EntryNumber, // Map EntryNumber to Reference column
-        TransactionDate: data.EntryDate, // Map to DB column
+        Reference: data.EntryNumber,
+        TransactionDate: data.EntryDate,
         Description: data.Description,
         Status: data.Status,
-        CreatedBy: 'test-user' // Simulator auth uses this or we just pass it if it's a column
+        CreatedBy: 'test-user'
       });
-      
+
       const responseData = headerResponse.data as any;
       const journalEntryId = responseData.Id || responseData.value?.[0]?.Id;
 
@@ -78,12 +93,10 @@ export default function NewJournalEntry() {
         throw new Error('Failed to get Journal Entry ID');
       }
 
-      // 2. Create Lines
       for (const line of data.Lines) {
-        // Lookup Account ID by Code
         const accountResponse = await api.get<{ value: any[] }>(`/accounts?$filter=Code eq '${line.AccountId}'`);
         const account = accountResponse.data.value?.[0];
-        
+
         if (!account) {
           throw new Error(`Account code '${line.AccountId}' not found`);
         }
@@ -110,70 +123,87 @@ export default function NewJournalEntry() {
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/journal-entries')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/journal-entries')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
           <ArrowLeft className="w-6 h-6" />
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">New Journal Entry</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">New Journal Entry</h1>
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         {/* Header Fields */}
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
           <div>
-            <label htmlFor="EntryNumber" className="block text-sm font-medium text-gray-700">Entry Number</label>
+            <label htmlFor="EntryNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Entry Number</label>
             <input
               id="EntryNumber"
               type="text"
               {...register('EntryNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
               placeholder="JE-001"
             />
-            {errors.EntryNumber && <p className="mt-1 text-sm text-red-600">{errors.EntryNumber.message}</p>}
+            {errors.EntryNumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.EntryNumber.message}</p>}
           </div>
 
           <div>
-            <label htmlFor="EntryDate" className="block text-sm font-medium text-gray-700">Date</label>
+            <label htmlFor="EntryDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Date</label>
             <input
               id="EntryDate"
               type="date"
               {...register('EntryDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
             />
-            {errors.EntryDate && <p className="mt-1 text-sm text-red-600">{errors.EntryDate.message}</p>}
+            {errors.EntryDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.EntryDate.message}</p>}
           </div>
 
           <div className="sm:col-span-2">
-            <label htmlFor="Description" className="block text-sm font-medium text-gray-700">Description</label>
+            <label htmlFor="Description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
             <input
               id="Description"
               type="text"
               {...register('Description')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
               placeholder="Opening Balance"
             />
-            {errors.Description && <p className="mt-1 text-sm text-red-600">{errors.Description.message}</p>}
+            {errors.Description && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Description.message}</p>}
           </div>
         </div>
 
         {/* Lines */}
         <div className="mt-6">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">Lines</h3>
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">Lines</h3>
           <div className="space-y-4">
             {fields.map((field, index) => (
               <div key={field.id}>
                 <div className="flex gap-4 items-start">
                   <div className="flex-1">
-                    <input
-                      {...register(`Lines.${index}.AccountId`)}
-                      placeholder="Account Code"
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                    <Controller
+                      name={`Lines.${index}.AccountId`}
+                      control={control}
+                      render={({ field: accountField }) => (
+                        <Autocomplete
+                          options={accounts}
+                          getOptionLabel={(option: Account) => `${option.Code} - ${option.Name}`}
+                          value={accounts.find((a) => a.Code === accountField.value) ?? null}
+                          onChange={(_event, newValue: Account | null) => {
+                            accountField.onChange(newValue?.Code ?? '');
+                          }}
+                          isOptionEqualToValue={(option: Account, val: Account) => option.Id === val.Id}
+                          size="small"
+                          renderInput={(params) => (
+                            <TextField
+                              {...params}
+                              placeholder="Account Code"
+                            />
+                          )}
+                        />
+                      )}
                     />
                   </div>
                   <div className="flex-1">
                     <input
                       {...register(`Lines.${index}.Description`)}
                       placeholder="Line Description"
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      className="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
                     />
                   </div>
                   <div className="w-32">
@@ -182,7 +212,7 @@ export default function NewJournalEntry() {
                       step="0.01"
                       {...register(`Lines.${index}.Debit`, { valueAsNumber: true })}
                       placeholder="Debit"
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      className="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
                     />
                   </div>
                   <div className="w-32">
@@ -191,30 +221,30 @@ export default function NewJournalEntry() {
                       step="0.01"
                       {...register(`Lines.${index}.Credit`, { valueAsNumber: true })}
                       placeholder="Credit"
-                      className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      className="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
                     />
                   </div>
                   <button
                     type="button"
                     onClick={() => remove(index)}
-                    className="p-2 text-red-600 hover:text-red-800"
+                    className="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
                   >
                     <Trash2 className="w-5 h-5" />
                   </button>
                 </div>
                 {errors.Lines?.[index] && (
-                  <p className="mt-1 text-sm text-red-600">
+                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">
                     {errors.Lines[index]?.message || errors.Lines[index]?.AccountId?.message}
                   </p>
                 )}
               </div>
             ))}
           </div>
-          
+
           <button
             type="button"
             onClick={() => append({ AccountId: '', Description: '', Debit: 0, Credit: 0 })}
-            className="mt-4 flex items-center text-indigo-600 hover:text-indigo-800"
+            className="mt-4 flex items-center text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
           >
             <Plus className="w-4 h-4 mr-1" />
             Add Line
@@ -222,26 +252,26 @@ export default function NewJournalEntry() {
         </div>
 
         {/* Totals */}
-        <div className="border-t border-gray-200 pt-4 flex justify-end space-x-8 text-sm font-medium">
+        <div className="border-t border-gray-200 dark:border-gray-600 pt-4 flex justify-end space-x-8 text-sm font-medium">
           <div>
-            <span className="text-gray-500">Total Debit:</span>
-            <span className="ml-2 text-gray-900">${totalDebit.toFixed(2)}</span>
+            <span className="text-gray-500 dark:text-gray-400">Total Debit:</span>
+            <span className="ml-2 text-gray-900 dark:text-gray-100">${totalDebit.toFixed(2)}</span>
           </div>
           <div>
-            <span className="text-gray-500">Total Credit:</span>
-            <span className="ml-2 text-gray-900">${totalCredit.toFixed(2)}</span>
+            <span className="text-gray-500 dark:text-gray-400">Total Credit:</span>
+            <span className="ml-2 text-gray-900 dark:text-gray-100">${totalCredit.toFixed(2)}</span>
           </div>
-          <div className={isBalanced ? "text-green-600" : "text-red-600"}>
+          <div className={isBalanced ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}>
             {isBalanced ? "Balanced" : "Unbalanced"}
           </div>
         </div>
-        {errors.Lines && <p className="text-right text-sm text-red-600">{errors.Lines.message}</p>}
+        {errors.Lines && <p className="text-right text-sm text-red-600 dark:text-red-400">{errors.Lines.message}</p>}
 
         <div className="flex justify-end pt-4">
           <button
             type="button"
             onClick={() => navigate('/journal-entries')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            className="mr-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
           >
             Cancel
           </button>

--- a/client/src/pages/NewTimeEntry.tsx
+++ b/client/src/pages/NewTimeEntry.tsx
@@ -79,20 +79,20 @@ export default function NewTimeEntry() {
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/time-entries')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/time-entries')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
           <ArrowLeft className="w-6 h-6" />
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">Log Time</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Log Time</h1>
       </div>
 
-      <form onSubmit={handleSubmit((data) => mutation.mutateAsync(data))} className="bg-white shadow rounded-lg p-6 space-y-6">
+      <form onSubmit={handleSubmit((data) => mutation.mutateAsync(data))} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div>
-          <label htmlFor="ProjectId" className="block text-sm font-medium text-gray-700">Project</label>
+          <label htmlFor="ProjectId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Project</label>
           <select
             id="ProjectId"
             {...register('ProjectId')}
             disabled={projectsLoading}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
           >
             <option value="">Select a project...</option>
             {activeProjects.map((project) => (
@@ -101,40 +101,40 @@ export default function NewTimeEntry() {
               </option>
             ))}
           </select>
-          {errors.ProjectId && <p className="mt-1 text-sm text-red-600">{errors.ProjectId.message}</p>}
+          {errors.ProjectId && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.ProjectId.message}</p>}
           {selectedProject && (
-            <p className="mt-1 text-sm text-gray-500">
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
               Customer: {customers.find(c => c.Id === selectedProject.CustomerId)?.Name || 'Unknown'}
             </p>
           )}
         </div>
 
         <div>
-          <label htmlFor="EmployeeName" className="block text-sm font-medium text-gray-700">Employee Name</label>
+          <label htmlFor="EmployeeName" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Employee Name</label>
           <input
             id="EmployeeName"
             type="text"
             {...register('EmployeeName')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
             placeholder="Your name"
           />
-          {errors.EmployeeName && <p className="mt-1 text-sm text-red-600">{errors.EmployeeName.message}</p>}
+          {errors.EmployeeName && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.EmployeeName.message}</p>}
         </div>
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label htmlFor="EntryDate" className="block text-sm font-medium text-gray-700">Date</label>
+            <label htmlFor="EntryDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Date</label>
             <input
               id="EntryDate"
               type="date"
               {...register('EntryDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
             />
-            {errors.EntryDate && <p className="mt-1 text-sm text-red-600">{errors.EntryDate.message}</p>}
+            {errors.EntryDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.EntryDate.message}</p>}
           </div>
 
           <div>
-            <label htmlFor="Hours" className="block text-sm font-medium text-gray-700">Hours</label>
+            <label htmlFor="Hours" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Hours</label>
             <input
               id="Hours"
               type="number"
@@ -142,35 +142,35 @@ export default function NewTimeEntry() {
               min="0.25"
               max="24"
               {...register('Hours')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
             />
-            {errors.Hours && <p className="mt-1 text-sm text-red-600">{errors.Hours.message}</p>}
+            {errors.Hours && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Hours.message}</p>}
           </div>
         </div>
 
         <div>
-          <label htmlFor="HourlyRate" className="block text-sm font-medium text-gray-700">Hourly Rate ($)</label>
+          <label htmlFor="HourlyRate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Hourly Rate ($)</label>
           <input
             id="HourlyRate"
             type="number"
             step="0.01"
             min="0"
             {...register('HourlyRate')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
           />
-          {errors.HourlyRate && <p className="mt-1 text-sm text-red-600">{errors.HourlyRate.message}</p>}
+          {errors.HourlyRate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.HourlyRate.message}</p>}
         </div>
 
         <div>
-          <label htmlFor="Description" className="block text-sm font-medium text-gray-700">Description</label>
+          <label htmlFor="Description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
           <textarea
             id="Description"
             rows={3}
             {...register('Description')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
             placeholder="What did you work on?"
           />
-          {errors.Description && <p className="mt-1 text-sm text-red-600">{errors.Description.message}</p>}
+          {errors.Description && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Description.message}</p>}
         </div>
 
         <div className="flex items-center">
@@ -178,18 +178,18 @@ export default function NewTimeEntry() {
             id="IsBillable"
             type="checkbox"
             {...register('IsBillable')}
-            className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+            className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
           />
-          <label htmlFor="IsBillable" className="ml-2 block text-sm text-gray-900">
+          <label htmlFor="IsBillable" className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
             Billable
           </label>
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
+        <div className="flex justify-end items-center border-t border-gray-200 dark:border-gray-600 pt-4">
           <button
             type="button"
             onClick={() => navigate('/time-entries')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            className="mr-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
           >
             Cancel
           </button>

--- a/client/src/pages/Projects.tsx
+++ b/client/src/pages/Projects.tsx
@@ -40,9 +40,9 @@ export default function Projects() {
       filterable: true,
       renderCell: (params) => (
         <div>
-          <div className="text-sm font-medium text-gray-900">{params.value}</div>
+          <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{params.value}</div>
           {params.row.Description && (
-            <div className="text-sm text-gray-500 truncate max-w-xs">{params.row.Description}</div>
+            <div className="text-sm text-gray-500 dark:text-gray-400 truncate max-w-xs">{params.row.Description}</div>
           )}
         </div>
       )
@@ -66,7 +66,7 @@ export default function Projects() {
       sortable: false,
       filterable: false,
       renderCell: (params) => (
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-gray-500 dark:text-gray-400">
           {params.row.StartDate && <div>Start: {formatDate(params.row.StartDate)}</div>}
           {params.row.EndDate && <div>End: {formatDate(params.row.EndDate)}</div>}
           {!params.row.StartDate && !params.row.EndDate && '-'}
@@ -80,7 +80,7 @@ export default function Projects() {
       sortable: false,
       filterable: false,
       renderCell: (params) => (
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-gray-500 dark:text-gray-400">
           {params.row.BudgetedHours && <div>{params.row.BudgetedHours} hrs</div>}
           {params.row.BudgetedAmount && <div>{formatCurrency(params.row.BudgetedAmount)}</div>}
           {!params.row.BudgetedHours && !params.row.BudgetedAmount && '-'}
@@ -92,7 +92,7 @@ export default function Projects() {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">Projects</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Projects</h1>
         <Link
           to="/projects/new"
           className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"

--- a/client/src/pages/TaxRates.tsx
+++ b/client/src/pages/TaxRates.tsx
@@ -232,8 +232,8 @@ export default function TaxRates() {
     <div className="max-w-6xl mx-auto">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">Tax Rates</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Tax Rates</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Manage sales tax rates for your invoices
           </p>
         </div>
@@ -248,9 +248,9 @@ export default function TaxRates() {
 
       {/* Form */}
       {showForm && (
-        <div className="bg-white shadow sm:rounded-lg mb-6 p-6">
+        <div className="bg-white dark:bg-gray-800 shadow sm:rounded-lg mb-6 p-6">
           <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-medium text-gray-900">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">
               {editingTaxRate ? 'Edit Tax Rate' : 'New Tax Rate'}
             </h2>
             <button
@@ -265,7 +265,7 @@ export default function TaxRates() {
               <div>
                 <label
                   htmlFor="name"
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
                   Name *
                 </label>
@@ -282,20 +282,20 @@ export default function TaxRates() {
                     }
                   }}
                   placeholder="e.g., California Sales Tax"
-                  className={`mt-1 block w-full rounded-md shadow-sm focus:ring-indigo-500 sm:text-sm border p-2 ${
+                  className={`mt-1 block w-full rounded-md shadow-sm focus:ring-indigo-500 sm:text-sm border p-2 dark:bg-gray-700 dark:text-gray-100 ${
                     validationErrors.name
                       ? 'border-red-300 focus:border-red-500'
-                      : 'border-gray-300 focus:border-indigo-500'
+                      : 'border-gray-300 dark:border-gray-600 focus:border-indigo-500'
                   }`}
                 />
                 {validationErrors.name && (
-                  <p className="mt-1 text-sm text-red-600">{validationErrors.name}</p>
+                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">{validationErrors.name}</p>
                 )}
               </div>
               <div>
                 <label
                   htmlFor="rate"
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
                   Rate (%) *
                 </label>
@@ -316,10 +316,10 @@ export default function TaxRates() {
                       }
                     }}
                     placeholder="8.25"
-                    className={`block w-full pr-10 rounded-md shadow-sm focus:ring-indigo-500 sm:text-sm border p-2 ${
+                    className={`block w-full pr-10 rounded-md shadow-sm focus:ring-indigo-500 sm:text-sm border p-2 dark:bg-gray-700 dark:text-gray-100 ${
                       validationErrors.rate
                         ? 'border-red-300 focus:border-red-500'
-                        : 'border-gray-300 focus:border-indigo-500'
+                        : 'border-gray-300 dark:border-gray-600 focus:border-indigo-500'
                     }`}
                   />
                   <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
@@ -327,13 +327,13 @@ export default function TaxRates() {
                   </div>
                 </div>
                 {validationErrors.rate && (
-                  <p className="mt-1 text-sm text-red-600">{validationErrors.rate}</p>
+                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">{validationErrors.rate}</p>
                 )}
               </div>
               <div className="sm:col-span-2">
                 <label
                   htmlFor="description"
-                  className="block text-sm font-medium text-gray-700"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
                   Description
                 </label>
@@ -345,7 +345,7 @@ export default function TaxRates() {
                     setFormData({ ...formData, Description: e.target.value })
                   }
                   placeholder="Optional description for this tax rate"
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                  className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
                 />
               </div>
               <div className="flex items-center gap-6">
@@ -358,7 +358,7 @@ export default function TaxRates() {
                     }
                     className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
                   />
-                  <span className="text-sm text-gray-700">Default tax rate</span>
+                  <span className="text-sm text-gray-700 dark:text-gray-300">Default tax rate</span>
                 </label>
                 <label className="flex items-center gap-2">
                   <input
@@ -369,7 +369,7 @@ export default function TaxRates() {
                     }
                     className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
                   />
-                  <span className="text-sm text-gray-700">Active</span>
+                  <span className="text-sm text-gray-700 dark:text-gray-300">Active</span>
                 </label>
               </div>
             </div>
@@ -377,7 +377,7 @@ export default function TaxRates() {
               <button
                 type="button"
                 onClick={resetForm}
-                className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 dark:bg-gray-700"
               >
                 Cancel
               </button>
@@ -406,14 +406,14 @@ export default function TaxRates() {
             placeholder="Search tax rates..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="pl-10 w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            className="pl-10 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
           />
         </div>
         <select
           data-testid="status-filter"
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+          className="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
         >
           <option value="all">All Status</option>
           <option value="active">Active</option>
@@ -422,31 +422,31 @@ export default function TaxRates() {
       </div>
 
       {/* Table */}
-      <div className="bg-white shadow overflow-x-auto sm:rounded-lg">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="bg-white dark:bg-gray-800 shadow overflow-x-auto sm:rounded-lg">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900/50">
             <tr>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Name
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Rate
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Description
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
               >
                 Status
               </th>
@@ -455,10 +455,10 @@ export default function TaxRates() {
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {filteredTaxRates?.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-6 py-4 text-center text-gray-500">
+                <td colSpan={5} className="px-6 py-4 text-center text-gray-500 dark:text-gray-400">
                   No tax rates found. Create your first tax rate to get started.
                 </td>
               </tr>
@@ -467,28 +467,28 @@ export default function TaxRates() {
                 <tr key={taxRate.Id}>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
-                      <span className="text-sm font-medium text-gray-900">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
                         {taxRate.Name}
                       </span>
                       {taxRate.IsDefault && (
-                        <span className="ml-2 inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 text-indigo-800">
+                        <span className="ml-2 inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300">
                           Default
                         </span>
                       )}
                     </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 font-mono">
                     {formatRate(taxRate.Rate)}
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                  <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
                     {taxRate.Description || '-'}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span
                       className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
                         taxRate.IsActive
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-gray-100 text-gray-800'
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                          : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300'
                       }`}
                     >
                       {taxRate.IsActive ? 'Active' : 'Inactive'}
@@ -498,20 +498,20 @@ export default function TaxRates() {
                     {!taxRate.IsDefault && taxRate.IsActive && (
                       <button
                         onClick={() => handleSetDefault(taxRate.Id)}
-                        className="text-indigo-600 hover:text-indigo-900 mr-4"
+                        className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 mr-4"
                       >
                         Set Default
                       </button>
                     )}
                     <button
                       onClick={() => handleEdit(taxRate)}
-                      className="text-indigo-600 hover:text-indigo-900 mr-4"
+                      className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 mr-4"
                     >
                       Edit
                     </button>
                     <button
                       onClick={() => handleDelete(taxRate.Id, taxRate.Name)}
-                      className="text-red-600 hover:text-red-900"
+                      className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300"
                     >
                       Delete
                     </button>
@@ -523,7 +523,7 @@ export default function TaxRates() {
         </table>
       </div>
 
-      <div className="mt-4 text-sm text-gray-500">
+      <div className="mt-4 text-sm text-gray-500 dark:text-gray-400">
         <p>
           Tax rates are automatically applied to taxable line items on invoices.
           The default tax rate will be pre-selected when creating new invoices.


### PR DESCRIPTION
## Summary
- **Rewrite 3 custom selectors** (CustomerSelector, ProductServiceSelector, VendorSelector) using MUI Autocomplete — eliminates ~450 lines of manual dropdown code with zero dark mode support, gains free a11y/keyboard navigation
- **Replace Account Code plain input** in NewJournalEntry with MUI Autocomplete fetching from `/accounts` API (displays "Code - Name")
- **Add `dark:` Tailwind variants** to all remaining un-themed pages: NewJournalEntry, NewTimeEntry, EstimateForm line items, Projects, TaxRates, Inventory, Classes

Closes #414, #399, #398, #411
Supersedes #403, #404, #405, #410, #412

## Changes by area

| Area | Files | What changed |
|------|-------|-------------|
| Selectors → MUI Autocomplete | `CustomerSelector`, `ProductServiceSelector`, `VendorSelector` | Full rewrite: custom dropdowns → MUI Autocomplete with same props interface |
| Account Code Autocomplete | `NewJournalEntry` | Plain input → Autocomplete with accounts API + react-hook-form Controller |
| Dark mode — Forms | `NewJournalEntry`, `NewTimeEntry` | bg, labels, inputs, errors, buttons, borders |
| Dark mode — EstimateForm | `EstimateForm` | Line item cards, labels, errors, amount, delete button, total |
| Dark mode — List pages | `Projects`, `TaxRates`, `Inventory`, `Classes` | Table headers/rows, badges, action links, filter inputs, modals |

## Test plan
- [ ] Toggle dark/light mode in Company Settings
- [ ] Verify `/invoices/new` — CustomerSelector, ProductServiceSelector render correctly
- [ ] Verify `/estimates/new` — CustomerSelector, ProductServiceSelector, line items themed
- [ ] Verify `/journal-entries/new` — Account Code autocomplete works, all form elements themed
- [ ] Verify `/time-entries/new` — all form elements themed
- [ ] Verify `/projects` — DataGrid renderCell text readable in dark mode
- [ ] Verify `/tax-rates` — form modal + table fully themed
- [ ] Verify `/inventory` — tabs + all three tables + adjustment modal themed
- [ ] Verify `/classes` — table fully themed
- [ ] Verify no regressions on existing themed pages (Dashboard, Invoices list, Customers list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)