### PR TITLE
fix(#402): Vertically align product name in Products & Services grid

### DIFF
--- a/client/src/pages/ProductsServices.tsx
+++ b/client/src/pages/ProductsServices.tsx
@@ -34,7 +34,7 @@ export default function ProductsServices() {
         const iconColor = params.row.Type === 'Service' ? 'text-blue-500' :
           params.row.Type === 'Inventory' ? 'text-green-500' : 'text-orange-500';
         return (
-          <div className="flex items-center">
+          <div className="flex items-center h-full">
             <IconComponent className={`w-4 h-4 mr-2 ${iconColor}`} />
             <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{params.value}</span>
           </div>


### PR DESCRIPTION
## Summary
- Fixes #402: Product name column content (icon + text) was top-aligned instead of vertically centered in the DataGrid rows
- Added `h-full` class to the Name column's `renderCell` container div so that flexbox `items-center` properly centers content within the full cell height

## Test plan
- [ ] Navigate to Products & Services page (`/products-services`)
- [ ] Verify the Name column content (icon + text) is vertically centered within each row
- [ ] Confirm alignment matches other columns (Type, Status, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)