### PR TITLE
fix(#407): Editing transaction category saves without auto-approving

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { PublicClientApplication, SilentRequest, AccountInfo } from '@azure/msal-browser';
-import { apiRequest, roleHierarchy, type UserRole } from './authConfig';
+import { apiRequest, roleHierarchy } from './authConfig';
 import { formatDateForOData } from './dateUtils';
 
 const api = axios.create({

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -299,18 +299,22 @@ export default function UnifiedTransactions() {
   }, []);
 
   const handleSaveEdit = useCallback((id: string) => {
+    // Look up the account name to use as category text
+    const selectedAccount = accounts.find(a => a.Id === editForm.accountId);
     updateMutation.mutate({
       id,
       data: {
-        SuggestedAccountId: editForm.accountId,
+        SuggestedAccountId: editForm.accountId || undefined,
+        SuggestedCategory: selectedAccount?.Name || undefined,
         SuggestedMemo: editForm.memo,
-        Status: 'Approved',
-        ApprovedAccountId: editForm.accountId,
-        ApprovedMemo: editForm.memo,
         IsPersonal: editForm.isPersonal,
       },
+    }, {
+      onSuccess: () => {
+        toast.success('Transaction updated');
+      },
     });
-  }, [editForm, updateMutation]);
+  }, [editForm, accounts, updateMutation]);
 
   const handleBulkApprove = useCallback(() => {
     bulkApproveMutation.mutate(Array.from(selectedIds.ids) as string[]);


### PR DESCRIPTION
## Summary
- **Removed auto-approval**: Editing a transaction's category no longer sets `Status: 'Approved'` — approval remains a separate, intentional action
- **Fixed category persistence**: The selected account name is now saved as `SuggestedCategory` so the category text actually persists after edit
- **Added save feedback**: Success toast shown after saving edits

## Root Cause
`handleSaveEdit` in `UnifiedTransactions.tsx` was setting `Status: 'Approved'`, `ApprovedAccountId`, and `ApprovedMemo` on every edit save. This auto-approved transactions and also never updated the `SuggestedCategory` text field, so the visible category name didn't change.

## Test plan
- [ ] Edit a Pending transaction's category → verify it saves without changing status to Approved
- [ ] Verify the category text updates in the grid after save
- [ ] Verify explicit Approve button still works independently
- [ ] `npm run build` passes
- [ ] Playwright tests pass: `unified-transactions-datagrid`, `bank-transactions`

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)