### PR TITLE
fix: Increase DataGrid bottom padding to prevent chat widget overlap

### DIFF
--- a/client/src/hooks/useGridHeight.ts
+++ b/client/src/hooks/useGridHeight.ts
@@ -5,12 +5,12 @@ import { useState, useEffect, useCallback, type RefObject } from 'react';
  * Returns a pixel value that fills from the element to the bottom of the viewport.
  *
  * @param ref - Reference to the element whose top position is measured
- * @param bottomPadding - Base padding at the bottom (default 16px)
+ * @param bottomPadding - Base padding at the bottom (default 80px, accounts for floating chat widget)
  * @param extraBottomOffset - Additional offset, e.g. for a fixed bottom bar (default 0)
  */
 export default function useGridHeight(
   ref: RefObject<HTMLElement | null>,
-  bottomPadding = 16,
+  bottomPadding = 80,
   extraBottomOffset = 0,
 ): number {
   const [height, setHeight] = useState(600);

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -398,7 +398,7 @@ export default function UnifiedTransactions() {
 
   // Calculate grid height, reserving space for the fixed bottom bulk-actions bar when visible
   const bulkBarVisible = selectedIds.ids.size > 0 || highConfidenceCount > 0;
-  const gridHeight = useGridHeight(gridRef, 16, bulkBarVisible ? BULK_ACTIONS_BAR_HEIGHT : 0);
+  const gridHeight = useGridHeight(gridRef, 80, bulkBarVisible ? BULK_ACTIONS_BAR_HEIGHT : 0);
 
   // DataGrid columns
   const columns: GridColDef[] = [


### PR DESCRIPTION
## Summary
- Increased the default `bottomPadding` in `useGridHeight` hook from 16px to 80px to account for the floating chat widget (fixed at bottom-right, ~56px tall with 24px offset)
- Updated `UnifiedTransactions` page which explicitly passed the old 16px value to use the new 80px value
- All other DataGrid consumers that use the default parameter automatically pick up the fix

## Test plan
- [ ] Navigate to any list view with a DataGrid (Customers, Vendors, Invoices, etc.)
- [ ] Verify the DataGrid pagination controls at the bottom are fully visible and not obscured by the chat widget
- [ ] Verify the DataGrid still fills the available viewport height appropriately
- [ ] Check UnifiedTransactions page -- verify pagination is visible with and without the bulk actions bar

Fixes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)