### PR TITLE
fix: Move Plaid scheduler to business hours and batch all jobs

### DIFF
--- a/chat-api/plaid-scheduler.js
+++ b/chat-api/plaid-scheduler.js
@@ -26,67 +26,14 @@ class PlaidScheduler {
             return;
         }
 
-        // Batched daily job at 9 AM PST — runs during business hours when the
+        // Batched daily job at 9 AM PT — runs during business hours when the
         // serverless DB is already awake, avoiding a costly off-hours resume.
         // Runs: transaction sync → balance update → connection validation sequentially.
-        this.scheduleJob('daily-batch', '0 9 * * *', async () => {
-            console.log('[Plaid Scheduler] Starting daily batch...');
-
-            // 1. Transaction sync
-            try {
-                console.log('[Plaid Scheduler] Running daily sync...');
-                const results = await plaidSync.syncAllConnections();
-                const successCount = results.filter(r => r.success).length;
-                const errorCount = results.filter(r => !r.success).length;
-                console.log(`[Plaid Scheduler] Daily sync complete: ${successCount} succeeded, ${errorCount} failed`);
-            } catch (error) {
-                console.error('[Plaid Scheduler] Daily sync error:', error.message);
-            }
-
-            // 2. Balance update
-            try {
-                console.log('[Plaid Scheduler] Updating account balances...');
-                const connections = await plaidService.getActiveConnections();
-                for (const conn of connections) {
-                    try {
-                        await plaidSync.updateBalances(conn.ItemId);
-                    } catch (error) {
-                        console.warn(`[Plaid Scheduler] Balance update failed for ${conn.InstitutionName}:`, error.message);
-                    }
-                }
-                console.log('[Plaid Scheduler] Balance update complete');
-            } catch (error) {
-                console.error('[Plaid Scheduler] Balance update error:', error.message);
-            }
-
-            // 3. Connection validation
-            try {
-                console.log('[Plaid Scheduler] Validating connections...');
-                const connections = await plaidService.getActiveConnections();
-                let validCount = 0;
-                let invalidCount = 0;
-
-                for (const conn of connections) {
-                    const result = await plaidService.validateConnection(conn.ItemId);
-                    if (result.valid) {
-                        validCount++;
-                    } else {
-                        invalidCount++;
-                        console.warn(`[Plaid Scheduler] Connection invalid: ${conn.InstitutionName} - ${result.error}`);
-                    }
-                }
-
-                console.log(`[Plaid Scheduler] Validation complete: ${validCount} valid, ${invalidCount} invalid`);
-            } catch (error) {
-                console.error('[Plaid Scheduler] Validation error:', error.message);
-            }
-
-            console.log('[Plaid Scheduler] Daily batch complete');
-        });
+        this.scheduleJob('daily-batch', '0 9 * * *', () => this._runDailyBatch());
 
         this.isRunning = true;
         console.log('[Plaid Scheduler] Started with scheduled jobs:');
