### PR TITLE
refactor(#401): Migrate 19 form components to MUI for automatic dark mode

### DIFF
--- a/client/src/components/AccountForm.tsx
+++ b/client/src/components/AccountForm.tsx
@@ -1,8 +1,13 @@
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
 
 const accountTypes = ['Asset', 'Liability', 'Equity', 'Revenue', 'Expense'] as const;
 
@@ -36,9 +41,14 @@ interface AccountFormProps {
 
 export default function AccountForm({ initialValues, onSubmit, title, isSubmitting, submitButtonText = 'Save Account' }: AccountFormProps) {
   const navigate = useNavigate();
-  const { register, handleSubmit, watch, formState: { errors } } = useForm<AccountFormData>({
+  const { control, handleSubmit, watch } = useForm<AccountFormData>({
     resolver: zodResolver(accountSchema),
     defaultValues: {
+      Code: '',
+      Name: '',
+      Subtype: '',
+      AccountNumber: '',
+      Description: '',
       IsActive: true,
       ...initialValues
     }
@@ -50,7 +60,7 @@ export default function AccountForm({ initialValues, onSubmit, title, isSubmitti
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/accounts')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/accounts')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -58,115 +68,149 @@ export default function AccountForm({ initialValues, onSubmit, title, isSubmitti
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="Code" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Code *</label>
-            <input
-              id="Code"
-              type="text"
-              placeholder="e.g., 1000"
-              {...register('Code')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.Code && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Code.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="AccountNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Account Number</label>
-            <input
-              id="AccountNumber"
-              type="text"
-              placeholder="Optional"
-              {...register('AccountNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.AccountNumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.AccountNumber.message}</p>}
-          </div>
-        </div>
-
-        <div>
-          <label htmlFor="Name" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Name *</label>
-          <input
-            id="Name"
-            type="text"
-            placeholder="e.g., Cash in Bank"
-            {...register('Name')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          <Controller
+            name="Code"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Code"
+                required
+                placeholder="e.g., 1000"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
           />
-          {errors.Name && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Name.message}</p>}
+          <Controller
+            name="AccountNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Account Number"
+                placeholder="Optional"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
         </div>
+
+        <Controller
+          name="Name"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Name"
+              required
+              placeholder="e.g., Cash in Bank"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
         <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="Type" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Type *</label>
-            <select
-              id="Type"
-              {...register('Type')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select a type...</option>
-              {accountTypes.map(type => (
-                <option key={type} value={type}>{type}</option>
-              ))}
-            </select>
-            {errors.Type && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Type.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="Subtype" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Subtype</label>
-            <select
-              id="Subtype"
-              {...register('Subtype')}
-              disabled={!selectedType}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 disabled:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">{selectedType ? 'Select a subtype...' : 'Select type first'}</option>
-              {availableSubtypes.map(subtype => (
-                <option key={subtype} value={subtype}>{subtype}</option>
-              ))}
-            </select>
-            {errors.Subtype && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Subtype.message}</p>}
-          </div>
-        </div>
-
-        <div>
-          <label htmlFor="Description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
-          <textarea
-            id="Description"
-            rows={3}
-            placeholder="Optional description of the account"
-            {...register('Description')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          <Controller
+            name="Type"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Type"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select a type...</MenuItem>
+                {accountTypes.map(type => (
+                  <MenuItem key={type} value={type}>{type}</MenuItem>
+                ))}
+              </TextField>
+            )}
           />
-          {errors.Description && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Description.message}</p>}
-        </div>
-
-        <div className="flex items-center">
-          <input
-            id="IsActive"
-            type="checkbox"
-            {...register('IsActive')}
-            className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+          <Controller
+            name="Subtype"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Subtype"
+                disabled={!selectedType}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">{selectedType ? 'Select a subtype...' : 'Select type first'}</MenuItem>
+                {availableSubtypes.map(subtype => (
+                  <MenuItem key={subtype} value={subtype}>{subtype}</MenuItem>
+                ))}
+              </TextField>
+            )}
           />
-          <label htmlFor="IsActive" className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
-            Active account
-          </label>
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <Controller
+          name="Description"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Description"
+              multiline
+              rows={3}
+              placeholder="Optional description of the account"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        <Controller
+          name="IsActive"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={<Checkbox {...field} checked={field.value ?? false} />}
+              label="Active account"
+            />
+          )}
+        />
+
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <Button
+            variant="outlined"
             onClick={() => navigate('/accounts')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/BillForm.tsx
+++ b/client/src/components/BillForm.tsx
@@ -1,4 +1,4 @@
-import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { useForm, useFieldArray, useWatch, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
@@ -7,6 +7,10 @@ import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/api';
 import { useCompanySettings } from '../contexts/CompanySettingsContext';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 
 export const billSchema = z.object({
   VendorId: z.string().uuid('Please select a vendor'),
@@ -76,9 +80,13 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
   const { register, control, handleSubmit, setValue, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<BillFormData>({
     resolver: zodResolver(billSchema),
     defaultValues: {
+      VendorId: '',
+      BillNumber: '',
       Status: 'Open',
       BillDate: new Date().toISOString().split('T')[0],
       DueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+      Terms: '',
+      Memo: '',
       Lines: [{ AccountId: '', Description: '', Amount: 0 }],
       TotalAmount: 0,
       AmountPaid: 0,
@@ -131,7 +139,7 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/bills')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/bills')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -139,97 +147,145 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="VendorId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Vendor</label>
-            <select
-              id="VendorId"
-              {...register('VendorId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select a vendor...</option>
-              {vendors?.map((vendor) => (
-                <option key={vendor.Id} value={vendor.Id}>
-                  {vendor.Name}
-                </option>
-              ))}
-            </select>
-            {errors.VendorId && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.VendorId.message}</p>}
-          </div>
+          <Controller
+            name="VendorId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Vendor"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select a vendor...</MenuItem>
+                {vendors?.map((vendor) => (
+                  <MenuItem key={vendor.Id} value={vendor.Id}>
+                    {vendor.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="BillNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Bill Number</label>
-            <input
-              id="BillNumber"
-              type="text"
-              {...register('BillNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="BILL-001"
-            />
-            {errors.BillNumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.BillNumber.message}</p>}
-          </div>
+          <Controller
+            name="BillNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Bill Number"
+                placeholder="BILL-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="BillDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Bill Date</label>
-            <input
-              id="BillDate"
-              type="date"
-              {...register('BillDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.BillDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.BillDate.message}</p>}
-          </div>
+          <Controller
+            name="BillDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Bill Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="DueDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Due Date</label>
-            <input
-              id="DueDate"
-              type="date"
-              {...register('DueDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.DueDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.DueDate.message}</p>}
-          </div>
+          <Controller
+            name="DueDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Due Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="Terms" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Terms</label>
-            <select
-              id="Terms"
-              {...register('Terms')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select terms...</option>
-              <option value="Due on Receipt">Due on Receipt</option>
-              <option value="Net 15">Net 15</option>
-              <option value="Net 30">Net 30</option>
-              <option value="Net 45">Net 45</option>
-              <option value="Net 60">Net 60</option>
-            </select>
-          </div>
+          <Controller
+            name="Terms"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Payment Terms"
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select terms...</MenuItem>
+                <MenuItem value="Due on Receipt">Due on Receipt</MenuItem>
+                <MenuItem value="Net 15">Net 15</MenuItem>
+                <MenuItem value="Net 30">Net 30</MenuItem>
+                <MenuItem value="Net 45">Net 45</MenuItem>
+                <MenuItem value="Net 60">Net 60</MenuItem>
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="Status" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="Draft">Draft</option>
-              <option value="Open">Open</option>
-              <option value="Partial">Partial</option>
-              <option value="Paid">Paid</option>
-              <option value="Overdue">Overdue</option>
-            </select>
-            {errors.Status && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Status.message}</p>}
-          </div>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Draft">Draft</MenuItem>
+                <MenuItem value="Open">Open</MenuItem>
+                <MenuItem value="Partial">Partial</MenuItem>
+                <MenuItem value="Paid">Paid</MenuItem>
+                <MenuItem value="Overdue">Overdue</MenuItem>
+              </TextField>
+            )}
+          />
 
           <div className="sm:col-span-2">
-            <label htmlFor="Memo" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Memo</label>
-            <textarea
-              id="Memo"
-              {...register('Memo')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="Add notes about this bill..."
+            <Controller
+              name="Memo"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Memo"
+                  multiline
+                  rows={2}
+                  placeholder="Add notes about this bill..."
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
         </div>
@@ -238,64 +294,87 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
         <div className="mt-8">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Line Items</h3>
-            <button
+            <Button
               type="button"
+              variant="outlined"
+              size="small"
+              startIcon={<Plus className="w-4 h-4" />}
               onClick={() => append({ AccountId: '', Description: '', Amount: 0 })}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
             >
-              <Plus className="w-4 h-4 mr-1" />
               Add Item
-            </button>
+            </Button>
           </div>
 
           <div className="space-y-4">
             {fields.map((field, index) => (
-              <div key={field.id} className="flex gap-4 items-start bg-gray-50 p-4 rounded-md">
+              <div key={field.id} className="flex gap-4 items-start bg-gray-50 dark:bg-gray-700 p-4 rounded-md">
                 <div className="w-48">
-                  <label className="block text-xs font-medium text-gray-500">Account</label>
-                  <select
-                    {...register(`Lines.${index}.AccountId`)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                  >
-                    <option value="">Select account...</option>
-                    {expenseAccounts.map((account) => (
-                      <option key={account.Id} value={account.Id}>
-                        {account.Name}
-                      </option>
-                    ))}
-                  </select>
-                  {errors.Lines?.[index]?.AccountId && (
-                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.AccountId?.message}</p>
-                  )}
+                  <Controller
+                    name={`Lines.${index}.AccountId`}
+                    control={control}
+                    render={({ field: f, fieldState }) => (
+                      <TextField
+                        {...f}
+                        value={f.value ?? ''}
+                        select
+                        label="Account"
+                        error={!!fieldState.error}
+                        helperText={fieldState.error?.message}
+                        size="small"
+                        fullWidth
+                      >
+                        <MenuItem value="">Select account...</MenuItem>
+                        {expenseAccounts.map((account) => (
+                          <MenuItem key={account.Id} value={account.Id}>
+                            {account.Name}
+                          </MenuItem>
+                        ))}
+                      </TextField>
+                    )}
+                  />
                 </div>
                 <div className="flex-grow">
-                  <label className="block text-xs font-medium text-gray-500">Description</label>
-                  <input
-                    {...register(`Lines.${index}.Description`)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                    placeholder="Item description"
+                  <Controller
+                    name={`Lines.${index}.Description`}
+                    control={control}
+                    render={({ field: f }) => (
+                      <TextField
+                        {...f}
+                        value={f.value ?? ''}
+                        label="Description"
+                        placeholder="Item description"
+                        size="small"
+                        fullWidth
+                      />
+                    )}
                   />
                 </div>
                 <div className="w-32">
-                  <label className="block text-xs font-medium text-gray-500">Amount</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.Amount`, { valueAsNumber: true })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                  />
-                  {errors.Lines?.[index]?.Amount && (
-                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Amount?.message}</p>
-                  )}
+                  {(() => {
+                    const { ref, ...rest } = register(`Lines.${index}.Amount`, { valueAsNumber: true });
+                    return (
+                      <TextField
+                        {...rest}
+                        inputRef={ref}
+                        type="number"
+                        label="Amount"
+                        slotProps={{ htmlInput: { step: '0.01' } }}
+                        error={!!errors.Lines?.[index]?.Amount}
+                        helperText={errors.Lines?.[index]?.Amount?.message}
+                        size="small"
+                        fullWidth
+                      />
+                    );
+                  })()}
                 </div>
-                <button
-                  type="button"
+                <IconButton
                   onClick={() => remove(index)}
-                  className="mt-6 text-red-600 hover:text-red-800"
                   disabled={fields.length === 1}
+                  color="error"
+                  sx={{ mt: 0.5 }}
                 >
                   <Trash2 className="w-5 h-5" />
-                </button>
+                </IconButton>
               </div>
             ))}
           </div>
@@ -308,20 +387,20 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
         {settings.invoicePostingMode === 'simple' && (
           <div className={`flex items-center gap-2 p-3 rounded-lg ${
             willAutoPost
-              ? 'bg-amber-50 border border-amber-200'
-              : 'bg-gray-50 border border-gray-200'
+              ? 'bg-amber-50 border border-amber-200 dark:bg-amber-950 dark:border-amber-700'
+              : 'bg-gray-50 border border-gray-200 dark:bg-gray-700 dark:border-gray-600'
           }`}>
             {willAutoPost ? (
               <>
                 <Zap className="h-4 w-4 text-amber-500" />
-                <span className="text-sm text-amber-700">
+                <span className="text-sm text-amber-700 dark:text-amber-400">
                   This bill will <strong>post to your books</strong> when saved (AP + Expense entries).
                 </span>
               </>
             ) : (
               <>
-                <Info className="h-4 w-4 text-gray-400" />
-                <span className="text-sm text-gray-600">
+                <Info className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <span className="text-sm text-gray-600 dark:text-gray-400">
                   Draft bills don't affect your books until the status is changed.
                 </span>
               </>
@@ -329,24 +408,24 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
           </div>
         )}
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <div className="text-xl font-bold text-gray-900 mr-6">
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <div className="text-xl font-bold text-gray-900 dark:text-gray-100 mr-6">
             Total: ${lines.reduce((sum, line) => sum + (line.Amount || 0), 0).toFixed(2)}
           </div>
-          <button
-            type="button"
+          <Button
+            variant="outlined"
             onClick={() => navigate('/bills')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/ConfirmModal.tsx
+++ b/client/src/components/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import { X, AlertTriangle } from 'lucide-react';
+import Button from '@mui/material/Button';
 
 interface ConfirmModalProps {
   isOpen: boolean;
@@ -25,47 +26,43 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   if (!isOpen) return null;
 
-  const confirmButtonClass =
-    variant === 'danger'
-      ? 'bg-red-600 hover:bg-red-700 focus:ring-red-500'
-      : 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500';
-
   return (
-    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full shadow-xl">
+    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-80 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full shadow-xl">
         <div className="flex justify-between items-start mb-4">
           <div className="flex items-center">
             {variant === 'danger' && (
               <AlertTriangle className="h-6 w-6 text-red-600 mr-2" />
             )}
-            <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
+            className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-400"
             disabled={isLoading}
           >
             <X className="h-5 w-5" />
           </button>
         </div>
 
-        <p className="text-sm text-gray-600 mb-6">{message}</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">{message}</p>
 
         <div className="flex justify-end space-x-3">
-          <button
+          <Button
+            variant="outlined"
             onClick={onClose}
             disabled={isLoading}
-            className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
           >
             {cancelText}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="contained"
+            color={variant === 'danger' ? 'error' : 'primary'}
             onClick={onConfirm}
             disabled={isLoading}
-            className={`px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 ${confirmButtonClass}`}
           >
             {isLoading ? 'Processing...' : confirmText}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/client/src/components/CreditMemoForm.tsx
+++ b/client/src/components/CreditMemoForm.tsx
@@ -1,4 +1,4 @@
-import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { useForm, useFieldArray, useWatch, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
@@ -6,6 +6,10 @@ import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/api';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 
 export const creditMemoSchema = z.object({
   CustomerId: z.string().uuid('Please select a customer'),
@@ -92,9 +96,12 @@ export default function CreditMemoForm({ initialValues, onSubmit, title, isSubmi
   const { register, control, handleSubmit, setValue, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<CreditMemoFormData>({
     resolver: zodResolver(creditMemoSchema),
     defaultValues: {
+      CustomerId: '',
+      CreditMemoNumber: '',
       Status: 'Open',
       CreditDate: new Date().toISOString().split('T')[0],
-      Lines: [{ AccountId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 }],
+      Reason: '',
+      Lines: [{ AccountId: '', ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 }],
       Subtotal: 0,
       TaxAmount: 0,
       TotalAmount: 0,
@@ -151,78 +158,113 @@ export default function CreditMemoForm({ initialValues, onSubmit, title, isSubmi
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/credit-memos')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/credit-memos')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6 dark:bg-gray-800">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700">Customer</label>
-            <select
-              id="CustomerId"
-              {...register('CustomerId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select a customer...</option>
-              {customers?.map((customer) => (
-                <option key={customer.Id} value={customer.Id}>
-                  {customer.Name}
-                </option>
-              ))}
-            </select>
-            {errors.CustomerId && <p className="mt-1 text-sm text-red-600">{errors.CustomerId.message}</p>}
-          </div>
+          <Controller
+            name="CustomerId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Customer"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select a customer...</MenuItem>
+                {customers?.map((customer) => (
+                  <MenuItem key={customer.Id} value={customer.Id}>
+                    {customer.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="CreditMemoNumber" className="block text-sm font-medium text-gray-700">Credit Memo Number</label>
-            <input
-              id="CreditMemoNumber"
-              type="text"
-              {...register('CreditMemoNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="CM-001"
-            />
-            {errors.CreditMemoNumber && <p className="mt-1 text-sm text-red-600">{errors.CreditMemoNumber.message}</p>}
-          </div>
+          <Controller
+            name="CreditMemoNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Credit Memo Number"
+                required
+                placeholder="CM-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="CreditDate" className="block text-sm font-medium text-gray-700">Credit Date</label>
-            <input
-              id="CreditDate"
-              type="date"
-              {...register('CreditDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.CreditDate && <p className="mt-1 text-sm text-red-600">{errors.CreditDate.message}</p>}
-          </div>
+          <Controller
+            name="CreditDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Credit Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="Status" className="block text-sm font-medium text-gray-700">Status</label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="Open">Open</option>
-              <option value="Applied">Applied</option>
-              <option value="PartiallyApplied">Partially Applied</option>
-              <option value="Refunded">Refunded</option>
-              <option value="Voided">Voided</option>
-            </select>
-            {errors.Status && <p className="mt-1 text-sm text-red-600">{errors.Status.message}</p>}
-          </div>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Open">Open</MenuItem>
+                <MenuItem value="Applied">Applied</MenuItem>
+                <MenuItem value="PartiallyApplied">Partially Applied</MenuItem>
+                <MenuItem value="Refunded">Refunded</MenuItem>
+                <MenuItem value="Voided">Voided</MenuItem>
+              </TextField>
+            )}
+          />
 
           <div className="sm:col-span-2">
-            <label htmlFor="Reason" className="block text-sm font-medium text-gray-700">Reason / Notes</label>
-            <textarea
-              id="Reason"
-              {...register('Reason')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="Reason for credit memo (e.g., returned goods, price adjustment, billing error)..."
+            <Controller
+              name="Reason"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Reason / Notes"
+                  multiline
+                  rows={2}
+                  placeholder="Reason for credit memo (e.g., returned goods, price adjustment, billing error)..."
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
         </div>
@@ -230,139 +272,187 @@ export default function CreditMemoForm({ initialValues, onSubmit, title, isSubmi
         {/* Line Items */}
         <div className="mt-8">
           <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-medium text-gray-900">Line Items</h3>
-            <button
+            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Line Items</h3>
+            <Button
               type="button"
-              onClick={() => append({ AccountId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 })}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
+              variant="outlined"
+              size="small"
+              startIcon={<Plus className="w-4 h-4" />}
+              onClick={() => append({ AccountId: '', ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 })}
             >
-              <Plus className="w-4 h-4 mr-1" />
               Add Item
-            </button>
+            </Button>
           </div>
 
           <div className="space-y-4">
             {fields.map((field, index) => (
-              <div key={field.id} className="flex gap-4 items-start bg-gray-50 p-4 rounded-md flex-wrap">
+              <div key={field.id} className="flex gap-4 items-start bg-gray-50 p-4 rounded-md flex-wrap dark:bg-gray-700">
                 <div className="w-40">
-                  <label className="block text-xs font-medium text-gray-500">Product/Service</label>
-                  <select
-                    {...register(`Lines.${index}.ProductServiceId`)}
-                    onChange={(e) => handleProductChange(index, e.target.value)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  >
-                    <option value="">Optional...</option>
-                    {productsServices?.map((ps) => (
-                      <option key={ps.Id} value={ps.Id}>
-                        {ps.Name}
-                      </option>
-                    ))}
-                  </select>
+                  <Controller
+                    name={`Lines.${index}.ProductServiceId`}
+                    control={control}
+                    render={({ field: f }) => (
+                      <TextField
+                        {...f}
+                        value={f.value ?? ''}
+                        select
+                        label="Product/Service"
+                        size="small"
+                        fullWidth
+                        onChange={(e) => {
+                          f.onChange(e);
+                          handleProductChange(index, e.target.value);
+                        }}
+                      >
+                        <MenuItem value="">Optional...</MenuItem>
+                        {productsServices?.map((ps) => (
+                          <MenuItem key={ps.Id} value={ps.Id}>
+                            {ps.Name}
+                          </MenuItem>
+                        ))}
+                      </TextField>
+                    )}
+                  />
                 </div>
                 <div className="w-40">
-                  <label className="block text-xs font-medium text-gray-500">Account</label>
-                  <select
-                    {...register(`Lines.${index}.AccountId`)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  >
-                    <option value="">Select account...</option>
-                    {revenueAccounts.map((account) => (
-                      <option key={account.Id} value={account.Id}>
-                        {account.Name}
-                      </option>
-                    ))}
-                  </select>
-                  {errors.Lines?.[index]?.AccountId && (
-                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.AccountId?.message}</p>
-                  )}
+                  <Controller
+                    name={`Lines.${index}.AccountId`}
+                    control={control}
+                    render={({ field: f, fieldState }) => (
+                      <TextField
+                        {...f}
+                        value={f.value ?? ''}
+                        select
+                        label="Account"
+                        error={!!fieldState.error}
+                        helperText={fieldState.error?.message}
+                        size="small"
+                        fullWidth
+                      >
+                        <MenuItem value="">Select account...</MenuItem>
+                        {revenueAccounts.map((account) => (
+                          <MenuItem key={account.Id} value={account.Id}>
+                            {account.Name}
+                          </MenuItem>
+                        ))}
+                      </TextField>
+                    )}
+                  />
                 </div>
                 <div className="flex-grow min-w-32">
-                  <label className="block text-xs font-medium text-gray-500">Description</label>
-                  <input
-                    {...register(`Lines.${index}.Description`)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                    placeholder="Item description"
+                  <Controller
+                    name={`Lines.${index}.Description`}
+                    control={control}
+                    render={({ field: f }) => (
+                      <TextField
+                        {...f}
+                        value={f.value ?? ''}
+                        label="Description"
+                        placeholder="Item description"
+                        size="small"
+                        fullWidth
+                      />
+                    )}
                   />
                 </div>
                 <div className="w-20">
-                  <label className="block text-xs font-medium text-gray-500">Qty</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.Quantity`, {
+                  {(() => {
+                    const { ref, ...rest } = register(`Lines.${index}.Quantity`, {
                       valueAsNumber: true,
                       onChange: (e) => {
                         const qty = parseFloat(e.target.value) || 0;
                         const price = lines[index]?.UnitPrice || 0;
                         updateLineAmount(index, qty, price);
                       }
-                    })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  />
+                    });
+                    return (
+                      <TextField
+                        {...rest}
+                        inputRef={ref}
+                        type="number"
+                        label="Qty"
+                        slotProps={{ htmlInput: { step: '0.01' } }}
+                        size="small"
+                        fullWidth
+                      />
+                    );
+                  })()}
                 </div>
                 <div className="w-24">
-                  <label className="block text-xs font-medium text-gray-500">Unit Price</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.UnitPrice`, {
+                  {(() => {
+                    const { ref, ...rest } = register(`Lines.${index}.UnitPrice`, {
                       valueAsNumber: true,
                       onChange: (e) => {
                         const price = parseFloat(e.target.value) || 0;
                         const qty = lines[index]?.Quantity || 0;
                         updateLineAmount(index, qty, price);
                       }
-                    })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  />
+                    });
+                    return (
+                      <TextField
+                        {...rest}
+                        inputRef={ref}
+                        type="number"
+                        label="Unit Price"
+                        slotProps={{ htmlInput: { step: '0.01' } }}
+                        size="small"
+                        fullWidth
+                      />
+                    );
+                  })()}
                 </div>
                 <div className="w-24">
-                  <label className="block text-xs font-medium text-gray-500">Amount</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.Amount`, { valueAsNumber: true })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 bg-gray-100"
-                    readOnly
-                  />
-                  {errors.Lines?.[index]?.Amount && (
-                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Amount?.message}</p>
-                  )}
+                  {(() => {
+                    const { ref, ...rest } = register(`Lines.${index}.Amount`, { valueAsNumber: true });
+                    return (
+                      <TextField
+                        {...rest}
+                        inputRef={ref}
+                        type="number"
+                        label="Amount"
+                        slotProps={{ htmlInput: { step: '0.01', readOnly: true } }}
+                        error={!!errors.Lines?.[index]?.Amount}
+                        helperText={errors.Lines?.[index]?.Amount?.message}
+                        size="small"
+                        fullWidth
+                      />
+                    );
+                  })()}
                 </div>
-                <button
-                  type="button"
+                <IconButton
                   onClick={() => remove(index)}
-                  className="mt-6 text-red-600 hover:text-red-800"
                   disabled={fields.length === 1}
+                  color="error"
+                  sx={{ mt: 0.5 }}
                 >
                   <Trash2 className="w-5 h-5" />
-                </button>
+                </IconButton>
               </div>
             ))}
           </div>
           {errors.Lines && typeof errors.Lines === 'object' && 'message' in errors.Lines && (
-            <p className="mt-2 text-sm text-red-600">{errors.Lines.message}</p>
+            <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.Lines.message}</p>
           )}
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <div className="text-xl font-bold text-gray-900 mr-6">
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <div className="text-xl font-bold text-gray-900 dark:text-gray-100 mr-6">
             Total Credit: ${lines.reduce((sum, line) => sum + (line.Amount || 0), 0).toFixed(2)}
           </div>
-          <button
-            type="button"
+          <Button
+            variant="outlined"
             onClick={() => navigate('/credit-memos')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/CustomerDepositForm.tsx
+++ b/client/src/components/CustomerDepositForm.tsx
@@ -5,6 +5,10 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
 import CustomerSelector from './CustomerSelector';
 import api from '../lib/api';
 
@@ -94,7 +98,7 @@ export default function CustomerDepositForm({
     }
   });
 
-  const { register, control, handleSubmit, watch, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<CustomerDepositFormData>({
+  const { control, handleSubmit, watch, formState: { errors, isSubmitting: formIsSubmitting } } = useForm<CustomerDepositFormData>({
     resolver: zodResolver(customerDepositSchema),
     defaultValues: {
       DepositDate: new Date().toISOString().split('T')[0],
@@ -134,219 +138,277 @@ export default function CustomerDepositForm({
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center">
-          <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700">
+          <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
             <ArrowLeft className="w-6 h-6" />
           </button>
-          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
         </div>
         {headerActions && <div className="flex items-center">{headerActions}</div>}
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6 dark:bg-gray-800">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="DepositNumber" className="block text-sm font-medium text-gray-700">Deposit Number</label>
-            <input
-              id="DepositNumber"
-              type="text"
-              {...register('DepositNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="DEP-001"
-            />
-            {errors.DepositNumber && <p className="mt-1 text-sm text-red-600">{errors.DepositNumber.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700">Customer</label>
-            <Controller
-              name="CustomerId"
-              control={control}
-              render={({ field }) => (
-                <CustomerSelector
-                  value={field.value || ''}
-                  onChange={field.onChange}
-                  error={errors.CustomerId?.message}
-                  disabled={isSubmitting}
-                />
-              )}
-            />
-          </div>
-
-          <div>
-            <label htmlFor="DepositDate" className="block text-sm font-medium text-gray-700">Deposit Date</label>
-            <input
-              id="DepositDate"
-              type="date"
-              {...register('DepositDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.DepositDate && <p className="mt-1 text-sm text-red-600">{errors.DepositDate.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="Amount" className="block text-sm font-medium text-gray-700">Amount</label>
-            <div className="mt-1 relative rounded-md shadow-sm">
-              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                <span className="text-gray-500 sm:text-sm">$</span>
-              </div>
-              <input
-                id="Amount"
-                type="number"
-                step="0.01"
-                min="0.01"
-                {...register('Amount', { valueAsNumber: true })}
-                className="block w-full rounded-md border-gray-300 pl-7 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                placeholder="0.00"
+          <Controller
+            name="DepositNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Deposit Number"
+                required
+                placeholder="DEP-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
               />
-            </div>
-            {errors.Amount && <p className="mt-1 text-sm text-red-600">{errors.Amount.message}</p>}
-          </div>
+            )}
+          />
 
-          <div>
-            <label htmlFor="PaymentMethod" className="block text-sm font-medium text-gray-700">Payment Method</label>
-            <select
-              id="PaymentMethod"
-              {...register('PaymentMethod')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              {PAYMENT_METHODS.map(method => (
-                <option key={method} value={method}>{method}</option>
-              ))}
-            </select>
-            {errors.PaymentMethod && <p className="mt-1 text-sm text-red-600">{errors.PaymentMethod.message}</p>}
-          </div>
+          <Controller
+            name="CustomerId"
+            control={control}
+            render={({ field }) => (
+              <CustomerSelector
+                value={field.value || ''}
+                onChange={field.onChange}
+                error={errors.CustomerId?.message}
+                disabled={isSubmitting}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="Reference" className="block text-sm font-medium text-gray-700">Reference / Check #</label>
-            <input
-              id="Reference"
-              type="text"
-              {...register('Reference')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="Optional reference number"
-            />
-          </div>
+          <Controller
+            name="DepositDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Deposit Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="DepositAccountId" className="block text-sm font-medium text-gray-700">Deposit To Account</label>
-            <select
-              id="DepositAccountId"
-              {...register('DepositAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select bank account</option>
-              {bankAccounts?.map(account => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
-                </option>
-              ))}
-            </select>
-            {errors.DepositAccountId && <p className="mt-1 text-sm text-red-600">{errors.DepositAccountId.message}</p>}
-          </div>
+          <Controller
+            name="Amount"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                onChange={(e) => field.onChange(e.target.value === '' ? '' : Number(e.target.value))}
+                label="Amount"
+                type="number"
+                required
+                placeholder="0.00"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{
+                  input: {
+                    startAdornment: <InputAdornment position="start">$</InputAdornment>
+                  },
+                  htmlInput: { step: '0.01', min: '0.01' }
+                }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="LiabilityAccountId" className="block text-sm font-medium text-gray-700">
-              Liability Account (Unearned Revenue)
-            </label>
-            <select
-              id="LiabilityAccountId"
-              {...register('LiabilityAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select liability account</option>
-              {liabilityAccounts?.map(account => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
-                </option>
-              ))}
-            </select>
-            {errors.LiabilityAccountId && <p className="mt-1 text-sm text-red-600">{errors.LiabilityAccountId.message}</p>}
-          </div>
+          <Controller
+            name="PaymentMethod"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                select
+                label="Payment Method"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                {PAYMENT_METHODS.map(method => (
+                  <MenuItem key={method} value={method}>{method}</MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+
+          <Controller
+            name="Reference"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Reference / Check #"
+                placeholder="Optional reference number"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
+
+          <Controller
+            name="DepositAccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Deposit To Account"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select bank account</MenuItem>
+                {bankAccounts?.map(account => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+
+          <Controller
+            name="LiabilityAccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Liability Account (Unearned Revenue)"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select liability account</MenuItem>
+                {liabilityAccounts?.map(account => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
           {/* Optional: Link to Project */}
           {watchedCustomerId && projects && projects.length > 0 && (
-            <div>
-              <label htmlFor="ProjectId" className="block text-sm font-medium text-gray-700">
-                Project (Optional)
-              </label>
-              <select
-                id="ProjectId"
-                {...register('ProjectId')}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              >
-                <option value="">No project</option>
-                {projects.map(project => (
-                  <option key={project.Id} value={project.Id}>
-                    {project.Name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <Controller
+              name="ProjectId"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Project (Optional)"
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="">No project</MenuItem>
+                  {projects.map(project => (
+                    <MenuItem key={project.Id} value={project.Id}>
+                      {project.Name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
           )}
 
           {/* Optional: Link to Estimate */}
           {watchedCustomerId && estimates && estimates.length > 0 && (
-            <div>
-              <label htmlFor="EstimateId" className="block text-sm font-medium text-gray-700">
-                Estimate (Optional)
-              </label>
-              <select
-                id="EstimateId"
-                {...register('EstimateId')}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              >
-                <option value="">No estimate</option>
-                {estimates.map(estimate => (
-                  <option key={estimate.Id} value={estimate.Id}>
-                    {estimate.EstimateNumber} (${estimate.TotalAmount.toFixed(2)})
-                  </option>
-                ))}
-              </select>
-            </div>
+            <Controller
+              name="EstimateId"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Estimate (Optional)"
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="">No estimate</MenuItem>
+                  {estimates.map(estimate => (
+                    <MenuItem key={estimate.Id} value={estimate.Id}>
+                      {estimate.EstimateNumber} (${estimate.TotalAmount.toFixed(2)})
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
           )}
 
           <div className="sm:col-span-2">
-            <label htmlFor="Memo" className="block text-sm font-medium text-gray-700">Memo</label>
-            <textarea
-              id="Memo"
-              {...register('Memo')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="Optional notes about this deposit"
+            <Controller
+              name="Memo"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Memo"
+                  multiline
+                  rows={2}
+                  placeholder="Optional notes about this deposit"
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
         </div>
 
         {/* Info box about journal entry */}
-        <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
-          <h4 className="text-sm font-medium text-blue-800 mb-2">Journal Entry Preview</h4>
-          <p className="text-sm text-blue-700">
+        <div className="bg-blue-50 border border-blue-200 rounded-md p-4 dark:bg-blue-950 dark:border-blue-800">
+          <h4 className="text-sm font-medium text-blue-800 mb-2 dark:text-blue-300">Journal Entry Preview</h4>
+          <p className="text-sm text-blue-700 dark:text-blue-400">
             This deposit will create a journal entry:
           </p>
-          <ul className="text-sm text-blue-700 mt-2 space-y-1">
+          <ul className="text-sm text-blue-700 dark:text-blue-400 mt-2 space-y-1">
             <li><strong>Debit:</strong> Selected bank account (Asset increases)</li>
             <li><strong>Credit:</strong> Unearned Revenue (Liability increases)</li>
           </ul>
-          <p className="text-sm text-blue-600 mt-2 italic">
+          <p className="text-sm text-blue-600 mt-2 italic dark:text-blue-400">
             When applied to an invoice, the liability is reversed and revenue is recognized.
           </p>
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <Button
+            variant="outlined"
             onClick={() => navigate(-1)}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Processing...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/CustomerForm.tsx
+++ b/client/src/components/CustomerForm.tsx
@@ -1,8 +1,10 @@
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
 import AddressFields, { AddressFieldValues } from './AddressFields';
 
 export const customerSchema = z.object({
@@ -32,57 +34,78 @@ interface CustomerFormProps {
 
 export default function CustomerForm({ initialValues, onSubmit, title, isSubmitting, submitButtonText = 'Save Customer' }: CustomerFormProps) {
   const navigate = useNavigate();
-  const { register, handleSubmit, setValue, formState: { errors } } = useForm<CustomerFormData>({
+  const { control, register, handleSubmit, setValue, formState: { errors } } = useForm<CustomerFormData>({
     resolver: zodResolver(customerSchema),
-    defaultValues: initialValues
+    defaultValues: {
+      Name: '',
+      Email: '',
+      Phone: '',
+      ...initialValues,
+    }
   });
 
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/customers')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/customers')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
-        <div>
-          <label htmlFor="Name" className="block text-sm font-medium text-gray-700">Name</label>
-          <input
-            id="Name"
-            type="text"
-            {...register('Name')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-          />
-          {errors.Name && <p className="mt-1 text-sm text-red-600">{errors.Name.message}</p>}
-        </div>
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
+        <Controller
+          name="Name"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Name"
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
-        <div>
-          <label htmlFor="Email" className="block text-sm font-medium text-gray-700">Email</label>
-          <input
-            id="Email"
-            type="email"
-            {...register('Email')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-          />
-          {errors.Email && <p className="mt-1 text-sm text-red-600">{errors.Email.message}</p>}
-        </div>
+        <Controller
+          name="Email"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Email"
+              type="email"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
-        <div>
-          <label htmlFor="Phone" className="block text-sm font-medium text-gray-700">Phone</label>
-          <input
-            id="Phone"
-            type="text"
-            {...register('Phone')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-          />
-          {errors.Phone && <p className="mt-1 text-sm text-red-600">{errors.Phone.message}</p>}
-        </div>
+        <Controller
+          name="Phone"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Phone"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
-        {/* Address Section */}
-        <div className="border-t pt-4">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">Address</h3>
+        {/* Address Section - AddressFields uses register directly */}
+        <div className="border-t pt-4 dark:border-gray-600">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">Address</h3>
           <AddressFields<CustomerFormData>
             register={register}
             errors={errors}
@@ -92,21 +115,13 @@ export default function CustomerForm({ initialValues, onSubmit, title, isSubmitt
           />
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
-            onClick={() => navigate('/customers')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-          >
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <Button variant="outlined" onClick={() => navigate('/customers')} sx={{ mr: 1.5 }}>
             Cancel
-          </button>
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
-          >
+          </Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/EmailSettingsForm.tsx
+++ b/client/src/components/EmailSettingsForm.tsx
@@ -1,8 +1,14 @@
 import { useState, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { Save, TestTube, Loader2, CheckCircle, XCircle, Eye, EyeOff, Info } from 'lucide-react';
+import TextField from '@mui/material/TextField';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
 import { emailSettingsApi, EmailSettings } from '../lib/emailApi';
 
 const emailSettingsSchema = z.object({
@@ -56,7 +62,7 @@ export default function EmailSettingsForm() {
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
 
-  const { register, handleSubmit, reset, formState: { errors } } = useForm<EmailSettingsFormData>({
+  const { control, handleSubmit, reset } = useForm<EmailSettingsFormData>({
     resolver: zodResolver(emailSettingsSchema),
     defaultValues: {
       SmtpHost: '',
@@ -168,125 +174,163 @@ export default function EmailSettingsForm() {
       {/* SMTP Server Settings */}
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
         <div className="sm:col-span-2">
-          <label htmlFor="SmtpHost" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-            SMTP Host *
-          </label>
-          <input
-            type="text"
-            id="SmtpHost"
-            placeholder="smtp.example.com"
-            {...register('SmtpHost')}
-            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          <Controller
+            name="SmtpHost"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="SMTP Host"
+                required
+                placeholder="smtp.example.com"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
           />
-          {errors.SmtpHost && <p className="mt-1 text-sm text-red-600">{errors.SmtpHost.message}</p>}
         </div>
 
-        <div>
-          <label htmlFor="SmtpPort" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-            SMTP Port *
-          </label>
-          <input
-            type="number"
-            id="SmtpPort"
-            {...register('SmtpPort')}
-            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          />
-          {errors.SmtpPort && <p className="mt-1 text-sm text-red-600">{errors.SmtpPort.message}</p>}
-        </div>
+        <Controller
+          name="SmtpPort"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              onChange={(e) => field.onChange(e.target.value === '' ? undefined : Number(e.target.value))}
+              label="SMTP Port"
+              type="number"
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
         <div className="flex items-center">
-          <input
-            type="checkbox"
-            id="SmtpSecure"
-            {...register('SmtpSecure')}
-            className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+          <Controller
+            name="SmtpSecure"
+            control={control}
+            render={({ field }) => (
+              <FormControlLabel
+                control={<Checkbox {...field} checked={field.value ?? false} />}
+                label="Use TLS/SSL (recommended)"
+              />
+            )}
           />
-          <label htmlFor="SmtpSecure" className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
-            Use TLS/SSL (recommended)
-          </label>
         </div>
 
-        <div>
-          <label htmlFor="SmtpUsername" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-            Username *
-          </label>
-          <input
-            type="text"
-            id="SmtpUsername"
-            placeholder="your-email@example.com"
-            {...register('SmtpUsername')}
-            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          />
-          {errors.SmtpUsername && <p className="mt-1 text-sm text-red-600">{errors.SmtpUsername.message}</p>}
-        </div>
-
-        <div>
-          <label htmlFor="SmtpPassword" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-            Password {hasExistingPassword ? '(leave blank to keep current)' : '*'}
-          </label>
-          <div className="relative">
-            <input
-              type={showPassword ? 'text' : 'password'}
-              id="SmtpPassword"
-              placeholder={hasExistingPassword ? '••••••••' : 'Enter password'}
-              {...register('SmtpPassword')}
-              className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 pr-10 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+        <Controller
+          name="SmtpUsername"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Username"
+              required
+              placeholder="your-email@example.com"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
             />
-            <button
-              type="button"
-              onClick={() => setShowPassword(!showPassword)}
-              className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
-            >
-              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-            </button>
-          </div>
-        </div>
+          )}
+        />
+
+        <Controller
+          name="SmtpPassword"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label={hasExistingPassword ? 'Password (leave blank to keep current)' : 'Password'}
+              type={showPassword ? 'text' : 'password'}
+              placeholder={hasExistingPassword ? '........' : 'Enter password'}
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={() => setShowPassword(!showPassword)}
+                        edge="end"
+                        size="small"
+                      >
+                        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+            />
+          )}
+        />
       </div>
 
       {/* Sender Settings */}
       <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
         <h3 className="text-md font-semibold text-gray-700 dark:text-gray-200 mb-4">Sender Information</h3>
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="FromName" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-              From Name *
-            </label>
-            <input
-              type="text"
-              id="FromName"
-              placeholder="Your Company Name"
-              {...register('FromName')}
-              className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            />
-            {errors.FromName && <p className="mt-1 text-sm text-red-600">{errors.FromName.message}</p>}
-          </div>
+          <Controller
+            name="FromName"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="From Name"
+                required
+                placeholder="Your Company Name"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="FromEmail" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-              From Email *
-            </label>
-            <input
-              type="email"
-              id="FromEmail"
-              placeholder="billing@example.com"
-              {...register('FromEmail')}
-              className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            />
-            {errors.FromEmail && <p className="mt-1 text-sm text-red-600">{errors.FromEmail.message}</p>}
-          </div>
+          <Controller
+            name="FromEmail"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="From Email"
+                type="email"
+                required
+                placeholder="billing@example.com"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
           <div className="sm:col-span-2">
-            <label htmlFor="ReplyToEmail" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-              Reply-To Email (optional)
-            </label>
-            <input
-              type="email"
-              id="ReplyToEmail"
-              placeholder="support@example.com"
-              {...register('ReplyToEmail')}
-              className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            <Controller
+              name="ReplyToEmail"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Reply-To Email (optional)"
+                  type="email"
+                  placeholder="support@example.com"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
-            {errors.ReplyToEmail && <p className="mt-1 text-sm text-red-600">{errors.ReplyToEmail.message}</p>}
           </div>
         </div>
       </div>
@@ -296,7 +340,7 @@ export default function EmailSettingsForm() {
         <div className="flex items-start justify-between mb-4">
           <h3 className="text-md font-semibold text-gray-700 dark:text-gray-200">Email Template</h3>
           <div className="relative group">
-            <button type="button" className="text-gray-400 hover:text-gray-600">
+            <button type="button" className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-400">
               <Info className="h-5 w-5" />
             </button>
             <div className="absolute right-0 w-64 p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
@@ -313,31 +357,44 @@ export default function EmailSettingsForm() {
         </div>
 
         <div className="space-y-4">
-          <div>
-            <label htmlFor="EmailSubjectTemplate" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-              Subject Template *
-            </label>
-            <input
-              type="text"
-              id="EmailSubjectTemplate"
-              {...register('EmailSubjectTemplate')}
-              className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            />
-            {errors.EmailSubjectTemplate && <p className="mt-1 text-sm text-red-600">{errors.EmailSubjectTemplate.message}</p>}
-          </div>
+          <Controller
+            name="EmailSubjectTemplate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Subject Template"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="EmailBodyTemplate" className="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-2">
-              Body Template *
-            </label>
-            <textarea
-              id="EmailBodyTemplate"
-              rows={10}
-              {...register('EmailBodyTemplate')}
-              className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm py-2.5 font-mono dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            />
-            {errors.EmailBodyTemplate && <p className="mt-1 text-sm text-red-600">{errors.EmailBodyTemplate.message}</p>}
-          </div>
+          <Controller
+            name="EmailBodyTemplate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Body Template"
+                required
+                multiline
+                rows={10}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{
+                  input: {
+                    sx: { fontFamily: 'monospace' },
+                  },
+                }}
+              />
+            )}
+          />
         </div>
       </div>
 
@@ -368,31 +425,23 @@ export default function EmailSettingsForm() {
 
       {/* Actions */}
       <div className="flex justify-end gap-3">
-        <button
+        <Button
           type="button"
+          variant="outlined"
           onClick={handleTestConnection}
           disabled={isTesting}
-          className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+          startIcon={isTesting ? <Loader2 className="h-4 w-4 animate-spin" /> : <TestTube className="h-4 w-4" />}
         >
-          {isTesting ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <TestTube className="h-4 w-4" />
-          )}
           {isTesting ? 'Testing...' : 'Test Connection'}
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
+          variant="contained"
           disabled={isSaving}
-          className="inline-flex items-center gap-2 px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+          startIcon={isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
         >
-          {isSaving ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Save className="h-4 w-4" />
-          )}
           {isSaving ? 'Saving...' : 'Save Settings'}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/client/src/components/EmployeeForm.tsx
+++ b/client/src/components/EmployeeForm.tsx
@@ -3,6 +3,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
 import AddressAutocomplete, { AddressSuggestion } from './AddressAutocomplete';
 import { US_STATES } from './AddressFields';
 import PlaidBankVerification from './PlaidBankVerification';
@@ -93,17 +97,36 @@ export default function EmployeeForm({
   bankVerifiedAt,
 }: EmployeeFormProps) {
   const navigate = useNavigate();
-  const { register, handleSubmit, formState: { errors }, watch, control, setValue } = useForm<EmployeeFormData>({
+  const { handleSubmit, watch, control, setValue } = useForm<EmployeeFormData>({
     resolver: zodResolver(employeeSchema),
     defaultValues: {
+      EmployeeNumber: '',
+      FirstName: '',
+      LastName: '',
+      Email: '',
+      Phone: '',
+      SSNLast4: '',
+      DateOfBirth: '',
+      HireDate: '',
+      TerminationDate: '',
       PayType: 'Hourly',
+      PayRate: 0,
       PayFrequency: 'Biweekly',
       FederalFilingStatus: 'Single',
       FederalAllowances: 0,
+      StateCode: '',
+      StateFilingStatus: '',
       StateAllowances: 0,
+      BankRoutingNumber: '',
+      BankAccountNumber: '',
+      BankAccountType: '',
+      Address: '',
+      City: '',
+      State: '',
+      ZipCode: '',
       Status: 'Active',
-      ...initialValues
-    }
+      ...initialValues,
+    },
   });
 
   // Handle address selection from autocomplete
@@ -115,8 +138,6 @@ export default function EmployeeForm({
 
   const payType = watch('PayType');
 
-  const inputClass = "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:bg-gray-700 dark:border-gray-600 dark:text-white";
-  const labelClass = "block text-sm font-medium text-gray-700 dark:text-gray-300";
   const sectionClass = "bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4";
   const sectionTitleClass = "text-lg font-medium text-gray-900 dark:text-white border-b pb-2 mb-4 dark:border-gray-600";
 
@@ -134,34 +155,102 @@ export default function EmployeeForm({
         <div className={sectionClass}>
           <h2 className={sectionTitleClass}>Personal Information</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="FirstName" className={labelClass}>First Name *</label>
-              <input id="FirstName" type="text" {...register('FirstName')} className={inputClass} />
-              {errors.FirstName && <p className="mt-1 text-sm text-red-600">{errors.FirstName.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="LastName" className={labelClass}>Last Name *</label>
-              <input id="LastName" type="text" {...register('LastName')} className={inputClass} />
-              {errors.LastName && <p className="mt-1 text-sm text-red-600">{errors.LastName.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="Email" className={labelClass}>Email</label>
-              <input id="Email" type="email" {...register('Email')} className={inputClass} />
-              {errors.Email && <p className="mt-1 text-sm text-red-600">{errors.Email.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="Phone" className={labelClass}>Phone</label>
-              <input id="Phone" type="text" {...register('Phone')} className={inputClass} placeholder="(555) 123-4567" />
-            </div>
-            <div>
-              <label htmlFor="SSNLast4" className={labelClass}>SSN (Last 4 Digits)</label>
-              <input id="SSNLast4" type="text" maxLength={4} {...register('SSNLast4')} className={inputClass} placeholder="1234" />
-              {errors.SSNLast4 && <p className="mt-1 text-sm text-red-600">{errors.SSNLast4.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="DateOfBirth" className={labelClass}>Date of Birth</label>
-              <input id="DateOfBirth" type="date" {...register('DateOfBirth')} className={inputClass} />
-            </div>
+            <Controller
+              name="FirstName"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label="First Name"
+                  required
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="LastName"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label="Last Name"
+                  required
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="Email"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Email"
+                  type="email"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="Phone"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Phone"
+                  placeholder="(555) 123-4567"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="SSNLast4"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="SSN (Last 4 Digits)"
+                  placeholder="1234"
+                  slotProps={{ htmlInput: { maxLength: 4 } }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="DateOfBirth"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Date of Birth"
+                  type="date"
+                  slotProps={{ inputLabel: { shrink: true } }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
           </div>
         </div>
 
@@ -169,28 +258,76 @@ export default function EmployeeForm({
         <div className={sectionClass}>
           <h2 className={sectionTitleClass}>Employment Information</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="EmployeeNumber" className={labelClass}>Employee Number *</label>
-              <input id="EmployeeNumber" type="text" {...register('EmployeeNumber')} className={inputClass} placeholder="EMP001" />
-              {errors.EmployeeNumber && <p className="mt-1 text-sm text-red-600">{errors.EmployeeNumber.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="Status" className={labelClass}>Status</label>
-              <select id="Status" {...register('Status')} className={inputClass}>
-                {EMPLOYEE_STATUSES.map(s => (
-                  <option key={s.value} value={s.value}>{s.label}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="HireDate" className={labelClass}>Hire Date *</label>
-              <input id="HireDate" type="date" {...register('HireDate')} className={inputClass} />
-              {errors.HireDate && <p className="mt-1 text-sm text-red-600">{errors.HireDate.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="TerminationDate" className={labelClass}>Termination Date</label>
-              <input id="TerminationDate" type="date" {...register('TerminationDate')} className={inputClass} />
-            </div>
+            <Controller
+              name="EmployeeNumber"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label="Employee Number"
+                  required
+                  placeholder="EMP001"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="Status"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Status"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                >
+                  {EMPLOYEE_STATUSES.map(s => (
+                    <MenuItem key={s.value} value={s.value}>{s.label}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+            <Controller
+              name="HireDate"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label="Hire Date"
+                  required
+                  type="date"
+                  slotProps={{ inputLabel: { shrink: true } }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="TerminationDate"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Termination Date"
+                  type="date"
+                  slotProps={{ inputLabel: { shrink: true } }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
           </div>
         </div>
 
@@ -198,39 +335,71 @@ export default function EmployeeForm({
         <div className={sectionClass}>
           <h2 className={sectionTitleClass}>Compensation</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div>
-              <label htmlFor="PayType" className={labelClass}>Pay Type *</label>
-              <select id="PayType" {...register('PayType')} className={inputClass}>
-                {PAY_TYPES.map(t => (
-                  <option key={t.value} value={t.value}>{t.label}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="PayRate" className={labelClass}>
-                {payType === 'Hourly' ? 'Hourly Rate *' : 'Annual Salary *'}
-              </label>
-              <div className="relative">
-                <span className="absolute inset-y-0 left-0 pl-3 flex items-center text-gray-500 dark:text-gray-400">$</span>
-                <input
-                  id="PayRate"
+            <Controller
+              name="PayType"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Pay Type"
+                  required
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                >
+                  {PAY_TYPES.map(t => (
+                    <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+            <Controller
+              name="PayRate"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  label={payType === 'Hourly' ? 'Hourly Rate' : 'Annual Salary'}
+                  required
                   type="number"
-                  step="0.01"
-                  {...register('PayRate')}
-                  className={`${inputClass} pl-7`}
                   placeholder={payType === 'Hourly' ? '25.00' : '52000.00'}
+                  slotProps={{
+                    input: {
+                      startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                    },
+                    htmlInput: { step: '0.01', min: '0' },
+                  }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
                 />
-              </div>
-              {errors.PayRate && <p className="mt-1 text-sm text-red-600">{errors.PayRate.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="PayFrequency" className={labelClass}>Pay Frequency *</label>
-              <select id="PayFrequency" {...register('PayFrequency')} className={inputClass}>
-                {PAY_FREQUENCIES.map(f => (
-                  <option key={f.value} value={f.value}>{f.label}</option>
-                ))}
-              </select>
-            </div>
+              )}
+            />
+            <Controller
+              name="PayFrequency"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Pay Frequency"
+                  required
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                >
+                  {PAY_FREQUENCIES.map(f => (
+                    <MenuItem key={f.value} value={f.value}>{f.label}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
           </div>
         </div>
 
@@ -241,44 +410,107 @@ export default function EmployeeForm({
             {/* Federal Tax */}
             <div className="space-y-4">
               <h3 className="text-md font-medium text-gray-800 dark:text-gray-200">Federal Tax</h3>
-              <div>
-                <label htmlFor="FederalFilingStatus" className={labelClass}>Filing Status *</label>
-                <select id="FederalFilingStatus" {...register('FederalFilingStatus')} className={inputClass}>
-                  {FILING_STATUSES.map(s => (
-                    <option key={s.value} value={s.value}>{s.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="FederalAllowances" className={labelClass}>Allowances</label>
-                <input id="FederalAllowances" type="number" min="0" {...register('FederalAllowances')} className={inputClass} />
-              </div>
+              <Controller
+                name="FederalFilingStatus"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    select
+                    label="Filing Status"
+                    required
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  >
+                    {FILING_STATUSES.map(s => (
+                      <MenuItem key={s.value} value={s.value}>{s.label}</MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
+              <Controller
+                name="FederalAllowances"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    label="Allowances"
+                    type="number"
+                    slotProps={{ htmlInput: { min: '0' } }}
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  />
+                )}
+              />
             </div>
 
             {/* State Tax */}
             <div className="space-y-4">
               <h3 className="text-md font-medium text-gray-800 dark:text-gray-200">State Tax</h3>
-              <div>
-                <label htmlFor="StateCode" className={labelClass}>Work State</label>
-                <select id="StateCode" {...register('StateCode')} className={inputClass}>
-                  {US_STATES.map(s => (
-                    <option key={s.code} value={s.code}>{s.name}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="StateFilingStatus" className={labelClass}>State Filing Status</label>
-                <select id="StateFilingStatus" {...register('StateFilingStatus')} className={inputClass}>
-                  <option value="">Use Federal Status</option>
-                  {FILING_STATUSES.map(s => (
-                    <option key={s.value} value={s.value}>{s.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="StateAllowances" className={labelClass}>State Allowances</label>
-                <input id="StateAllowances" type="number" min="0" {...register('StateAllowances')} className={inputClass} />
-              </div>
+              <Controller
+                name="StateCode"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    select
+                    label="Work State"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  >
+                    {US_STATES.map(s => (
+                      <MenuItem key={s.code} value={s.code}>{s.name}</MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
+              <Controller
+                name="StateFilingStatus"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    select
+                    label="State Filing Status"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  >
+                    <MenuItem value="">Use Federal Status</MenuItem>
+                    {FILING_STATUSES.map(s => (
+                      <MenuItem key={s.value} value={s.value}>{s.label}</MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
+              <Controller
+                name="StateAllowances"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    label="State Allowances"
+                    type="number"
+                    slotProps={{ htmlInput: { min: '0' } }}
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  />
+                )}
+              />
             </div>
           </div>
         </div>
@@ -303,22 +535,59 @@ export default function EmployeeForm({
           )}
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div>
-              <label htmlFor="BankRoutingNumber" className={labelClass}>Routing Number</label>
-              <input id="BankRoutingNumber" type="text" maxLength={9} {...register('BankRoutingNumber')} className={inputClass} placeholder="123456789" />
-            </div>
-            <div>
-              <label htmlFor="BankAccountNumber" className={labelClass}>Account Number</label>
-              <input id="BankAccountNumber" type="text" {...register('BankAccountNumber')} className={inputClass} placeholder="************1234" />
-            </div>
-            <div>
-              <label htmlFor="BankAccountType" className={labelClass}>Account Type</label>
-              <select id="BankAccountType" {...register('BankAccountType')} className={inputClass}>
-                {BANK_ACCOUNT_TYPES.map(t => (
-                  <option key={t.value} value={t.value}>{t.label}</option>
-                ))}
-              </select>
-            </div>
+            <Controller
+              name="BankRoutingNumber"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Routing Number"
+                  placeholder="123456789"
+                  slotProps={{ htmlInput: { maxLength: 9 } }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="BankAccountNumber"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Account Number"
+                  placeholder="************1234"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="BankAccountType"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Account Type"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                >
+                  {BANK_ACCOUNT_TYPES.map(t => (
+                    <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
           </div>
 
           {!employeeId && (
@@ -335,56 +604,90 @@ export default function EmployeeForm({
             <Controller
               name="Address"
               control={control}
-              render={({ field }) => (
+              render={({ field, fieldState }) => (
                 <AddressAutocomplete
                   id="Address"
                   label="Street Address"
-                  labelClassName={labelClass}
-                  className={inputClass}
                   value={field.value || ''}
                   onChange={field.onChange}
                   onAddressSelect={handleAddressSelect}
-                  error={errors.Address?.message}
+                  error={fieldState.error?.message}
                 />
               )}
             />
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div>
-                <label htmlFor="City" className={labelClass}>City</label>
-                <input id="City" type="text" {...register('City')} className={inputClass} />
-              </div>
-              <div>
-                <label htmlFor="State" className={labelClass}>State</label>
-                <select id="State" {...register('State')} className={inputClass}>
-                  {US_STATES.map(s => (
-                    <option key={s.code} value={s.code}>{s.name}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="ZipCode" className={labelClass}>ZIP Code</label>
-                <input id="ZipCode" type="text" maxLength={10} {...register('ZipCode')} className={inputClass} placeholder="12345" />
-              </div>
+              <Controller
+                name="City"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    label="City"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  />
+                )}
+              />
+              <Controller
+                name="State"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    select
+                    label="State"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  >
+                    {US_STATES.map(s => (
+                      <MenuItem key={s.code} value={s.code}>{s.name}</MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
+              <Controller
+                name="ZipCode"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    label="ZIP Code"
+                    placeholder="12345"
+                    slotProps={{ htmlInput: { maxLength: 10 } }}
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    size="small"
+                    fullWidth
+                  />
+                )}
+              />
             </div>
           </div>
         </div>
 
         {/* Form Actions */}
         <div className="flex justify-end items-center pt-4">
-          <button
-            type="button"
+          <Button
+            variant="outlined"
             onClick={() => navigate('/employees')}
-            className="mr-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/ExpenseForm.tsx
+++ b/client/src/components/ExpenseForm.tsx
@@ -1,4 +1,4 @@
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm, useWatch, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
@@ -6,6 +6,12 @@ import { ArrowLeft, X, Receipt } from 'lucide-react';
 import { useRef, useState, useCallback, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/api';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputAdornment from '@mui/material/InputAdornment';
 
 const expenseSchemaBase = z.object({
   ExpenseNumber: z.string().nullish(),
@@ -151,6 +157,9 @@ export default function ExpenseForm({
   const isReimbursable = useWatch({ control, name: 'IsReimbursable' });
   const isSubmitting = externalIsSubmitting || formIsSubmitting;
 
+  // Amount uses register with valueAsNumber — destructure ref for inputRef pattern
+  const { ref: amountRef, ...amountRest } = register('Amount', { valueAsNumber: true });
+
   // Handle file drop
   const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -220,7 +229,7 @@ export default function ExpenseForm({
       <div className="mb-6 flex items-center">
         <button
           onClick={() => navigate('/expenses')}
-          className="mr-4 text-gray-500 hover:text-gray-700"
+          className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
         >
           <ArrowLeft className="w-6 h-6" />
         </button>
@@ -236,14 +245,14 @@ export default function ExpenseForm({
           <div
             onDrop={handleDrop}
             onDragOver={handleDragOver}
-            className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-indigo-500 transition-colors cursor-pointer"
+            className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center hover:border-indigo-500 transition-colors cursor-pointer"
             onClick={() => fileInputRef.current?.click()}
           >
-            <Receipt className="mx-auto h-12 w-12 text-gray-400" />
-            <p className="mt-2 text-sm text-gray-600">
+            <Receipt className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
               Drag and drop receipt images or PDFs here, or click to browse
             </p>
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
               Supports JPG, PNG, and PDF files
             </p>
             <input
@@ -271,8 +280,8 @@ export default function ExpenseForm({
                       className="w-full h-full object-cover"
                     />
                   ) : (
-                    <div className="w-full h-full flex items-center justify-center bg-gray-100">
-                      <span className="text-xs text-gray-600 text-center px-1 truncate">
+                    <div className="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-gray-600">
+                      <span className="text-xs text-gray-600 dark:text-gray-400 text-center px-1 truncate">
                         {receipt.file.name}
                       </span>
                     </div>
@@ -295,49 +304,49 @@ export default function ExpenseForm({
 
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
           {/* Date and Amount */}
-          <div>
-            <label htmlFor="ExpenseDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Date
-            </label>
-            <input
-              id="ExpenseDate"
-              type="date"
-              {...register('ExpenseDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.ExpenseDate && (
-              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.ExpenseDate.message}</p>
-            )}
-          </div>
-
-          <div>
-            <label htmlFor="Amount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Amount
-            </label>
-            <div className="mt-1 relative rounded-md shadow-sm">
-              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                <span className="text-gray-500 sm:text-sm">$</span>
-              </div>
-              <input
-                id="Amount"
-                type="number"
-                step="0.01"
-                {...register('Amount', { valueAsNumber: true })}
-                className="block w-full rounded-md border-gray-300 pl-7 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                placeholder="0.00"
+          <Controller
+            name="ExpenseDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="date"
+                label="Date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
               />
-            </div>
-            {errors.Amount && (
-              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Amount.message}</p>
             )}
-          </div>
+          />
+
+          <TextField
+            {...amountRest}
+            inputRef={amountRef}
+            type="number"
+            label="Amount"
+            required
+            placeholder="0.00"
+            error={!!errors.Amount}
+            helperText={errors.Amount?.message}
+            size="small"
+            fullWidth
+            slotProps={{
+              htmlInput: { step: '0.01' },
+              input: {
+                startAdornment: <InputAdornment position="start">$</InputAdornment>,
+              },
+            }}
+          />
 
           {/* Vendor Selection */}
           <div className="sm:col-span-2">
             <div className="flex items-center justify-between mb-1">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 Vendor / Payee
-              </label>
+              </span>
               <button
                 type="button"
                 onClick={() => {
@@ -348,224 +357,272 @@ export default function ExpenseForm({
                     setValue('VendorName', null);
                   }
                 }}
-                className="text-xs text-indigo-600 hover:text-indigo-800"
+                className="text-xs text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
               >
                 {useQuickVendor ? 'Select from list' : 'Enter name manually'}
               </button>
             </div>
             {useQuickVendor ? (
-              <input
-                type="text"
-                {...register('VendorName')}
-                className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                placeholder="Enter vendor name..."
+              <Controller
+                name="VendorName"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    label="Vendor Name"
+                    placeholder="Enter vendor name..."
+                    size="small"
+                    fullWidth
+                  />
+                )}
               />
             ) : (
-              <select
-                {...register('VendorId')}
-                className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              >
-                <option value="">Select a vendor (optional)...</option>
-                {vendors?.map((vendor) => (
-                  <option key={vendor.Id} value={vendor.Id}>
-                    {vendor.Name}
-                  </option>
-                ))}
-              </select>
+              <Controller
+                name="VendorId"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    select
+                    label="Vendor"
+                    size="small"
+                    fullWidth
+                  >
+                    <MenuItem value="">Select a vendor (optional)...</MenuItem>
+                    {vendors?.map((vendor) => (
+                      <MenuItem key={vendor.Id} value={vendor.Id}>
+                        {vendor.Name}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
             )}
           </div>
 
           {/* Expense Category */}
-          <div>
-            <label htmlFor="AccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Category / Account
-            </label>
-            <select
-              id="AccountId"
-              {...register('AccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select a category...</option>
-              {expenseAccounts.map((account) => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name}
-                </option>
-              ))}
-            </select>
-            {errors.AccountId && (
-              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.AccountId.message}</p>
+          <Controller
+            name="AccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Category / Account"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select a category...</MenuItem>
+                {expenseAccounts.map((account) => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
             )}
-          </div>
+          />
 
           {/* Payment Method */}
-          <div>
-            <label htmlFor="PaymentMethod" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Payment Method
-            </label>
-            <select
-              id="PaymentMethod"
-              {...register('PaymentMethod')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select method...</option>
-              <option value="Cash">Cash</option>
-              <option value="Credit Card">Credit Card</option>
-              <option value="Debit Card">Debit Card</option>
-              <option value="Check">Check</option>
-              <option value="Bank Transfer">Bank Transfer</option>
-              <option value="Other">Other</option>
-            </select>
-          </div>
+          <Controller
+            name="PaymentMethod"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Payment Method"
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select method...</MenuItem>
+                <MenuItem value="Cash">Cash</MenuItem>
+                <MenuItem value="Credit Card">Credit Card</MenuItem>
+                <MenuItem value="Debit Card">Debit Card</MenuItem>
+                <MenuItem value="Check">Check</MenuItem>
+                <MenuItem value="Bank Transfer">Bank Transfer</MenuItem>
+                <MenuItem value="Other">Other</MenuItem>
+              </TextField>
+            )}
+          />
 
           {/* Payment Account */}
-          <div>
-            <label htmlFor="PaymentAccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Paid From Account
-            </label>
-            <select
-              id="PaymentAccountId"
-              {...register('PaymentAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select account...</option>
-              {paymentAccounts.map((account) => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name} ({account.Type})
-                </option>
-              ))}
-            </select>
-          </div>
+          <Controller
+            name="PaymentAccountId"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Paid From Account"
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select account...</MenuItem>
+                {paymentAccounts.map((account) => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name} ({account.Type})
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
           {/* Reference */}
-          <div>
-            <label htmlFor="Reference" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Reference / Check #
-            </label>
-            <input
-              id="Reference"
-              type="text"
-              {...register('Reference')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="Check # or transaction ID"
-            />
-          </div>
+          <Controller
+            name="Reference"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Reference / Check #"
+                placeholder="Check # or transaction ID"
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
           {/* Description */}
           <div className="sm:col-span-2">
-            <label htmlFor="Description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Description
-            </label>
-            <textarea
-              id="Description"
-              {...register('Description')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="What was this expense for?"
+            <Controller
+              name="Description"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Description"
+                  multiline
+                  rows={2}
+                  placeholder="What was this expense for?"
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
 
           {/* Personal and Reimbursable Checkboxes */}
-          <div className="sm:col-span-2 space-y-3">
-            <div className="flex items-center">
-              <input
-                id="IsPersonal"
-                type="checkbox"
-                {...register('IsPersonal')}
-                className="h-4 w-4 text-orange-600 focus:ring-orange-500 border-gray-300 rounded"
-              />
-              <label htmlFor="IsPersonal" className="ml-2 block text-sm text-gray-900">
-                This is a personal expense (not business-related)
-              </label>
-            </div>
-            <div className="flex items-center">
-              <input
-                id="IsReimbursable"
-                type="checkbox"
-                {...register('IsReimbursable')}
-                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
-              />
-              <label htmlFor="IsReimbursable" className="ml-2 block text-sm text-gray-900">
-                This is a reimbursable expense
-              </label>
-            </div>
+          <div className="sm:col-span-2 space-y-1">
+            <Controller
+              name="IsPersonal"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={<Checkbox {...field} checked={field.value ?? false} />}
+                  label="This is a personal expense (not business-related)"
+                />
+              )}
+            />
+            <Controller
+              name="IsReimbursable"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={<Checkbox {...field} checked={field.value ?? false} />}
+                  label="This is a reimbursable expense"
+                />
+              )}
+            />
           </div>
 
           {/* Customer (for billable expenses) */}
           {isReimbursable && (
-            <div>
-              <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Bill to Customer (optional)
-              </label>
-              <select
-                id="CustomerId"
-                {...register('CustomerId')}
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              >
-                <option value="">Select customer...</option>
-                {customers?.map((customer) => (
-                  <option key={customer.Id} value={customer.Id}>
-                    {customer.Name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <Controller
+              name="CustomerId"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Bill to Customer (optional)"
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="">Select customer...</MenuItem>
+                  {customers?.map((customer) => (
+                    <MenuItem key={customer.Id} value={customer.Id}>
+                      {customer.Name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
           )}
 
           {/* Project */}
-          <div>
-            <label htmlFor="ProjectId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Project (optional)
-            </label>
-            <select
-              id="ProjectId"
-              {...register('ProjectId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select project...</option>
-              {projects?.map((project) => (
-                <option key={project.Id} value={project.Id}>
-                  {project.Name}
-                </option>
-              ))}
-            </select>
-          </div>
+          <Controller
+            name="ProjectId"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Project (optional)"
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select project...</MenuItem>
+                {projects?.map((project) => (
+                  <MenuItem key={project.Id} value={project.Id}>
+                    {project.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
           {/* Class */}
-          <div>
-            <label htmlFor="ClassId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Class (optional)
-            </label>
-            <select
-              id="ClassId"
-              {...register('ClassId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select class...</option>
-              {classes?.map((cls) => (
-                <option key={cls.Id} value={cls.Id}>
-                  {cls.Name}
-                </option>
-              ))}
-            </select>
-          </div>
+          <Controller
+            name="ClassId"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Class (optional)"
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select class...</MenuItem>
+                {classes?.map((cls) => (
+                  <MenuItem key={cls.Id} value={cls.Id}>
+                    {cls.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
         </div>
 
         {/* Submit Buttons */}
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <Button
+            variant="outlined"
             onClick={() => navigate('/expenses')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/InvoiceForm.tsx
+++ b/client/src/components/InvoiceForm.tsx
@@ -5,6 +5,12 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2, Zap, Info, MapPin } from 'lucide-react';
 import { useEffect, ReactNode, useMemo, useState, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
 import CustomerSelector from './CustomerSelector';
 import ProductServiceSelector, { ProductService } from './ProductServiceSelector';
 import api from '../lib/api';
@@ -247,7 +253,7 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center">
-          <button onClick={() => navigate('/invoices')} className="mr-4 text-gray-500 hover:text-gray-700">
+          <button onClick={() => navigate('/invoices')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
             <ArrowLeft className="w-6 h-6" />
           </button>
           <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -257,20 +263,24 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="InvoiceNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Invoice Number</label>
-            <input
-              id="InvoiceNumber"
-              type="text"
-              {...register('InvoiceNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="INV-002"
-            />
-            {errors.InvoiceNumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.InvoiceNumber.message}</p>}
-          </div>
+          <Controller
+            name="InvoiceNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Invoice Number"
+                required
+                placeholder="INV-002"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
           <div>
-            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Customer</label>
             <Controller
               name="CustomerId"
               control={control}
@@ -302,79 +312,106 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
             )}
           </div>
 
-          <div>
-            <label htmlFor="IssueDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Issue Date</label>
-            <input
-              id="IssueDate"
-              type="date"
-              {...register('IssueDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.IssueDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.IssueDate.message}</p>}
-          </div>
+          <Controller
+            name="IssueDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="date"
+                label="Issue Date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="DueDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Due Date</label>
-            <input
-              id="DueDate"
-              type="date"
-              {...register('DueDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.DueDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.DueDate.message}</p>}
-          </div>
+          <Controller
+            name="DueDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="date"
+                label="Due Date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="Status" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="Draft">Draft</option>
-              <option value="Sent">Sent</option>
-              <option value="Paid">Paid</option>
-              <option value="Overdue">Overdue</option>
-            </select>
-            {errors.Status && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Status.message}</p>}
-          </div>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Draft">Draft</MenuItem>
+                <MenuItem value="Sent">Sent</MenuItem>
+                <MenuItem value="Paid">Paid</MenuItem>
+                <MenuItem value="Overdue">Overdue</MenuItem>
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="TaxRateId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Tax Rate</label>
-            <select
-              id="TaxRateId"
-              {...register('TaxRateId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">No Tax</option>
-              {taxRates?.map((taxRate) => (
-                <option key={taxRate.Id} value={taxRate.Id}>
-                  {taxRate.Name} ({formatTaxRate(taxRate.Rate)})
-                </option>
-              ))}
-            </select>
-            <p className="mt-1 text-xs text-gray-500">
-              Tax will be applied to taxable line items only
-            </p>
-          </div>
+          <Controller
+            name="TaxRateId"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Tax Rate"
+                size="small"
+                fullWidth
+                helperText="Tax will be applied to taxable line items only"
+              >
+                <MenuItem value="">No Tax</MenuItem>
+                {taxRates?.map((taxRate) => (
+                  <MenuItem key={taxRate.Id} value={taxRate.Id}>
+                    {taxRate.Name} ({formatTaxRate(taxRate.Rate)})
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
         </div>
 
         {/* Line Items */}
         <div className="mt-8">
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Line Items</h3>
-            <button
+            <Button
               type="button"
+              variant="outlined"
+              size="small"
+              startIcon={<Plus className="w-4 h-4" />}
               onClick={() => {
                 append({ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0, IsTaxable: true });
                 // Set new line as taxable by default
                 setLineTaxableStatus(prev => ({ ...prev, [fields.length]: true }));
               }}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
             >
-              <Plus className="w-4 h-4 mr-1" />
               Add Item
-            </button>
+            </Button>
           </div>
 
           <div className="space-y-4">
@@ -398,11 +435,14 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
               const lineAmount = (lines[index]?.Quantity || 0) * (lines[index]?.UnitPrice || 0);
               const isTaxable = lineTaxableStatus[index] ?? true;
 
+              const { ref: descRef, ...descRest } = register(`Lines.${index}.Description`);
+              const { ref: qtyRef, ...qtyRest } = register(`Lines.${index}.Quantity`, { valueAsNumber: true });
+              const { ref: priceRef, ...priceRest } = register(`Lines.${index}.UnitPrice`, { valueAsNumber: true });
+
               return (
-                <div key={field.id} className="bg-gray-50 p-4 rounded-md">
+                <div key={field.id} className="bg-gray-50 dark:bg-gray-700 p-4 rounded-md">
                   <div className="flex gap-4 items-start mb-3">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">Product/Service</label>
                       <Controller
                         name={`Lines.${index}.ProductServiceId`}
                         control={control}
@@ -416,62 +456,66 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
                         )}
                       />
                     </div>
-                    <div className="flex items-center pt-5">
-                      <input
-                        type="checkbox"
-                        id={`taxable-${index}`}
-                        checked={isTaxable}
-                        onChange={(e) => {
-                          setLineTaxableStatus(prev => ({ ...prev, [index]: e.target.checked }));
-                        }}
-                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    <div className="flex items-center pt-1">
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={isTaxable}
+                            onChange={(e) => {
+                              setLineTaxableStatus(prev => ({ ...prev, [index]: e.target.checked }));
+                            }}
+                            size="small"
+                          />
+                        }
+                        label="Taxable"
+                        slotProps={{ typography: { variant: 'caption' } }}
                       />
-                      <label htmlFor={`taxable-${index}`} className="ml-2 text-xs text-gray-600">
-                        Taxable
-                      </label>
                     </div>
                   </div>
                   <div className="flex gap-4 items-start">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">Description</label>
-                      <input
-                        {...register(`Lines.${index}.Description`)}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                      <TextField
+                        {...descRest}
+                        inputRef={descRef}
+                        label="Description"
                         placeholder="Item description"
+                        error={!!errors.Lines?.[index]?.Description}
+                        helperText={errors.Lines?.[index]?.Description?.message}
+                        size="small"
+                        fullWidth
                       />
-                      {errors.Lines?.[index]?.Description && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Description?.message}</p>
-                      )}
                     </div>
                     <div className="w-24">
-                      <label className="block text-xs font-medium text-gray-500">Qty</label>
-                      <input
+                      <TextField
+                        {...qtyRest}
+                        inputRef={qtyRef}
                         type="number"
-                        step="0.01"
-                        {...register(`Lines.${index}.Quantity`, { valueAsNumber: true })}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                        label="Qty"
+                        size="small"
+                        fullWidth
+                        slotProps={{ htmlInput: { step: '0.01' } }}
                       />
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">Unit Price</label>
-                      <input
+                      <TextField
+                        {...priceRest}
+                        inputRef={priceRef}
                         type="number"
-                        step="0.01"
-                        {...register(`Lines.${index}.UnitPrice`, { valueAsNumber: true })}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                        label="Unit Price"
+                        size="small"
+                        fullWidth
+                        slotProps={{ htmlInput: { step: '0.01' } }}
                       />
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">Amount</label>
-                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium">
+                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 dark:text-gray-300 font-medium">
                         ${lineAmount.toFixed(2)}
                         {!isTaxable && selectedTaxRate && (
-                          <span className="ml-1 text-xs text-gray-400">(no tax)</span>
+                          <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">(no tax)</span>
                         )}
                       </div>
                     </div>
-                    <button
-                      type="button"
+                    <IconButton
                       onClick={() => {
                         remove(index);
                         // Update taxable status indices
@@ -488,10 +532,12 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
                           return newStatus;
                         });
                       }}
-                      className="mt-6 text-red-600 hover:text-red-800"
+                      color="error"
+                      size="small"
+                      sx={{ mt: 1 }}
                     >
                       <Trash2 className="w-5 h-5" />
-                    </button>
+                    </IconButton>
                   </div>
                 </div>
               );
@@ -501,32 +547,32 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
         </div>
 
         {/* Totals Section */}
-        <div className="border-t pt-4">
+        <div className="border-t dark:border-gray-600 pt-4">
           <div className="flex justify-end">
             <div className="w-72 space-y-2">
               <div className="flex justify-between text-sm">
-                <span className="text-gray-600">Subtotal:</span>
-                <span className="font-medium text-gray-900">${calculations.subtotal.toFixed(2)}</span>
+                <span className="text-gray-600 dark:text-gray-400">Subtotal:</span>
+                <span className="font-medium text-gray-900 dark:text-gray-100">${calculations.subtotal.toFixed(2)}</span>
               </div>
               {selectedTaxRate && (
                 <>
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600">
+                    <span className="text-gray-600 dark:text-gray-400">
                       Tax ({selectedTaxRate.Name} - {formatTaxRate(selectedTaxRate.Rate)}):
                     </span>
-                    <span className="font-medium text-gray-900">${calculations.taxAmount.toFixed(2)}</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">${calculations.taxAmount.toFixed(2)}</span>
                   </div>
                   {calculations.taxableAmount !== calculations.subtotal && (
-                    <div className="flex justify-between text-xs text-gray-500">
+                    <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400">
                       <span>Taxable amount:</span>
                       <span>${calculations.taxableAmount.toFixed(2)}</span>
                     </div>
                   )}
                 </>
               )}
-              <div className="flex justify-between text-lg font-bold border-t pt-2">
-                <span className="text-gray-900">Total:</span>
-                <span className="text-gray-900">${calculations.total.toFixed(2)}</span>
+              <div className="flex justify-between text-lg font-bold border-t dark:border-gray-600 pt-2">
+                <span className="text-gray-900 dark:text-gray-100">Total:</span>
+                <span className="text-gray-900 dark:text-gray-100">${calculations.total.toFixed(2)}</span>
               </div>
             </div>
           </div>
@@ -536,20 +582,20 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
         {settings.invoicePostingMode === 'simple' && (
           <div className={`flex items-center gap-2 p-3 rounded-lg ${
             willAutoPost
-              ? 'bg-amber-50 border border-amber-200'
-              : 'bg-gray-50 border border-gray-200'
+              ? 'bg-amber-50 border border-amber-200 dark:bg-amber-950 dark:border-amber-700'
+              : 'bg-gray-50 border border-gray-200 dark:bg-gray-800 dark:border-gray-600'
           }`}>
             {willAutoPost ? (
               <>
                 <Zap className="h-4 w-4 text-amber-500" />
-                <span className="text-sm text-amber-700">
+                <span className="text-sm text-amber-700 dark:text-amber-400">
                   This invoice will <strong>post to your books</strong> when saved (AR + Revenue entries).
                 </span>
               </>
             ) : (
               <>
-                <Info className="h-4 w-4 text-gray-400" />
-                <span className="text-sm text-gray-600">
+                <Info className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <span className="text-sm text-gray-600 dark:text-gray-400">
                   Draft invoices don't affect your books until the status is changed.
                 </span>
               </>
@@ -557,21 +603,21 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
           </div>
         )}
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <Button
+            variant="outlined"
             onClick={() => navigate('/invoices')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/PayBillForm.tsx
+++ b/client/src/components/PayBillForm.tsx
@@ -5,6 +5,11 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { useEffect, ReactNode, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
 import VendorSelector from './VendorSelector';
 import api from '../lib/api';
 
@@ -170,7 +175,7 @@ export default function PayBillForm({
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center">
-          <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700">
+          <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
             <ArrowLeft className="w-6 h-6" />
           </button>
           <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -180,92 +185,124 @@ export default function PayBillForm({
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="PaymentNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Number</label>
-            <input
-              id="PaymentNumber"
-              type="text"
-              {...register('PaymentNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="BP-001"
-            />
-            {errors.PaymentNumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentNumber.message}</p>}
-          </div>
+          <Controller
+            name="PaymentNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Payment Number"
+                required
+                placeholder="BP-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
+
+          <Controller
+            name="VendorId"
+            control={control}
+            render={({ field }) => (
+              <VendorSelector
+                value={field.value || ''}
+                onChange={field.onChange}
+                error={errors.VendorId?.message}
+                disabled={isSubmitting}
+              />
+            )}
+          />
+
+          <Controller
+            name="PaymentDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Payment Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
+
+          <Controller
+            name="PaymentMethod"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                select
+                label="Payment Method"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                {PAYMENT_METHODS.map(method => (
+                  <MenuItem key={method} value={method}>{method}</MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+
+          <Controller
+            name="PaymentAccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Pay From Account"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select an account</MenuItem>
+                {bankAccounts?.map(account => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
           <div>
-            <label htmlFor="VendorId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Vendor</label>
-            <Controller
-              name="VendorId"
-              control={control}
-              render={({ field }) => (
-                <VendorSelector
-                  value={field.value || ''}
-                  onChange={field.onChange}
-                  error={errors.VendorId?.message}
-                  disabled={isSubmitting}
-                />
-              )}
-            />
-          </div>
-
-          <div>
-            <label htmlFor="PaymentDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Date</label>
-            <input
-              id="PaymentDate"
-              type="date"
-              {...register('PaymentDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.PaymentDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentDate.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="PaymentMethod" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Method</label>
-            <select
-              id="PaymentMethod"
-              {...register('PaymentMethod')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              {PAYMENT_METHODS.map(method => (
-                <option key={method} value={method}>{method}</option>
-              ))}
-            </select>
-            {errors.PaymentMethod && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentMethod.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="PaymentAccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Pay From Account</label>
-            <select
-              id="PaymentAccountId"
-              {...register('PaymentAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select an account</option>
-              {bankAccounts?.map(account => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
-                </option>
-              ))}
-            </select>
-            {errors.PaymentAccountId && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentAccountId.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="TotalAmount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Total Amount</label>
-            <div className="mt-1 block w-full rounded-md border-gray-300 bg-gray-50 p-2 text-lg font-semibold text-gray-900">
+            <div className="text-sm font-medium text-gray-700 mb-1 dark:text-gray-300">Total Amount</div>
+            <div className="block w-full rounded-md border-gray-300 bg-gray-50 p-2 text-lg font-semibold text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
               ${calculatedTotal.toFixed(2)}
             </div>
             <input type="hidden" {...register('TotalAmount', { valueAsNumber: true })} />
           </div>
 
           <div className="sm:col-span-2">
-            <label htmlFor="Memo" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Memo</label>
-            <textarea
-              id="Memo"
-              {...register('Memo')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="Optional notes about this payment"
+            <Controller
+              name="Memo"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Memo"
+                  multiline
+                  rows={2}
+                  placeholder="Optional notes about this payment"
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
         </div>
@@ -277,40 +314,40 @@ export default function PayBillForm({
           </div>
 
           {!watchedVendorId ? (
-            <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md">
+            <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md dark:text-gray-400 dark:bg-gray-700">
               Select a vendor to see their unpaid bills
             </div>
           ) : isLoadingBills ? (
-            <div className="text-center py-8 text-gray-500">Loading bills...</div>
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400">Loading bills...</div>
           ) : (
             <>
               {/* Available Bills */}
               {availableBills.length > 0 && (
                 <div className="mb-4">
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">Available Bills</h4>
-                  <div className="bg-gray-50 rounded-md overflow-hidden">
-                    <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-gray-100">
+                  <h4 className="text-sm font-medium text-gray-700 mb-2 dark:text-gray-300">Available Bills</h4>
+                  <div className="bg-gray-50 rounded-md overflow-hidden dark:bg-gray-700">
+                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
+                      <thead className="bg-gray-100 dark:bg-gray-600">
                         <tr>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">Bill #</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">Due Date</th>
-                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500">Total</th>
-                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500">Balance Due</th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400">Bill #</th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400">Due Date</th>
+                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">Total</th>
+                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">Balance Due</th>
                           <th className="px-4 py-2"></th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-gray-200">
+                      <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
                         {availableBills.map(bill => (
                           <tr key={bill.Id}>
-                            <td className="px-4 py-2 text-sm text-gray-900">{bill.BillNumber}</td>
-                            <td className="px-4 py-2 text-sm text-gray-600">{formatDate(bill.DueDate)}</td>
-                            <td className="px-4 py-2 text-sm text-gray-900 text-right">${bill.TotalAmount.toFixed(2)}</td>
-                            <td className="px-4 py-2 text-sm font-medium text-gray-900 text-right">${bill.BalanceDue.toFixed(2)}</td>
+                            <td className="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">{bill.BillNumber}</td>
+                            <td className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">{formatDate(bill.DueDate)}</td>
+                            <td className="px-4 py-2 text-sm text-gray-900 dark:text-gray-100 text-right">${bill.TotalAmount.toFixed(2)}</td>
+                            <td className="px-4 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">${bill.BalanceDue.toFixed(2)}</td>
                             <td className="px-4 py-2 text-right">
                               <button
                                 type="button"
                                 onClick={() => handleAddBill(bill)}
-                                className="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-700 bg-indigo-100 hover:bg-indigo-200 rounded"
+                                className="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-700 bg-indigo-100 hover:bg-indigo-200 rounded dark:text-indigo-300 dark:bg-indigo-900 dark:hover:bg-indigo-800"
                               >
                                 <Plus className="w-3 h-3 mr-1" />
                                 Apply
@@ -327,44 +364,52 @@ export default function PayBillForm({
               {/* Applied Bills */}
               {fields.length > 0 && (
                 <div>
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">Payment Applied To</h4>
+                  <h4 className="text-sm font-medium text-gray-700 mb-2 dark:text-gray-300">Payment Applied To</h4>
                   <div className="space-y-3">
-                    {fields.map((field, index) => (
-                      <div key={field.id} className="bg-green-50 p-4 rounded-md flex items-center gap-4">
-                        <div className="flex-grow">
-                          <div className="text-sm font-medium text-gray-900">
-                            Bill #{field.BillNumber}
+                    {fields.map((field, index) => {
+                      const { ref, ...rest } = register(`Applications.${index}.AmountApplied`, { valueAsNumber: true });
+                      return (
+                        <div key={field.id} className="bg-green-50 p-4 rounded-md flex items-center gap-4 dark:bg-green-950">
+                          <div className="flex-grow">
+                            <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                              Bill #{field.BillNumber}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                              Balance due: ${(field.BillBalanceDue || 0).toFixed(2)}
+                            </div>
                           </div>
-                          <div className="text-xs text-gray-500">
-                            Balance due: ${(field.BillBalanceDue || 0).toFixed(2)}
+                          <div className="w-40">
+                            <TextField
+                              {...rest}
+                              inputRef={ref}
+                              type="number"
+                              label="Amount to Apply"
+                              size="small"
+                              fullWidth
+                              slotProps={{
+                                input: {
+                                  startAdornment: <InputAdornment position="start">$</InputAdornment>
+                                },
+                                htmlInput: { step: '0.01', min: '0', max: field.BillBalanceDue || undefined }
+                              }}
+                            />
                           </div>
+                          <IconButton
+                            onClick={() => remove(index)}
+                            color="error"
+                            size="small"
+                          >
+                            <Trash2 className="w-5 h-5" />
+                          </IconButton>
                         </div>
-                        <div className="w-40">
-                          <label className="block text-xs font-medium text-gray-500">Amount to Apply</label>
-                          <input
-                            type="number"
-                            step="0.01"
-                            min="0"
-                            max={field.BillBalanceDue || undefined}
-                            {...register(`Applications.${index}.AmountApplied`, { valueAsNumber: true })}
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                          />
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => remove(index)}
-                          className="text-red-600 hover:text-red-800 p-1"
-                        >
-                          <Trash2 className="w-5 h-5" />
-                        </button>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               )}
 
               {fields.length === 0 && availableBills.length === 0 && (
-                <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md">
+                <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md dark:text-gray-400 dark:bg-gray-700">
                   No unpaid bills found for this vendor
                 </div>
               )}
@@ -377,32 +422,32 @@ export default function PayBillForm({
         </div>
 
         {/* Totals Section */}
-        <div className="border-t pt-4">
+        <div className="border-t pt-4 dark:border-gray-600">
           <div className="flex justify-end">
             <div className="w-72 space-y-2">
               <div className="flex justify-between text-lg font-bold">
-                <span className="text-gray-900">Total Payment:</span>
-                <span className="text-gray-900">${calculatedTotal.toFixed(2)}</span>
+                <span className="text-gray-900 dark:text-gray-100">Total Payment:</span>
+                <span className="text-gray-900 dark:text-gray-100">${calculatedTotal.toFixed(2)}</span>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <Button
+            variant="outlined"
             onClick={() => navigate(-1)}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting || fields.length === 0}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Processing...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/ProductServiceForm.tsx
+++ b/client/src/components/ProductServiceForm.tsx
@@ -1,10 +1,16 @@
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../lib/api';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputAdornment from '@mui/material/InputAdornment';
+import Button from '@mui/material/Button';
 
 export const productServiceSchema = z.object({
   Name: z.string().min(1, 'Name is required'),
@@ -44,9 +50,21 @@ export default function ProductServiceForm({ initialValues, onSubmit, title, isS
   const expenseAccounts = accounts?.filter(a => a.Type === 'Expense') || [];
   const assetAccounts = accounts?.filter(a => a.Type === 'Asset') || [];
 
-  const { register, handleSubmit, watch, formState: { errors } } = useForm<ProductServiceFormData>({
+  const { control, handleSubmit, watch } = useForm<ProductServiceFormData>({
     resolver: zodResolver(productServiceSchema),
-    defaultValues: { ...initialValues, Type: initialValues?.Type || 'Service', Taxable: initialValues?.Taxable ?? true, Status: initialValues?.Status || 'Active' }
+    defaultValues: {
+      Name: '',
+      SKU: '',
+      Description: '',
+      Category: '',
+      IncomeAccountId: '',
+      ExpenseAccountId: '',
+      InventoryAssetAccountId: '',
+      ...initialValues,
+      Type: initialValues?.Type || 'Service',
+      Taxable: initialValues?.Taxable ?? true,
+      Status: initialValues?.Status || 'Active',
+    }
   });
 
   const selectedType = watch('Type');
@@ -54,109 +72,262 @@ export default function ProductServiceForm({ initialValues, onSubmit, title, isS
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/products-services')} className="mr-4 text-gray-500 hover:text-gray-700" aria-label="Back to products and services"><ArrowLeft className="w-6 h-6" /></button>
+        <button onClick={() => navigate('/products-services')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200" aria-label="Back to products and services">
+          <ArrowLeft className="w-6 h-6" />
+        </button>
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
       </div>
+
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
-        <div>
-          <label htmlFor="Name" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Name *</label>
-          <input id="Name" type="text" {...register('Name')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100" />
-          {errors.Name && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Name.message}</p>}
-        </div>
-        <div>
-          <label htmlFor="Type" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Type *</label>
-          <select id="Type" {...register('Type')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-            <option value="Service">Service</option>
-            <option value="NonInventory">Non-Inventory Product</option>
-            <option value="Inventory">Inventory Product</option>
-          </select>
-          {errors.Type && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Type.message}</p>}
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-            {selectedType === 'Service' && 'Services you provide to customers (e.g., consulting, labor)'}
-            {selectedType === 'NonInventory' && 'Products you sell but do not track inventory for'}
-            {selectedType === 'Inventory' && 'Products you buy and sell with inventory tracking'}
-          </p>
-        </div>
-        <div>
-          <label htmlFor="SKU" className="block text-sm font-medium text-gray-700 dark:text-gray-300">SKU / Item Code</label>
-          <input id="SKU" type="text" {...register('SKU')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100" />
-        </div>
-        <div>
-          <label htmlFor="Category" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Category</label>
-          <input id="Category" type="text" {...register('Category')} placeholder="e.g., Professional Services, Hardware" className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100" />
-        </div>
-        <div>
-          <label htmlFor="Description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
-          <textarea id="Description" rows={3} {...register('Description')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100" />
-        </div>
-        <div className="border-t pt-6">
+        <Controller
+          name="Name"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Name"
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        <Controller
+          name="Type"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              select
+              label="Type"
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message || (
+                field.value === 'Service' ? 'Services you provide to customers (e.g., consulting, labor)' :
+                field.value === 'NonInventory' ? 'Products you sell but do not track inventory for' :
+                field.value === 'Inventory' ? 'Products you buy and sell with inventory tracking' : undefined
+              )}
+              size="small"
+              fullWidth
+            >
+              <MenuItem value="Service">Service</MenuItem>
+              <MenuItem value="NonInventory">Non-Inventory Product</MenuItem>
+              <MenuItem value="Inventory">Inventory Product</MenuItem>
+            </TextField>
+          )}
+        />
+
+        <Controller
+          name="SKU"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="SKU / Item Code"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        <Controller
+          name="Category"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Category"
+              placeholder="e.g., Professional Services, Hardware"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        <Controller
+          name="Description"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Description"
+              multiline
+              rows={3}
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        {/* Pricing Section */}
+        <div className="border-t pt-6 dark:border-gray-600">
           <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">Pricing</h3>
           <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="SalesPrice" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Sales Price</label>
-              <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"><span className="text-gray-500 dark:text-gray-400 sm:text-sm">$</span></div>
-                <input id="SalesPrice" type="number" step="0.01" {...register('SalesPrice')} className="block w-full rounded-md border-gray-300 pl-7 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100" />
-              </div>
-              {errors.SalesPrice && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.SalesPrice.message}</p>}
-            </div>
-            <div>
-              <label htmlFor="PurchaseCost" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Purchase Cost</label>
-              <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"><span className="text-gray-500 dark:text-gray-400 sm:text-sm">$</span></div>
-                <input id="PurchaseCost" type="number" step="0.01" {...register('PurchaseCost')} className="block w-full rounded-md border-gray-300 pl-7 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100" />
-              </div>
-              {errors.PurchaseCost && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PurchaseCost.message}</p>}
-            </div>
+            <Controller
+              name="SalesPrice"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Sales Price"
+                  type="number"
+                  slotProps={{
+                    htmlInput: { step: '0.01', min: '0' },
+                    input: { startAdornment: <InputAdornment position="start">$</InputAdornment> },
+                  }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
+            <Controller
+              name="PurchaseCost"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Purchase Cost"
+                  type="number"
+                  slotProps={{
+                    htmlInput: { step: '0.01', min: '0' },
+                    input: { startAdornment: <InputAdornment position="start">$</InputAdornment> },
+                  }}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
+            />
           </div>
         </div>
-        <div className="border-t pt-6">
+
+        {/* Accounting Section */}
+        <div className="border-t pt-6 dark:border-gray-600">
           <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">Accounting</h3>
           <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="IncomeAccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Income Account</label>
-              <select id="IncomeAccountId" {...register('IncomeAccountId')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                <option value="">Select an account...</option>
-                {incomeAccounts.map((account) => (<option key={account.Id} value={account.Id}>{account.Code} - {account.Name}</option>))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="ExpenseAccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Expense Account</label>
-              <select id="ExpenseAccountId" {...register('ExpenseAccountId')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                <option value="">Select an account...</option>
-                {expenseAccounts.map((account) => (<option key={account.Id} value={account.Id}>{account.Code} - {account.Name}</option>))}
-              </select>
-            </div>
+            <Controller
+              name="IncomeAccountId"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Income Account"
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="">Select an account...</MenuItem>
+                  {incomeAccounts.map((account) => (
+                    <MenuItem key={account.Id} value={account.Id}>{account.Code} - {account.Name}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+            <Controller
+              name="ExpenseAccountId"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Expense Account"
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="">Select an account...</MenuItem>
+                  {expenseAccounts.map((account) => (
+                    <MenuItem key={account.Id} value={account.Id}>{account.Code} - {account.Name}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
             {selectedType === 'Inventory' && (
-              <div className="col-span-2">
-                <label htmlFor="InventoryAssetAccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Inventory Asset Account</label>
-                <select id="InventoryAssetAccountId" {...register('InventoryAssetAccountId')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                  <option value="">Select an account...</option>
-                  {assetAccounts.map((account) => (<option key={account.Id} value={account.Id}>{account.Code} - {account.Name}</option>))}
-                </select>
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Account used to track inventory value on the balance sheet</p>
-              </div>
+              <Controller
+                name="InventoryAssetAccountId"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    value={field.value ?? ''}
+                    select
+                    label="Inventory Asset Account"
+                    helperText="Account used to track inventory value on the balance sheet"
+                    size="small"
+                    fullWidth
+                    className="col-span-2"
+                  >
+                    <MenuItem value="">Select an account...</MenuItem>
+                    {assetAccounts.map((account) => (
+                      <MenuItem key={account.Id} value={account.Id}>{account.Code} - {account.Name}</MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
             )}
           </div>
         </div>
-        <div className="border-t pt-6">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex items-center">
-              <input id="Taxable" type="checkbox" {...register('Taxable')} className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
-              <label htmlFor="Taxable" className="ml-2 block text-sm text-gray-900 dark:text-gray-100">Taxable</label>
-            </div>
-            <div>
-              <label htmlFor="Status" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
-              <select id="Status" {...register('Status')} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
-                <option value="Active">Active</option>
-                <option value="Inactive">Inactive</option>
-              </select>
-            </div>
+
+        {/* Status & Taxable */}
+        <div className="border-t pt-6 dark:border-gray-600">
+          <div className="grid grid-cols-2 gap-4 items-center">
+            <Controller
+              name="Taxable"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={<Checkbox {...field} checked={field.value ?? false} />}
+                  label="Taxable"
+                />
+              )}
+            />
+            <Controller
+              name="Status"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  select
+                  label="Status"
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                >
+                  <MenuItem value="Active">Active</MenuItem>
+                  <MenuItem value="Inactive">Inactive</MenuItem>
+                </TextField>
+              )}
+            />
           </div>
         </div>
-        <div className="flex justify-end items-center border-t pt-4">
-          <button type="button" onClick={() => navigate('/products-services')} className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">Cancel</button>
-          <button type="submit" disabled={isSubmitting} className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:opacity-50">{isSubmitting ? 'Saving...' : submitButtonText}</button>
+
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <Button variant="outlined" onClick={() => navigate('/products-services')} sx={{ mr: 1.5 }}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving...' : submitButtonText}
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/ProjectForm.tsx
+++ b/client/src/components/ProjectForm.tsx
@@ -1,10 +1,14 @@
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import { customersApi, Customer } from '../lib/api';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import InputAdornment from '@mui/material/InputAdornment';
+import Button from '@mui/material/Button';
 
 export const projectSchema = z.object({
   Name: z.string().min(1, 'Project name is required'),
@@ -41,9 +45,14 @@ export default function ProjectForm({
     queryFn: customersApi.getAll,
   });
 
-  const { register, handleSubmit, formState: { errors } } = useForm<ProjectFormData>({
+  const { control, handleSubmit } = useForm<ProjectFormData>({
     resolver: zodResolver(projectSchema),
     defaultValues: {
+      Name: '',
+      CustomerId: '',
+      Description: '',
+      StartDate: '',
+      EndDate: '',
       Status: 'Active',
       ...initialValues,
     }
@@ -52,134 +61,176 @@ export default function ProjectForm({
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/projects')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/projects')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
       </div>
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
-        <div>
-          <label htmlFor="Name" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Project Name</label>
-          <input
-            id="Name"
-            type="text"
-            {...register('Name')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+        <Controller
+          name="Name"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Project Name"
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        <Controller
+          name="CustomerId"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              select
+              label="Customer"
+              required
+              disabled={customersLoading}
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            >
+              <MenuItem value="">Select a customer...</MenuItem>
+              {customers.map((customer) => (
+                <MenuItem key={customer.Id} value={customer.Id}>{customer.Name}</MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+
+        <Controller
+          name="Description"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Description"
+              multiline
+              rows={3}
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
+
+        <Controller
+          name="Status"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              select
+              label="Status"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            >
+              <MenuItem value="Active">Active</MenuItem>
+              <MenuItem value="OnHold">On Hold</MenuItem>
+              <MenuItem value="Completed">Completed</MenuItem>
+            </TextField>
+          )}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <Controller
+            name="StartDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Start Date"
+                type="date"
+                slotProps={{ inputLabel: { shrink: true } }}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
           />
-          {errors.Name && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Name.message}</p>}
-        </div>
-
-        <div>
-          <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Customer</label>
-          <select
-            id="CustomerId"
-            {...register('CustomerId')}
-            disabled={customersLoading}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-          >
-            <option value="">Select a customer...</option>
-            {customers.map((customer) => (
-              <option key={customer.Id} value={customer.Id}>
-                {customer.Name}
-              </option>
-            ))}
-          </select>
-          {errors.CustomerId && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.CustomerId.message}</p>}
-        </div>
-
-        <div>
-          <label htmlFor="Description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
-          <textarea
-            id="Description"
-            rows={3}
-            {...register('Description')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          <Controller
+            name="EndDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="End Date"
+                type="date"
+                slotProps={{ inputLabel: { shrink: true } }}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
           />
-          {errors.Description && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Description.message}</p>}
-        </div>
-
-        <div>
-          <label htmlFor="Status" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
-          <select
-            id="Status"
-            {...register('Status')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-          >
-            <option value="Active">Active</option>
-            <option value="OnHold">On Hold</option>
-            <option value="Completed">Completed</option>
-          </select>
-          {errors.Status && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Status.message}</p>}
         </div>
 
         <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="StartDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Start Date</label>
-            <input
-              id="StartDate"
-              type="date"
-              {...register('StartDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.StartDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.StartDate.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="EndDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">End Date</label>
-            <input
-              id="EndDate"
-              type="date"
-              {...register('EndDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.EndDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.EndDate.message}</p>}
-          </div>
+          <Controller
+            name="BudgetedHours"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Budgeted Hours"
+                type="number"
+                slotProps={{ htmlInput: { step: '0.5', min: '0' } }}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
+          <Controller
+            name="BudgetedAmount"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Budgeted Amount"
+                type="number"
+                slotProps={{
+                  htmlInput: { step: '0.01', min: '0' },
+                  input: { startAdornment: <InputAdornment position="start">$</InputAdornment> },
+                }}
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="BudgetedHours" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Budgeted Hours</label>
-            <input
-              id="BudgetedHours"
-              type="number"
-              step="0.5"
-              min="0"
-              {...register('BudgetedHours')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.BudgetedHours && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.BudgetedHours.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="BudgetedAmount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Budgeted Amount ($)</label>
-            <input
-              id="BudgetedAmount"
-              type="number"
-              step="0.01"
-              min="0"
-              {...register('BudgetedAmount')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.BudgetedAmount && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.BudgetedAmount.message}</p>}
-          </div>
-        </div>
-
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
-            onClick={() => navigate('/projects')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-          >
+        <div className="flex justify-end items-center border-t dark:border-gray-600 pt-4">
+          <Button variant="outlined" onClick={() => navigate('/projects')} sx={{ mr: 1.5 }}>
             Cancel
-          </button>
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
-          >
+          </Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/PurchaseOrderForm.tsx
+++ b/client/src/components/PurchaseOrderForm.tsx
@@ -5,6 +5,10 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import api from '../lib/api';
 import ProductServiceSelector, { ProductService } from './ProductServiceSelector';
 
@@ -113,7 +117,7 @@ export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSu
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/purchase-orders')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/purchase-orders')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -121,93 +125,127 @@ export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSu
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="PONumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              PO Number <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="PONumber"
-              type="text"
-              {...register('PONumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="PO-001"
-            />
-            {errors.PONumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PONumber.message}</p>}
-          </div>
+          <Controller
+            name="PONumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="PO Number"
+                required
+                placeholder="PO-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="VendorId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Vendor <span className="text-red-500">*</span>
-            </label>
-            <select
-              id="VendorId"
-              {...register('VendorId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select a vendor...</option>
-              {vendors?.map((vendor) => (
-                <option key={vendor.Id} value={vendor.Id}>
-                  {vendor.Name}
-                </option>
-              ))}
-            </select>
-            {errors.VendorId && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.VendorId.message}</p>}
-          </div>
+          <Controller
+            name="VendorId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Vendor"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select a vendor...</MenuItem>
+                {vendors?.map((vendor) => (
+                  <MenuItem key={vendor.Id} value={vendor.Id}>
+                    {vendor.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="PODate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              PO Date <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="PODate"
-              type="date"
-              {...register('PODate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.PODate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PODate.message}</p>}
-          </div>
+          <Controller
+            name="PODate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="PO Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="ExpectedDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Expected Delivery Date
-            </label>
-            <input
-              id="ExpectedDate"
-              type="date"
-              {...register('ExpectedDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.ExpectedDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.ExpectedDate.message}</p>}
-          </div>
+          <Controller
+            name="ExpectedDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Expected Delivery Date"
+                type="date"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="Status" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="Draft">Draft</option>
-              <option value="Sent">Sent</option>
-              <option value="Received">Received</option>
-              <option value="Partial">Partial</option>
-              <option value="Cancelled">Cancelled</option>
-            </select>
-            {errors.Status && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.Status.message}</p>}
-          </div>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Draft">Draft</MenuItem>
+                <MenuItem value="Sent">Sent</MenuItem>
+                <MenuItem value="Received">Received</MenuItem>
+                <MenuItem value="Partial">Partial</MenuItem>
+                <MenuItem value="Cancelled">Cancelled</MenuItem>
+              </TextField>
+            )}
+          />
         </div>
 
         {/* Notes */}
-        <div>
-          <label htmlFor="Notes" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Notes</label>
-          <textarea
-            id="Notes"
-            rows={3}
-            {...register('Notes')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            placeholder="Additional notes for this purchase order..."
-          />
-        </div>
+        <Controller
+          name="Notes"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Notes"
+              multiline
+              rows={3}
+              placeholder="Additional notes for this purchase order..."
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
         {/* Line Items */}
         <div className="mt-8">
@@ -215,14 +253,15 @@ export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSu
             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
               Line Items <span className="text-red-500">*</span>
             </h3>
-            <button
+            <Button
               type="button"
+              variant="outlined"
+              size="small"
+              startIcon={<Plus className="w-4 h-4" />}
               onClick={() => append({ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0 })}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
             >
-              <Plus className="w-4 h-4 mr-1" />
               Add Item
-            </button>
+            </Button>
           </div>
 
           <div className="space-y-4">
@@ -242,11 +281,13 @@ export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSu
                 }
               };
 
+              const qtyReg = register(`Lines.${index}.Quantity`, { valueAsNumber: true });
+              const priceReg = register(`Lines.${index}.UnitPrice`, { valueAsNumber: true });
+
               return (
-                <div key={field.id} className="bg-gray-50 p-4 rounded-md">
+                <div key={field.id} className="bg-gray-50 p-4 rounded-md dark:bg-gray-700">
                   <div className="flex gap-4 items-start mb-3">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">Product/Service</label>
                       <Controller
                         name={`Lines.${index}.ProductServiceId`}
                         control={control}
@@ -263,63 +304,66 @@ export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSu
                   </div>
                   <div className="flex gap-4 items-start">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">
-                        Description <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        {...register(`Lines.${index}.Description`)}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                        placeholder="Item description"
+                      <Controller
+                        name={`Lines.${index}.Description`}
+                        control={control}
+                        render={({ field: descField, fieldState }) => (
+                          <TextField
+                            {...descField}
+                            value={descField.value ?? ''}
+                            label="Description"
+                            required
+                            placeholder="Item description"
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            size="small"
+                            fullWidth
+                          />
+                        )}
                       />
-                      {errors.Lines?.[index]?.Description && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Description?.message}</p>
-                      )}
                     </div>
                     <div className="w-24">
-                      <label className="block text-xs font-medium text-gray-500">
-                        Qty <span className="text-red-500">*</span>
-                      </label>
-                      <input
+                      <TextField
+                        {...qtyReg}
+                        inputRef={qtyReg.ref}
                         type="number"
-                        step="0.0001"
-                        min="0.0001"
-                        {...register(`Lines.${index}.Quantity`, { valueAsNumber: true })}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                        label="Qty"
+                        required
+                        slotProps={{ htmlInput: { step: '0.0001', min: '0.0001' } }}
+                        error={!!errors.Lines?.[index]?.Quantity}
+                        helperText={errors.Lines?.[index]?.Quantity?.message}
+                        size="small"
+                        fullWidth
                       />
-                      {errors.Lines?.[index]?.Quantity && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Quantity?.message}</p>
-                      )}
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">
-                        Unit Price <span className="text-red-500">*</span>
-                      </label>
-                      <input
+                      <TextField
+                        {...priceReg}
+                        inputRef={priceReg.ref}
                         type="number"
-                        step="0.01"
-                        min="0"
-                        {...register(`Lines.${index}.UnitPrice`, { valueAsNumber: true })}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                        label="Unit Price"
+                        required
+                        slotProps={{ htmlInput: { step: '0.01', min: '0' } }}
+                        error={!!errors.Lines?.[index]?.UnitPrice}
+                        helperText={errors.Lines?.[index]?.UnitPrice?.message}
+                        size="small"
+                        fullWidth
                       />
-                      {errors.Lines?.[index]?.UnitPrice && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.UnitPrice?.message}</p>
-                      )}
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">Amount</label>
-                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium">
+                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium dark:text-gray-300">
                         ${((lines[index]?.Quantity || 0) * (lines[index]?.UnitPrice || 0)).toFixed(2)}
                       </div>
                     </div>
-                    <button
-                      type="button"
+                    <IconButton
                       onClick={() => remove(index)}
                       disabled={fields.length === 1}
-                      className="mt-6 text-red-600 hover:text-red-800 disabled:text-gray-300 disabled:cursor-not-allowed"
+                      color="error"
                       title={fields.length === 1 ? 'At least one line item is required' : 'Remove item'}
+                      sx={{ mt: 0.5 }}
                     >
                       <Trash2 className="w-5 h-5" />
-                    </button>
+                    </IconButton>
                   </div>
                 </div>
               );
@@ -330,24 +374,24 @@ export default function PurchaseOrderForm({ initialValues, onSubmit, title, isSu
           )}
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <div className="text-xl font-bold text-gray-900 mr-6">
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <div className="text-xl font-bold text-gray-900 dark:text-gray-100 mr-6">
             Total: ${lines.reduce((sum, line) => sum + (line.Quantity || 0) * (line.UnitPrice || 0), 0).toFixed(2)}
           </div>
-          <button
-            type="button"
+          <Button
+            variant="outlined"
             onClick={() => navigate('/purchase-orders')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/ReceivePaymentForm.tsx
+++ b/client/src/components/ReceivePaymentForm.tsx
@@ -5,6 +5,11 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { useEffect, ReactNode, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
 import CustomerSelector from './CustomerSelector';
 import api from '../lib/api';
 
@@ -171,7 +176,7 @@ export default function ReceivePaymentForm({
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center">
-          <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700">
+          <button onClick={() => navigate(-1)} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
             <ArrowLeft className="w-6 h-6" />
           </button>
           <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
@@ -181,92 +186,124 @@ export default function ReceivePaymentForm({
 
       <form onSubmit={handleSubmit(onSubmit)} className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-6">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="PaymentNumber" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Number</label>
-            <input
-              id="PaymentNumber"
-              type="text"
-              {...register('PaymentNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="PMT-001"
-            />
-            {errors.PaymentNumber && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentNumber.message}</p>}
-          </div>
+          <Controller
+            name="PaymentNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Payment Number"
+                required
+                placeholder="PMT-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
+
+          <Controller
+            name="CustomerId"
+            control={control}
+            render={({ field }) => (
+              <CustomerSelector
+                value={field.value || ''}
+                onChange={field.onChange}
+                error={errors.CustomerId?.message}
+                disabled={isSubmitting}
+              />
+            )}
+          />
+
+          <Controller
+            name="PaymentDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Payment Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
+
+          <Controller
+            name="PaymentMethod"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                select
+                label="Payment Method"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                {PAYMENT_METHODS.map(method => (
+                  <MenuItem key={method} value={method}>{method}</MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+
+          <Controller
+            name="DepositAccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Deposit To Account"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select an account</MenuItem>
+                {bankAccounts?.map(account => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
           <div>
-            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Customer</label>
-            <Controller
-              name="CustomerId"
-              control={control}
-              render={({ field }) => (
-                <CustomerSelector
-                  value={field.value || ''}
-                  onChange={field.onChange}
-                  error={errors.CustomerId?.message}
-                  disabled={isSubmitting}
-                />
-              )}
-            />
-          </div>
-
-          <div>
-            <label htmlFor="PaymentDate" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Date</label>
-            <input
-              id="PaymentDate"
-              type="date"
-              {...register('PaymentDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            />
-            {errors.PaymentDate && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentDate.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="PaymentMethod" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Payment Method</label>
-            <select
-              id="PaymentMethod"
-              {...register('PaymentMethod')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              {PAYMENT_METHODS.map(method => (
-                <option key={method} value={method}>{method}</option>
-              ))}
-            </select>
-            {errors.PaymentMethod && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.PaymentMethod.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="DepositAccountId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Deposit To Account</label>
-            <select
-              id="DepositAccountId"
-              {...register('DepositAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-            >
-              <option value="">Select an account</option>
-              {bankAccounts?.map(account => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
-                </option>
-              ))}
-            </select>
-            {errors.DepositAccountId && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.DepositAccountId.message}</p>}
-          </div>
-
-          <div>
-            <label htmlFor="TotalAmount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Total Amount</label>
-            <div className="mt-1 block w-full rounded-md border-gray-300 bg-gray-50 p-2 text-lg font-semibold text-gray-900">
+            <div className="text-sm font-medium text-gray-700 mb-1 dark:text-gray-300">Total Amount</div>
+            <div className="block w-full rounded-md border-gray-300 bg-gray-50 p-2 text-lg font-semibold text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
               ${calculatedTotal.toFixed(2)}
             </div>
             <input type="hidden" {...register('TotalAmount', { valueAsNumber: true })} />
           </div>
 
           <div className="sm:col-span-2">
-            <label htmlFor="Memo" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Memo</label>
-            <textarea
-              id="Memo"
-              {...register('Memo')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-              placeholder="Optional notes about this payment"
+            <Controller
+              name="Memo"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Memo"
+                  multiline
+                  rows={2}
+                  placeholder="Optional notes about this payment"
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
         </div>
@@ -278,40 +315,40 @@ export default function ReceivePaymentForm({
           </div>
 
           {!watchedCustomerId ? (
-            <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md">
+            <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md dark:text-gray-400 dark:bg-gray-700">
               Select a customer to see their unpaid invoices
             </div>
           ) : isLoadingInvoices ? (
-            <div className="text-center py-8 text-gray-500">Loading invoices...</div>
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400">Loading invoices...</div>
           ) : (
             <>
               {/* Available Invoices */}
               {availableInvoices.length > 0 && (
                 <div className="mb-4">
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">Available Invoices</h4>
-                  <div className="bg-gray-50 rounded-md overflow-hidden">
-                    <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-gray-100">
+                  <h4 className="text-sm font-medium text-gray-700 mb-2 dark:text-gray-300">Available Invoices</h4>
+                  <div className="bg-gray-50 rounded-md overflow-hidden dark:bg-gray-700">
+                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
+                      <thead className="bg-gray-100 dark:bg-gray-600">
                         <tr>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">Invoice #</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">Due Date</th>
-                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500">Total</th>
-                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500">Balance Due</th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400">Invoice #</th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400">Due Date</th>
+                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">Total</th>
+                          <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400">Balance Due</th>
                           <th className="px-4 py-2"></th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-gray-200">
+                      <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
                         {availableInvoices.map(invoice => (
                           <tr key={invoice.Id}>
-                            <td className="px-4 py-2 text-sm text-gray-900">{invoice.InvoiceNumber}</td>
-                            <td className="px-4 py-2 text-sm text-gray-600">{formatDate(invoice.DueDate)}</td>
-                            <td className="px-4 py-2 text-sm text-gray-900 text-right">${invoice.TotalAmount.toFixed(2)}</td>
-                            <td className="px-4 py-2 text-sm font-medium text-gray-900 text-right">${invoice.BalanceDue.toFixed(2)}</td>
+                            <td className="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">{invoice.InvoiceNumber}</td>
+                            <td className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400">{formatDate(invoice.DueDate)}</td>
+                            <td className="px-4 py-2 text-sm text-gray-900 dark:text-gray-100 text-right">${invoice.TotalAmount.toFixed(2)}</td>
+                            <td className="px-4 py-2 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">${invoice.BalanceDue.toFixed(2)}</td>
                             <td className="px-4 py-2 text-right">
                               <button
                                 type="button"
                                 onClick={() => handleAddInvoice(invoice)}
-                                className="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-700 bg-indigo-100 hover:bg-indigo-200 rounded"
+                                className="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-700 bg-indigo-100 hover:bg-indigo-200 rounded dark:text-indigo-300 dark:bg-indigo-900 dark:hover:bg-indigo-800"
                               >
                                 <Plus className="w-3 h-3 mr-1" />
                                 Apply
@@ -328,44 +365,52 @@ export default function ReceivePaymentForm({
               {/* Applied Invoices */}
               {fields.length > 0 && (
                 <div>
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">Payment Applied To</h4>
+                  <h4 className="text-sm font-medium text-gray-700 mb-2 dark:text-gray-300">Payment Applied To</h4>
                   <div className="space-y-3">
-                    {fields.map((field, index) => (
-                      <div key={field.id} className="bg-indigo-50 p-4 rounded-md flex items-center gap-4">
-                        <div className="flex-grow">
-                          <div className="text-sm font-medium text-gray-900">
-                            Invoice #{field.InvoiceNumber}
+                    {fields.map((field, index) => {
+                      const { ref, ...rest } = register(`Applications.${index}.AmountApplied`, { valueAsNumber: true });
+                      return (
+                        <div key={field.id} className="bg-indigo-50 p-4 rounded-md flex items-center gap-4 dark:bg-indigo-950">
+                          <div className="flex-grow">
+                            <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                              Invoice #{field.InvoiceNumber}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                              Balance due: ${(field.InvoiceBalanceDue || 0).toFixed(2)}
+                            </div>
                           </div>
-                          <div className="text-xs text-gray-500">
-                            Balance due: ${(field.InvoiceBalanceDue || 0).toFixed(2)}
+                          <div className="w-40">
+                            <TextField
+                              {...rest}
+                              inputRef={ref}
+                              type="number"
+                              label="Amount to Apply"
+                              size="small"
+                              fullWidth
+                              slotProps={{
+                                input: {
+                                  startAdornment: <InputAdornment position="start">$</InputAdornment>
+                                },
+                                htmlInput: { step: '0.01', min: '0', max: field.InvoiceBalanceDue || undefined }
+                              }}
+                            />
                           </div>
+                          <IconButton
+                            onClick={() => remove(index)}
+                            color="error"
+                            size="small"
+                          >
+                            <Trash2 className="w-5 h-5" />
+                          </IconButton>
                         </div>
-                        <div className="w-40">
-                          <label className="block text-xs font-medium text-gray-500">Amount to Apply</label>
-                          <input
-                            type="number"
-                            step="0.01"
-                            min="0"
-                            max={field.InvoiceBalanceDue || undefined}
-                            {...register(`Applications.${index}.AmountApplied`, { valueAsNumber: true })}
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
-                          />
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => remove(index)}
-                          className="text-red-600 hover:text-red-800 p-1"
-                        >
-                          <Trash2 className="w-5 h-5" />
-                        </button>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               )}
 
               {fields.length === 0 && availableInvoices.length === 0 && (
-                <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md">
+                <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-md dark:text-gray-400 dark:bg-gray-700">
                   No unpaid invoices found for this customer
                 </div>
               )}
@@ -378,32 +423,32 @@ export default function ReceivePaymentForm({
         </div>
 
         {/* Totals Section */}
-        <div className="border-t pt-4">
+        <div className="border-t pt-4 dark:border-gray-600">
           <div className="flex justify-end">
             <div className="w-72 space-y-2">
               <div className="flex justify-between text-lg font-bold">
-                <span className="text-gray-900">Total Payment:</span>
-                <span className="text-gray-900">${calculatedTotal.toFixed(2)}</span>
+                <span className="text-gray-900 dark:text-gray-100">Total Payment:</span>
+                <span className="text-gray-900 dark:text-gray-100">${calculatedTotal.toFixed(2)}</span>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <Button
+            variant="outlined"
             onClick={() => navigate(-1)}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting || fields.length === 0}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Processing...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/SalesReceiptForm.tsx
+++ b/client/src/components/SalesReceiptForm.tsx
@@ -5,6 +5,12 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { useEffect, ReactNode, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
 import CustomerSelector from './CustomerSelector';
 import ProductServiceSelector, { ProductService } from './ProductServiceSelector';
 import api from '../lib/api';
@@ -189,146 +195,187 @@ export default function SalesReceiptForm({
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center">
-          <button onClick={() => navigate('/sales-receipts')} className="mr-4 text-gray-500 hover:text-gray-700">
+          <button onClick={() => navigate('/sales-receipts')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
             <ArrowLeft className="w-6 h-6" />
           </button>
-          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
         </div>
         {headerActions && <div className="flex items-center">{headerActions}</div>}
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6 dark:bg-gray-800">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="SalesReceiptNumber" className="block text-sm font-medium text-gray-700">Sales Receipt #</label>
-            <input
-              id="SalesReceiptNumber"
-              type="text"
-              {...register('SalesReceiptNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="SR-001"
-            />
-            {errors.SalesReceiptNumber && <p className="mt-1 text-sm text-red-600">{errors.SalesReceiptNumber.message}</p>}
-          </div>
+          <Controller
+            name="SalesReceiptNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Sales Receipt #"
+                required
+                placeholder="SR-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="CustomerId" className="block text-sm font-medium text-gray-700">Customer (Optional)</label>
-            <Controller
-              name="CustomerId"
-              control={control}
-              render={({ field }) => (
-                <CustomerSelector
-                  value={field.value || ''}
-                  onChange={field.onChange}
-                  error={errors.CustomerId?.message}
-                  disabled={isSubmitting}
-                />
-              )}
-            />
-          </div>
+          <Controller
+            name="CustomerId"
+            control={control}
+            render={({ field }) => (
+              <CustomerSelector
+                value={field.value || ''}
+                onChange={field.onChange}
+                error={errors.CustomerId?.message}
+                disabled={isSubmitting}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="SaleDate" className="block text-sm font-medium text-gray-700">Sale Date</label>
-            <input
-              id="SaleDate"
-              type="date"
-              {...register('SaleDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.SaleDate && <p className="mt-1 text-sm text-red-600">{errors.SaleDate.message}</p>}
-          </div>
+          <Controller
+            name="SaleDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="date"
+                label="Sale Date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="DepositAccountId" className="block text-sm font-medium text-gray-700">Deposit To</label>
-            <select
-              id="DepositAccountId"
-              {...register('DepositAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select deposit account...</option>
-              {depositAccounts?.map((account) => (
-                <option key={account.Id} value={account.Id}>
-                  {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
-                </option>
-              ))}
-            </select>
-            {errors.DepositAccountId && <p className="mt-1 text-sm text-red-600">{errors.DepositAccountId.message}</p>}
-          </div>
+          <Controller
+            name="DepositAccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Deposit To"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select deposit account...</MenuItem>
+                {depositAccounts?.map((account) => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.Name} {account.AccountNumber ? `(${account.AccountNumber})` : ''}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="PaymentMethod" className="block text-sm font-medium text-gray-700">Payment Method</label>
-            <select
-              id="PaymentMethod"
-              {...register('PaymentMethod')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select payment method...</option>
-              {PAYMENT_METHODS.map((method) => (
-                <option key={method.value} value={method.value}>
-                  {method.label}
-                </option>
-              ))}
-            </select>
-          </div>
+          <Controller
+            name="PaymentMethod"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Payment Method"
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select payment method...</MenuItem>
+                {PAYMENT_METHODS.map((method) => (
+                  <MenuItem key={method.value} value={method.value}>
+                    {method.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="Reference" className="block text-sm font-medium text-gray-700">Reference # (Check #, etc.)</label>
-            <input
-              id="Reference"
-              type="text"
-              {...register('Reference')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="Optional"
-            />
-          </div>
+          <Controller
+            name="Reference"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Reference # (Check #, etc.)"
+                placeholder="Optional"
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="TaxRateId" className="block text-sm font-medium text-gray-700">Tax Rate</label>
-            <select
-              id="TaxRateId"
-              {...register('TaxRateId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">No Tax</option>
-              {taxRates?.map((taxRate) => (
-                <option key={taxRate.Id} value={taxRate.Id}>
-                  {taxRate.Name} ({formatTaxRate(taxRate.Rate)})
-                </option>
-              ))}
-            </select>
-            <p className="mt-1 text-xs text-gray-500">
-              Tax will be applied to taxable line items only
-            </p>
-          </div>
+          <Controller
+            name="TaxRateId"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Tax Rate"
+                size="small"
+                fullWidth
+                helperText="Tax will be applied to taxable line items only"
+              >
+                <MenuItem value="">No Tax</MenuItem>
+                {taxRates?.map((taxRate) => (
+                  <MenuItem key={taxRate.Id} value={taxRate.Id}>
+                    {taxRate.Name} ({formatTaxRate(taxRate.Rate)})
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="Status" className="block text-sm font-medium text-gray-700">Status</label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="Completed">Completed</option>
-              <option value="Voided">Voided</option>
-            </select>
-          </div>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Completed">Completed</MenuItem>
+                <MenuItem value="Voided">Voided</MenuItem>
+              </TextField>
+            )}
+          />
         </div>
 
         {/* Line Items */}
         <div className="mt-8">
           <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-medium text-gray-900">Line Items</h3>
-            <button
+            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Line Items</h3>
+            <Button
               type="button"
+              variant="outlined"
+              size="small"
+              startIcon={<Plus className="w-4 h-4" />}
               onClick={() => {
                 append({ ProductServiceId: '', Description: '', Quantity: 1, UnitPrice: 0, IsTaxable: true });
                 setLineTaxableStatus(prev => ({ ...prev, [fields.length]: true }));
               }}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
             >
-              <Plus className="w-4 h-4 mr-1" />
               Add Item
-            </button>
+            </Button>
           </div>
 
           <div className="space-y-4">
@@ -349,11 +396,14 @@ export default function SalesReceiptForm({
               const lineAmount = (lines[index]?.Quantity || 0) * (lines[index]?.UnitPrice || 0);
               const isTaxable = lineTaxableStatus[index] ?? true;
 
+              const { ref: descRef, ...descRest } = register(`Lines.${index}.Description`);
+              const { ref: qtyRef, ...qtyRest } = register(`Lines.${index}.Quantity`, { valueAsNumber: true });
+              const { ref: priceRef, ...priceRest } = register(`Lines.${index}.UnitPrice`, { valueAsNumber: true });
+
               return (
-                <div key={field.id} className="bg-gray-50 p-4 rounded-md">
+                <div key={field.id} className="bg-gray-50 p-4 rounded-md dark:bg-gray-700">
                   <div className="flex gap-4 items-start mb-3">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">Product/Service</label>
                       <Controller
                         name={`Lines.${index}.ProductServiceId`}
                         control={control}
@@ -367,62 +417,66 @@ export default function SalesReceiptForm({
                         )}
                       />
                     </div>
-                    <div className="flex items-center pt-5">
-                      <input
-                        type="checkbox"
-                        id={`taxable-${index}`}
-                        checked={isTaxable}
-                        onChange={(e) => {
-                          setLineTaxableStatus(prev => ({ ...prev, [index]: e.target.checked }));
-                        }}
-                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    <div className="flex items-center pt-1">
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={isTaxable}
+                            onChange={(e) => {
+                              setLineTaxableStatus(prev => ({ ...prev, [index]: e.target.checked }));
+                            }}
+                            size="small"
+                          />
+                        }
+                        label="Taxable"
+                        slotProps={{ typography: { variant: 'caption' } }}
                       />
-                      <label htmlFor={`taxable-${index}`} className="ml-2 text-xs text-gray-600">
-                        Taxable
-                      </label>
                     </div>
                   </div>
                   <div className="flex gap-4 items-start">
                     <div className="flex-grow">
-                      <label className="block text-xs font-medium text-gray-500">Description</label>
-                      <input
-                        {...register(`Lines.${index}.Description`)}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                      <TextField
+                        {...descRest}
+                        inputRef={descRef}
+                        label="Description"
                         placeholder="Item description"
+                        error={!!errors.Lines?.[index]?.Description}
+                        helperText={errors.Lines?.[index]?.Description?.message}
+                        size="small"
+                        fullWidth
                       />
-                      {errors.Lines?.[index]?.Description && (
-                        <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Description?.message}</p>
-                      )}
                     </div>
                     <div className="w-24">
-                      <label className="block text-xs font-medium text-gray-500">Qty</label>
-                      <input
+                      <TextField
+                        {...qtyRest}
+                        inputRef={qtyRef}
                         type="number"
-                        step="0.01"
-                        {...register(`Lines.${index}.Quantity`, { valueAsNumber: true })}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                        label="Qty"
+                        size="small"
+                        fullWidth
+                        slotProps={{ htmlInput: { step: '0.01' } }}
                       />
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">Unit Price</label>
-                      <input
+                      <TextField
+                        {...priceRest}
+                        inputRef={priceRef}
                         type="number"
-                        step="0.01"
-                        {...register(`Lines.${index}.UnitPrice`, { valueAsNumber: true })}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+                        label="Unit Price"
+                        size="small"
+                        fullWidth
+                        slotProps={{ htmlInput: { step: '0.01' } }}
                       />
                     </div>
                     <div className="w-32">
-                      <label className="block text-xs font-medium text-gray-500">Amount</label>
-                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium">
+                      <div className="mt-1 py-2 px-3 text-sm text-gray-700 font-medium dark:text-gray-300">
                         ${lineAmount.toFixed(2)}
                         {!isTaxable && selectedTaxRate && (
-                          <span className="ml-1 text-xs text-gray-400">(no tax)</span>
+                          <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">(no tax)</span>
                         )}
                       </div>
                     </div>
-                    <button
-                      type="button"
+                    <IconButton
                       onClick={() => {
                         remove(index);
                         setLineTaxableStatus(prev => {
@@ -438,77 +492,85 @@ export default function SalesReceiptForm({
                           return newStatus;
                         });
                       }}
-                      className="mt-6 text-red-600 hover:text-red-800"
+                      color="error"
+                      size="small"
+                      sx={{ mt: 1 }}
                     >
                       <Trash2 className="w-5 h-5" />
-                    </button>
+                    </IconButton>
                   </div>
                 </div>
               );
             })}
           </div>
-          {errors.Lines && <p className="mt-2 text-sm text-red-600">{errors.Lines.message}</p>}
+          {errors.Lines && <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.Lines.message}</p>}
         </div>
 
         {/* Memo */}
-        <div>
-          <label htmlFor="Memo" className="block text-sm font-medium text-gray-700">Memo / Message</label>
-          <textarea
-            id="Memo"
-            {...register('Memo')}
-            rows={2}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            placeholder="Notes or message to customer"
-          />
-        </div>
+        <Controller
+          name="Memo"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              value={field.value ?? ''}
+              label="Memo / Message"
+              multiline
+              rows={2}
+              placeholder="Notes or message to customer"
+              size="small"
+              fullWidth
+            />
+          )}
+        />
 
         {/* Totals Section */}
-        <div className="border-t pt-4">
+        <div className="border-t pt-4 dark:border-gray-600">
           <div className="flex justify-end">
             <div className="w-72 space-y-2">
               <div className="flex justify-between text-sm">
-                <span className="text-gray-600">Subtotal:</span>
-                <span className="font-medium text-gray-900">${calculations.subtotal.toFixed(2)}</span>
+                <span className="text-gray-600 dark:text-gray-400">Subtotal:</span>
+                <span className="font-medium text-gray-900 dark:text-gray-100">${calculations.subtotal.toFixed(2)}</span>
               </div>
               {selectedTaxRate && (
                 <>
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600">
+                    <span className="text-gray-600 dark:text-gray-400">
                       Tax ({selectedTaxRate.Name} - {formatTaxRate(selectedTaxRate.Rate)}):
                     </span>
-                    <span className="font-medium text-gray-900">${calculations.taxAmount.toFixed(2)}</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-100">${calculations.taxAmount.toFixed(2)}</span>
                   </div>
                   {calculations.taxableAmount !== calculations.subtotal && (
-                    <div className="flex justify-between text-xs text-gray-500">
+                    <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400">
                       <span>Taxable amount:</span>
                       <span>${calculations.taxableAmount.toFixed(2)}</span>
                     </div>
                   )}
                 </>
               )}
-              <div className="flex justify-between text-lg font-bold border-t pt-2">
-                <span className="text-gray-900">Total:</span>
-                <span className="text-gray-900">${calculations.total.toFixed(2)}</span>
+              <div className="flex justify-between text-lg font-bold border-t pt-2 dark:border-gray-600">
+                <span className="text-gray-900 dark:text-gray-100">Total:</span>
+                <span className="text-gray-900 dark:text-gray-100">${calculations.total.toFixed(2)}</span>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <Button
+            variant="outlined"
             onClick={() => navigate('/sales-receipts')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/VendorCreditForm.tsx
+++ b/client/src/components/VendorCreditForm.tsx
@@ -1,10 +1,14 @@
-import { useForm, useFieldArray, useWatch } from 'react-hook-form';
+import { useForm, useFieldArray, useWatch, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import api from '../lib/api';
 
 export const vendorCreditSchema = z.object({
@@ -150,77 +154,114 @@ export default function VendorCreditForm({ initialValues, onSubmit, title, isSub
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-6 flex items-center">
-        <button onClick={() => navigate('/vendor-credits')} className="mr-4 text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate('/vendor-credits')} className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
           <ArrowLeft className="w-6 h-6" />
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
       </div>
 
-      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6">
+      <form onSubmit={handleSubmit(onSubmit)} className="bg-white shadow rounded-lg p-6 space-y-6 dark:bg-gray-800">
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div>
-            <label htmlFor="VendorId" className="block text-sm font-medium text-gray-700">Vendor</label>
-            <select
-              id="VendorId"
-              {...register('VendorId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select a vendor...</option>
-              {vendors?.map((vendor) => (
-                <option key={vendor.Id} value={vendor.Id}>
-                  {vendor.Name}
-                </option>
-              ))}
-            </select>
-            {errors.VendorId && <p className="mt-1 text-sm text-red-600">{errors.VendorId.message}</p>}
-          </div>
+          <Controller
+            name="VendorId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Vendor"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select a vendor...</MenuItem>
+                {vendors?.map((vendor) => (
+                  <MenuItem key={vendor.Id} value={vendor.Id}>
+                    {vendor.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
 
-          <div>
-            <label htmlFor="CreditNumber" className="block text-sm font-medium text-gray-700">Credit Number</label>
-            <input
-              id="CreditNumber"
-              type="text"
-              {...register('CreditNumber')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="VC-001"
-            />
-            {errors.CreditNumber && <p className="mt-1 text-sm text-red-600">{errors.CreditNumber.message}</p>}
-          </div>
+          <Controller
+            name="CreditNumber"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Credit Number"
+                required
+                placeholder="VC-001"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="CreditDate" className="block text-sm font-medium text-gray-700">Credit Date</label>
-            <input
-              id="CreditDate"
-              type="date"
-              {...register('CreditDate')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.CreditDate && <p className="mt-1 text-sm text-red-600">{errors.CreditDate.message}</p>}
-          </div>
+          <Controller
+            name="CreditDate"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                label="Credit Date"
+                type="date"
+                required
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
+          />
 
-          <div>
-            <label htmlFor="Status" className="block text-sm font-medium text-gray-700">Status</label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="Open">Open</option>
-              <option value="Applied">Applied</option>
-              <option value="Partial">Partial</option>
-              <option value="Voided">Voided</option>
-            </select>
-            {errors.Status && <p className="mt-1 text-sm text-red-600">{errors.Status.message}</p>}
-          </div>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Open">Open</MenuItem>
+                <MenuItem value="Applied">Applied</MenuItem>
+                <MenuItem value="Partial">Partial</MenuItem>
+                <MenuItem value="Voided">Voided</MenuItem>
+              </TextField>
+            )}
+          />
 
           <div className="sm:col-span-2">
-            <label htmlFor="Reason" className="block text-sm font-medium text-gray-700">Reason / Notes</label>
-            <textarea
-              id="Reason"
-              {...register('Reason')}
-              rows={2}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-              placeholder="Reason for credit (e.g., returned goods, price adjustment)..."
+            <Controller
+              name="Reason"
+              control={control}
+              render={({ field, fieldState }) => (
+                <TextField
+                  {...field}
+                  value={field.value ?? ''}
+                  label="Reason / Notes"
+                  multiline
+                  rows={2}
+                  placeholder="Reason for credit (e.g., returned goods, price adjustment)..."
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                  size="small"
+                  fullWidth
+                />
+              )}
             />
           </div>
         </div>
@@ -228,139 +269,186 @@ export default function VendorCreditForm({ initialValues, onSubmit, title, isSub
         {/* Line Items */}
         <div className="mt-8">
           <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-medium text-gray-900">Line Items</h3>
-            <button
+            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Line Items</h3>
+            <Button
               type="button"
+              variant="outlined"
+              size="small"
+              startIcon={<Plus className="w-4 h-4" />}
               onClick={() => append({ AccountId: '', Description: '', Quantity: 1, UnitPrice: 0, Amount: 0 })}
-              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200"
             >
-              <Plus className="w-4 h-4 mr-1" />
               Add Item
-            </button>
+            </Button>
           </div>
 
           <div className="space-y-4">
-            {fields.map((field, index) => (
-              <div key={field.id} className="flex gap-4 items-start bg-gray-50 p-4 rounded-md flex-wrap">
-                <div className="w-40">
-                  <label className="block text-xs font-medium text-gray-500">Product/Service</label>
-                  <select
-                    {...register(`Lines.${index}.ProductServiceId`)}
-                    onChange={(e) => handleProductChange(index, e.target.value)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
+            {fields.map((field, index) => {
+              const qtyReg = register(`Lines.${index}.Quantity`, {
+                valueAsNumber: true,
+                onChange: (e) => {
+                  const qty = parseFloat(e.target.value) || 0;
+                  const price = lines[index]?.UnitPrice || 0;
+                  updateLineAmount(index, qty, price);
+                }
+              });
+              const priceReg = register(`Lines.${index}.UnitPrice`, {
+                valueAsNumber: true,
+                onChange: (e) => {
+                  const price = parseFloat(e.target.value) || 0;
+                  const qty = lines[index]?.Quantity || 0;
+                  updateLineAmount(index, qty, price);
+                }
+              });
+              const amountReg = register(`Lines.${index}.Amount`, { valueAsNumber: true });
+
+              return (
+                <div key={field.id} className="flex gap-4 items-start bg-gray-50 p-4 rounded-md flex-wrap dark:bg-gray-700">
+                  <div className="w-40">
+                    <Controller
+                      name={`Lines.${index}.ProductServiceId`}
+                      control={control}
+                      render={({ field: psField }) => (
+                        <TextField
+                          {...psField}
+                          value={psField.value ?? ''}
+                          select
+                          label="Product/Service"
+                          size="small"
+                          fullWidth
+                          onChange={(e) => {
+                            psField.onChange(e);
+                            handleProductChange(index, e.target.value);
+                          }}
+                        >
+                          <MenuItem value="">Optional...</MenuItem>
+                          {productsServices?.map((ps) => (
+                            <MenuItem key={ps.Id} value={ps.Id}>
+                              {ps.Name}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                      )}
+                    />
+                  </div>
+                  <div className="w-40">
+                    <Controller
+                      name={`Lines.${index}.AccountId`}
+                      control={control}
+                      render={({ field: accField, fieldState }) => (
+                        <TextField
+                          {...accField}
+                          value={accField.value ?? ''}
+                          select
+                          label="Account"
+                          required
+                          error={!!fieldState.error}
+                          helperText={fieldState.error?.message}
+                          size="small"
+                          fullWidth
+                        >
+                          <MenuItem value="">Select account...</MenuItem>
+                          {expenseAccounts.map((account) => (
+                            <MenuItem key={account.Id} value={account.Id}>
+                              {account.Name}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                      )}
+                    />
+                  </div>
+                  <div className="flex-grow min-w-32">
+                    <Controller
+                      name={`Lines.${index}.Description`}
+                      control={control}
+                      render={({ field: descField, fieldState }) => (
+                        <TextField
+                          {...descField}
+                          value={descField.value ?? ''}
+                          label="Description"
+                          placeholder="Item description"
+                          error={!!fieldState.error}
+                          helperText={fieldState.error?.message}
+                          size="small"
+                          fullWidth
+                        />
+                      )}
+                    />
+                  </div>
+                  <div className="w-20">
+                    <TextField
+                      {...qtyReg}
+                      inputRef={qtyReg.ref}
+                      type="number"
+                      label="Qty"
+                      slotProps={{ htmlInput: { step: '0.01' } }}
+                      error={!!errors.Lines?.[index]?.Quantity}
+                      helperText={errors.Lines?.[index]?.Quantity?.message}
+                      size="small"
+                      fullWidth
+                    />
+                  </div>
+                  <div className="w-24">
+                    <TextField
+                      {...priceReg}
+                      inputRef={priceReg.ref}
+                      type="number"
+                      label="Unit Price"
+                      slotProps={{ htmlInput: { step: '0.01' } }}
+                      error={!!errors.Lines?.[index]?.UnitPrice}
+                      helperText={errors.Lines?.[index]?.UnitPrice?.message}
+                      size="small"
+                      fullWidth
+                    />
+                  </div>
+                  <div className="w-24">
+                    <TextField
+                      {...amountReg}
+                      inputRef={amountReg.ref}
+                      type="number"
+                      label="Amount"
+                      slotProps={{ htmlInput: { step: '0.01', readOnly: true } }}
+                      error={!!errors.Lines?.[index]?.Amount}
+                      helperText={errors.Lines?.[index]?.Amount?.message}
+                      size="small"
+                      fullWidth
+                      sx={{ '& .MuiInputBase-input': { backgroundColor: 'action.hover' } }}
+                    />
+                  </div>
+                  <IconButton
+                    onClick={() => remove(index)}
+                    disabled={fields.length === 1}
+                    color="error"
+                    sx={{ mt: 0.5 }}
                   >
-                    <option value="">Optional...</option>
-                    {productsServices?.map((ps) => (
-                      <option key={ps.Id} value={ps.Id}>
-                        {ps.Name}
-                      </option>
-                    ))}
-                  </select>
+                    <Trash2 className="w-5 h-5" />
+                  </IconButton>
                 </div>
-                <div className="w-40">
-                  <label className="block text-xs font-medium text-gray-500">Account</label>
-                  <select
-                    {...register(`Lines.${index}.AccountId`)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  >
-                    <option value="">Select account...</option>
-                    {expenseAccounts.map((account) => (
-                      <option key={account.Id} value={account.Id}>
-                        {account.Name}
-                      </option>
-                    ))}
-                  </select>
-                  {errors.Lines?.[index]?.AccountId && (
-                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.AccountId?.message}</p>
-                  )}
-                </div>
-                <div className="flex-grow min-w-32">
-                  <label className="block text-xs font-medium text-gray-500">Description</label>
-                  <input
-                    {...register(`Lines.${index}.Description`)}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                    placeholder="Item description"
-                  />
-                </div>
-                <div className="w-20">
-                  <label className="block text-xs font-medium text-gray-500">Qty</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.Quantity`, {
-                      valueAsNumber: true,
-                      onChange: (e) => {
-                        const qty = parseFloat(e.target.value) || 0;
-                        const price = lines[index]?.UnitPrice || 0;
-                        updateLineAmount(index, qty, price);
-                      }
-                    })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  />
-                </div>
-                <div className="w-24">
-                  <label className="block text-xs font-medium text-gray-500">Unit Price</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.UnitPrice`, {
-                      valueAsNumber: true,
-                      onChange: (e) => {
-                        const price = parseFloat(e.target.value) || 0;
-                        const qty = lines[index]?.Quantity || 0;
-                        updateLineAmount(index, qty, price);
-                      }
-                    })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-                  />
-                </div>
-                <div className="w-24">
-                  <label className="block text-xs font-medium text-gray-500">Amount</label>
-                  <input
-                    type="number"
-                    step="0.01"
-                    {...register(`Lines.${index}.Amount`, { valueAsNumber: true })}
-                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 bg-gray-100"
-                    readOnly
-                  />
-                  {errors.Lines?.[index]?.Amount && (
-                    <p className="mt-1 text-xs text-red-600">{errors.Lines[index]?.Amount?.message}</p>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => remove(index)}
-                  className="mt-6 text-red-600 hover:text-red-800"
-                  disabled={fields.length === 1}
-                >
-                  <Trash2 className="w-5 h-5" />
-                </button>
-              </div>
-            ))}
+              );
+            })}
           </div>
           {errors.Lines && typeof errors.Lines === 'object' && 'message' in errors.Lines && (
-            <p className="mt-2 text-sm text-red-600">{errors.Lines.message}</p>
+            <p className="mt-2 text-sm text-red-600 dark:text-red-400">{errors.Lines.message}</p>
           )}
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <div className="text-xl font-bold text-gray-900 mr-6">
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <div className="text-xl font-bold text-gray-900 dark:text-gray-100 mr-6">
             Total Credit: ${lines.reduce((sum, line) => sum + (line.Amount || 0), 0).toFixed(2)}
           </div>
-          <button
-            type="button"
+          <Button
+            variant="outlined"
             onClick={() => navigate('/vendor-credits')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/client/src/components/VendorForm.tsx
+++ b/client/src/components/VendorForm.tsx
@@ -1,9 +1,14 @@
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Button from '@mui/material/Button';
 import api from '../lib/api';
 import AddressFields, { AddressFieldValues } from './AddressFields';
 
@@ -47,12 +52,26 @@ export default function VendorForm({
   const navigate = useNavigate();
   const {
     register,
+    control,
     handleSubmit,
     setValue,
     formState: { errors },
   } = useForm<VendorFormData>({
     resolver: zodResolver(vendorSchema),
     defaultValues: {
+      Name: '',
+      Email: '',
+      Phone: '',
+      AddressLine1: '',
+      AddressLine2: '',
+      City: '',
+      State: '',
+      PostalCode: '',
+      Country: '',
+      Address: '',
+      PaymentTerms: '',
+      TaxId: '',
+      DefaultExpenseAccountId: '',
       ...initialValues,
       Is1099Vendor: initialValues?.Is1099Vendor ?? false,
       Status: initialValues?.Status ?? 'Active',
@@ -75,76 +94,71 @@ export default function VendorForm({
       <div className="mb-6 flex items-center">
         <button
           onClick={() => navigate('/vendors')}
-          className="mr-4 text-gray-500 hover:text-gray-700"
+          className="mr-4 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
         >
           <ArrowLeft className="w-6 h-6" />
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">{title}</h1>
       </div>
 
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="bg-white shadow rounded-lg p-6 space-y-6"
+        className="bg-white shadow rounded-lg p-6 space-y-6 dark:bg-gray-800"
       >
-        <div>
-          <label
-            htmlFor="Name"
-            className="block text-sm font-medium text-gray-700"
-          >
-            Name
-          </label>
-          <input
-            id="Name"
-            type="text"
-            {...register('Name')}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-          />
-          {errors.Name && (
-            <p className="mt-1 text-sm text-red-600">{errors.Name.message}</p>
+        <Controller
+          name="Name"
+          control={control}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Name"
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              size="small"
+              fullWidth
+            />
           )}
-        </div>
+        />
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label
-              htmlFor="Email"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Email
-            </label>
-            <input
-              id="Email"
-              type="email"
-              {...register('Email')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.Email && (
-              <p className="mt-1 text-sm text-red-600">{errors.Email.message}</p>
+          <Controller
+            name="Email"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Email"
+                type="email"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
             )}
-          </div>
+          />
 
-          <div>
-            <label
-              htmlFor="Phone"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Phone
-            </label>
-            <input
-              id="Phone"
-              type="text"
-              {...register('Phone')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.Phone && (
-              <p className="mt-1 text-sm text-red-600">{errors.Phone.message}</p>
+          <Controller
+            name="Phone"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Phone"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
             )}
-          </div>
+          />
         </div>
 
         {/* Address Section */}
-        <div className="border-t pt-4">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">Address</h3>
+        <div className="border-t pt-4 dark:border-gray-600">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">Address</h3>
           <AddressFields<VendorFormData>
             register={register}
             errors={errors}
@@ -155,130 +169,120 @@ export default function VendorForm({
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label
-              htmlFor="PaymentTerms"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Payment Terms
-            </label>
-            <select
-              id="PaymentTerms"
-              {...register('PaymentTerms')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select payment terms</option>
-              <option value="Net 15">Net 15</option>
-              <option value="Net 30">Net 30</option>
-              <option value="Net 45">Net 45</option>
-              <option value="Net 60">Net 60</option>
-              <option value="Due on Receipt">Due on Receipt</option>
-            </select>
-            {errors.PaymentTerms && (
-              <p className="mt-1 text-sm text-red-600">
-                {errors.PaymentTerms.message}
-              </p>
+          <Controller
+            name="PaymentTerms"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Payment Terms"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select payment terms</MenuItem>
+                <MenuItem value="Net 15">Net 15</MenuItem>
+                <MenuItem value="Net 30">Net 30</MenuItem>
+                <MenuItem value="Net 45">Net 45</MenuItem>
+                <MenuItem value="Net 60">Net 60</MenuItem>
+                <MenuItem value="Due on Receipt">Due on Receipt</MenuItem>
+              </TextField>
             )}
-          </div>
+          />
 
-          <div>
-            <label
-              htmlFor="Status"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Status
-            </label>
-            <select
-              id="Status"
-              {...register('Status')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="Active">Active</option>
-              <option value="Inactive">Inactive</option>
-            </select>
-            {errors.Status && (
-              <p className="mt-1 text-sm text-red-600">{errors.Status.message}</p>
+          <Controller
+            name="Status"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Status"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="Active">Active</MenuItem>
+                <MenuItem value="Inactive">Inactive</MenuItem>
+              </TextField>
             )}
-          </div>
+          />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label
-              htmlFor="TaxId"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Tax ID (EIN/SSN)
-            </label>
-            <input
-              id="TaxId"
-              type="text"
-              {...register('TaxId')}
-              placeholder="XX-XXXXXXX"
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            />
-            {errors.TaxId && (
-              <p className="mt-1 text-sm text-red-600">{errors.TaxId.message}</p>
+          <Controller
+            name="TaxId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                label="Tax ID (EIN/SSN)"
+                placeholder="XX-XXXXXXX"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              />
             )}
-          </div>
-
-          <div>
-            <label
-              htmlFor="DefaultExpenseAccountId"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Default Expense Account
-            </label>
-            <select
-              id="DefaultExpenseAccountId"
-              {...register('DefaultExpenseAccountId')}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2"
-            >
-              <option value="">Select an account</option>
-              {accounts?.map((account: any) => (
-                <option key={account.Id} value={account.Id}>
-                  {account.AccountNumber} - {account.Name}
-                </option>
-              ))}
-            </select>
-            {errors.DefaultExpenseAccountId && (
-              <p className="mt-1 text-sm text-red-600">
-                {errors.DefaultExpenseAccountId.message}
-              </p>
-            )}
-          </div>
-        </div>
-
-        <div className="flex items-center">
-          <input
-            id="Is1099Vendor"
-            type="checkbox"
-            {...register('Is1099Vendor')}
-            className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
           />
-          <label
-            htmlFor="Is1099Vendor"
-            className="ml-2 block text-sm text-gray-700"
-          >
-            1099 Vendor (requires tax reporting)
-          </label>
+
+          <Controller
+            name="DefaultExpenseAccountId"
+            control={control}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                value={field.value ?? ''}
+                select
+                label="Default Expense Account"
+                error={!!fieldState.error}
+                helperText={fieldState.error?.message}
+                size="small"
+                fullWidth
+              >
+                <MenuItem value="">Select an account</MenuItem>
+                {accounts?.map((account: any) => (
+                  <MenuItem key={account.Id} value={account.Id}>
+                    {account.AccountNumber} - {account.Name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
         </div>
 
-        <div className="flex justify-end items-center border-t pt-4">
-          <button
-            type="button"
+        <Controller
+          name="Is1099Vendor"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={<Checkbox {...field} checked={field.value ?? false} />}
+              label="1099 Vendor (requires tax reporting)"
+            />
+          )}
+        />
+
+        <div className="flex justify-end items-center border-t pt-4 dark:border-gray-600">
+          <Button
+            variant="outlined"
             onClick={() => navigate('/vendors')}
-            className="mr-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            sx={{ mr: 1.5 }}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
+            variant="contained"
             disabled={isSubmitting}
-            className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
           >
             {isSubmitting ? 'Saving...' : submitButtonText}
-          </button>
+          </Button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Migrate **19 form components** from plain HTML inputs (`<input>`, `<select>`, `<textarea>`, `<button>`) to MUI components (`TextField`, `MenuItem`, `Checkbox`, `FormControlLabel`, `Button`)
- Dark mode is now handled automatically by the MUI ThemeProvider instead of requiring manual Tailwind `dark:` class variants on every form element

Closes #401, closes #399

## Approach
The ThemeProvider (with `colorSchemeSelector: '.dark'`) already syncs MUI with Tailwind's dark mode. Rather than adding `dark:` variants to every HTML element, we replaced them with MUI components that inherit theming automatically.

### Migration patterns used
- **Text/number inputs** → `Controller` + `<TextField>`
- **Selects** → `Controller` + `<TextField select>` + `<MenuItem>`
- **Textareas** → `Controller` + `<TextField multiline>`
- **Date inputs** → `<TextField type="date">` with `slotProps={{ inputLabel: { shrink: true } }}`
- **Currency inputs** → `<TextField>` with `InputAdornment` for `$` prefix
- **Checkboxes** → `Controller` + `<FormControlLabel>` + `<Checkbox>`
- **Buttons** → MUI `<Button variant="outlined/contained">`
- **Number fields with valueAsNumber** → `register` + `inputRef` pattern

## Components migrated
| Category | Components |
|----------|-----------|
| **Simple forms** | AccountForm, CustomerForm, ProductServiceForm, ProjectForm, ConfirmModal |
| **Medium forms** | VendorForm, EmployeeForm, BillForm, CreditMemoForm, CustomerDepositForm, PayBillForm, ReceivePaymentForm, PurchaseOrderForm, VendorCreditForm, EmailSettingsForm |
| **Complex line-item forms** | InvoiceForm, SalesReceiptForm, ExpenseForm, MileageForm |

## Test plan
- [ ] Toggle dark/light mode and verify all 19 forms render correctly in both modes
- [ ] Verify line-item forms (Invoice, SalesReceipt, CreditMemo, VendorCredit, Bill, PurchaseOrder) — add/remove items, auto-calculations
- [ ] Verify forms with special features: receipt upload (Expense), odometer calc (Mileage), auto-tax (Invoice), product auto-fill (CreditMemo, VendorCredit)
- [ ] Verify AddressFields still works in CustomerForm and VendorForm
- [ ] Confirm TypeScript compiles clean and production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)