### PR TITLE
fix: Customer edit form missing Phone, AddressLine2, City, State fields

### DIFF
--- a/client/src/components/CustomerForm.tsx
+++ b/client/src/components/CustomerForm.tsx
@@ -40,6 +40,13 @@ export default function CustomerForm({ initialValues, onSubmit, title, isSubmitt
       Name: '',
       Email: '',
       Phone: '',
+      AddressLine1: '',
+      AddressLine2: '',
+      City: '',
+      State: '',
+      PostalCode: '',
+      Country: '',
+      Address: '',
       ...initialValues,
     }
   });

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -278,6 +278,12 @@ export interface Customer {
   Email?: string;
   Phone?: string;
   Address?: string;
+  AddressLine1?: string | null;
+  AddressLine2?: string | null;
+  City?: string | null;
+  State?: string | null;
+  PostalCode?: string | null;
+  Country?: string | null;
   CreatedAt: string;
   UpdatedAt: string;
 }

--- a/dab-config.json
+++ b/dab-config.json
@@ -260,6 +260,7 @@
                 "Phone": "Phone",
                 "Address": "Address",
                 "AddressLine1": "AddressLine1",
+                "AddressLine2": "AddressLine2",
                 "City": "City",
                 "State": "State",
                 "PostalCode": "PostalCode",


### PR DESCRIPTION
## Summary
- Added missing `AddressLine2` to DAB config entity mappings for the `customers` entity, so it is now returned in API responses
- Expanded `CustomerForm` `defaultValues` to initialize all address fields (AddressLine1, AddressLine2, City, State, PostalCode, Country, Address), ensuring uncontrolled inputs via `register()` receive proper initial values
- Updated the `Customer` TypeScript interface to include address breakdown fields for type safety

## Test plan
- [ ] Edit an existing customer that has Phone, Address Line 2, City, and State data in the DB
- [ ] Verify all fields are pre-populated in the edit form
- [ ] Verify saving the form preserves all field values
- [ ] Verify creating a new customer still works correctly
- [ ] Verify dark mode styling is unaffected

Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)