### PR TITLE
fix(#405): Use MUI theme tokens for DataGrid dark mode styling

### DIFF
--- a/client/src/components/RestDataGrid.tsx
+++ b/client/src/components/RestDataGrid.tsx
@@ -170,8 +170,6 @@ export default function RestDataGrid<T extends GridValidRowModel>({
           disableRowSelectionOnClick={disableRowSelectionOnClick}
           // Styling
           sx={{
-            border: '1px solid var(--mui-palette-divider)',
-            color: 'var(--mui-palette-text-primary)',
             '& .MuiDataGrid-main': {
               overflow: 'auto',
             },
@@ -179,17 +177,7 @@ export default function RestDataGrid<T extends GridValidRowModel>({
               overflow: 'auto !important',
             },
             '& .MuiDataGrid-row:hover': {
-              backgroundColor: 'action.hover',
               cursor: editPath || onRowClick ? 'pointer' : 'default',
-            },
-            '& .MuiDataGrid-cell': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
-            '& .MuiDataGrid-columnHeaders': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
-            '& .MuiDataGrid-footerContainer': {
-              borderColor: 'var(--mui-palette-divider)',
             },
           }}
           localeText={{

--- a/client/src/components/ServerDataGrid.tsx
+++ b/client/src/components/ServerDataGrid.tsx
@@ -348,8 +348,6 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
           disableRowSelectionOnClick={disableRowSelectionOnClick}
           // Styling
           sx={{
-            border: '1px solid var(--mui-palette-divider)',
-            color: 'var(--mui-palette-text-primary)',
             '& .MuiDataGrid-main': {
               overflow: 'auto',
             },
@@ -357,17 +355,7 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
               overflow: 'auto !important',
             },
             '& .MuiDataGrid-row:hover': {
-              backgroundColor: 'action.hover',
               cursor: editPath || onRowClick ? 'pointer' : 'default',
-            },
-            '& .MuiDataGrid-cell': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
-            '& .MuiDataGrid-columnHeaders': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
-            '& .MuiDataGrid-footerContainer': {
-              borderColor: 'var(--mui-palette-divider)',
             },
           }}
           localeText={{

--- a/client/src/pages/AuditLog.tsx
+++ b/client/src/pages/AuditLog.tsx
@@ -668,19 +668,6 @@ export default function AuditLog() {
           getRowId={(row) => row.Id}
           sx={{
             border: 0,
-            color: 'var(--mui-palette-text-primary)',
-            '& .MuiDataGrid-row:hover': {
-              backgroundColor: 'action.hover',
-            },
-            '& .MuiDataGrid-cell': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
-            '& .MuiDataGrid-columnHeaders': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
-            '& .MuiDataGrid-footerContainer': {
-              borderColor: 'var(--mui-palette-divider)',
-            },
           }}
           localeText={{
             noRowsLabel: 'No audit log entries found.',

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -43,11 +43,25 @@ const appTheme = createTheme({
       styleOverrides: {
         root: {
           '--DataGrid-containerBackground': 'var(--mui-palette-background-default)',
+          border: '1px solid var(--mui-palette-divider)',
+          color: 'var(--mui-palette-text-primary)',
           '& .MuiDataGrid-columnHeaderTitle': {
             fontWeight: 600,
           },
           '& .MuiDataGrid-cell:focus': {
             outline: 'none',
+          },
+          '& .MuiDataGrid-cell': {
+            borderColor: 'var(--mui-palette-divider)',
+          },
+          '& .MuiDataGrid-columnHeaders': {
+            borderColor: 'var(--mui-palette-divider)',
+          },
+          '& .MuiDataGrid-footerContainer': {
+            borderColor: 'var(--mui-palette-divider)',
+          },
+          '& .MuiDataGrid-row:hover': {
+            backgroundColor: 'var(--mui-palette-action-hover)',
           },
         },
         columnHeaders: {


### PR DESCRIPTION
## Summary
- Replace hardcoded `rgba(79, 70, 229, 0.04)` hover color with MUI's `action.hover` theme token so the hover effect adapts to both light and dark modes
- Add explicit `border`, `color`, `borderColor` overrides using `var(--mui-palette-*)` CSS variables on the DataGrid root, cells, column headers, and footer so all visual elements follow the MUI theme's color scheme
- Applied consistently across `RestDataGrid`, `ServerDataGrid`, and `AuditLog` standalone DataGrid

Closes #405

## Test plan
- [ ] Toggle dark mode on and navigate to the Projects page — the DataGrid should render with a dark background, light text, and dark-colored borders
- [ ] Verify the same dark mode behavior on other DataGrid pages (Invoices, Customers, Bills, Vendors, Audit Log)
- [ ] Verify light mode still displays correctly (white background, dark text, light borders)
- [ ] Verify row hover effect is visible in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)