-        console.log('  - Daily batch (sync + balances + validation) at 9:00 AM PST');
+        console.log('  - Daily batch (sync + balances + validation) at 9:00 AM PT');
     }
 
     /**
@@ -122,6 +69,86 @@ class PlaidScheduler {
     }
 
     /**
+     * Run the daily batch: sync → balances → validation.
+     * Shared by the cron schedule and the runNow API.
+     */
+    async _runDailyBatch() {
+        console.log('[Plaid Scheduler] Starting daily batch...');
+
+        // 1. Transaction sync
+        let syncResults = [];
+        try {
+            console.log('[Plaid Scheduler] Running daily sync...');
+            syncResults = await plaidSync.syncAllConnections();
+            const successCount = syncResults.filter(r => r.success).length;
+            const errorCount = syncResults.filter(r => !r.success).length;
+            console.log(`[Plaid Scheduler] Daily sync complete: ${successCount} succeeded, ${errorCount} failed`);
+        } catch (error) {
+            console.error('[Plaid Scheduler] Daily sync error:', error.message);
+        }
+
+        // Fetch connections once for both balances and validation
+        let connections = [];
+        try {
+            connections = await plaidService.getActiveConnections();
+        } catch (error) {
+            console.error('[Plaid Scheduler] Failed to fetch connections:', error.message);
+            console.log('[Plaid Scheduler] Daily batch complete (skipped balances + validation)');
+            return { sync: syncResults, balances: [], validation: [] };
+        }
+
+        // 2. Balance update
+        const balanceResults = [];
+        try {
+            console.log('[Plaid Scheduler] Updating account balances...');
+            for (const conn of connections) {
+                try {
+                    const result = await plaidSync.updateBalances(conn.ItemId);
+                    balanceResults.push({ itemId: conn.ItemId, ...result });
+                } catch (error) {
+                    balanceResults.push({ itemId: conn.ItemId, success: false, error: error.message });
+                    console.warn(`[Plaid Scheduler] Balance update failed for ${conn.InstitutionName}:`, error.message);
+                }
+            }
+            console.log('[Plaid Scheduler] Balance update complete');
+        } catch (error) {
+            console.error('[Plaid Scheduler] Balance update error:', error.message);
+        }
+
+        // 3. Connection validation
+        const validationResults = [];
+        try {
+            console.log('[Plaid Scheduler] Validating connections...');
+            let validCount = 0;
+            let invalidCount = 0;
+
+            for (const conn of connections) {
+                try {
+                    const result = await plaidService.validateConnection(conn.ItemId);
+                    validationResults.push({ itemId: conn.ItemId, ...result });
+                    if (result.valid) {
+                        validCount++;
+                    } else {
+                        invalidCount++;
+                        console.warn(`[Plaid Scheduler] Connection invalid: ${conn.InstitutionName} - ${result.error}`);
+                    }
+                } catch (error) {
+                    validationResults.push({ itemId: conn.ItemId, valid: false, error: error.message });
+                    invalidCount++;
+                    console.warn(`[Plaid Scheduler] Validation failed for ${conn.InstitutionName}:`, error.message);
+                }
+            }
+
+            console.log(`[Plaid Scheduler] Validation complete: ${validCount} valid, ${invalidCount} invalid`);
+        } catch (error) {
+            console.error('[Plaid Scheduler] Validation error:', error.message);
+        }
+
+        console.log('[Plaid Scheduler] Daily batch complete');
+        return { sync: syncResults, balances: balanceResults, validation: validationResults };
+    }
+
+    /**
      * Run a specific job immediately
      * @param {string} name - Job name
      */
@@ -132,29 +159,9 @@ class PlaidScheduler {
         }
 
         console.log(`[Plaid Scheduler] Running job now: ${name}`);
-        // Trigger the task associated with the job
-        // Note: node-cron doesn't expose the task directly, so we'll need to track tasks separately
-        // For now, we'll handle common jobs directly
         switch (name) {
-            case 'daily-batch': {
-                const syncResults = await plaidSync.syncAllConnections();
-                const connections = await plaidService.getActiveConnections();
-                const balanceResults = [];
-                for (const conn of connections) {
-                    try {
-                        const result = await plaidSync.updateBalances(conn.ItemId);
-                        balanceResults.push({ itemId: conn.ItemId, ...result });
-                    } catch (error) {
-                        balanceResults.push({ itemId: conn.ItemId, success: false, error: error.message });
-                    }
-                }
-                const validationResults = [];
-                for (const conn of connections) {
-                    const result = await plaidService.validateConnection(conn.ItemId);
-                    validationResults.push({ itemId: conn.ItemId, ...result });
-                }
-                return { sync: syncResults, balances: balanceResults, validation: validationResults };
-            }
+            case 'daily-batch':
+                return await this._runDailyBatch();
             default:
                 throw new Error(`Unknown job: ${name}`);
         }


### PR DESCRIPTION
## Summary
- **Root cause**: Three separate Plaid cron jobs (6 AM ET, 7 AM ET, every 12h ET) were waking the serverless SQL DB at 3 AM PST and keeping it running for ~2 hours overnight, burning ~5.12k App CPU billed with no users active
- **Fix**: Consolidated into a single `daily-batch` job at **9 AM PST** when the DB is already awake from user activity
- **Timezone**: Changed from `America/New_York` to `America/Los_Angeles` to match the team

### Before (3 jobs, Eastern)
| Job | ET | PST |
|-----|-----|-----|
| daily-sync | 6 AM | 3 AM |
| balance-update | 7 AM | 4 AM |
| validate-connections | every 12h | 9 PM / 9 AM |

### After (1 batched job, Pacific)
| Job | PST |
|-----|-----|
| daily-batch (sync → balances → validation) | 9 AM |

## Test plan
- [ ] Deploy to prod and verify no DB resume between midnight–9 AM PST via Activity Log
- [ ] Confirm daily-batch fires at 9 AM PST and completes successfully (check App Service logs)
- [ ] Test manual trigger via `POST /api/plaid/scheduler/run/daily-batch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)