### PR TITLE
fix: Convert empty string to null for Project/Class dropdowns (#493)

### DIFF
--- a/client/src/components/BillForm.tsx
+++ b/client/src/components/BillForm.tsx
@@ -284,7 +284,7 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
             render={({ field }) => (
               <ProjectSelector
                 value={field.value || ''}
-                onChange={field.onChange}
+                onChange={(projectId) => field.onChange(projectId || null)}
                 disabled={isSubmitting}
               />
             )}
@@ -296,7 +296,7 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
             render={({ field }) => (
               <ClassSelector
                 value={field.value || ''}
-                onChange={field.onChange}
+                onChange={(classId) => field.onChange(classId || null)}
                 disabled={isSubmitting}
               />
             )}
@@ -415,7 +415,7 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
                       render={({ field: pField }) => (
                         <ProjectSelector
                           value={pField.value || ''}
-                          onChange={pField.onChange}
+                          onChange={(projectId) => pField.onChange(projectId || null)}
                           disabled={isSubmitting}
                         />
                       )}
@@ -428,7 +428,7 @@ export default function BillForm({ initialValues, onSubmit, title, isSubmitting:
                       render={({ field: cField }) => (
                         <ClassSelector
                           value={cField.value || ''}
-                          onChange={cField.onChange}
+                          onChange={(classId) => cField.onChange(classId || null)}
                           disabled={isSubmitting}
                         />
                       )}

--- a/client/src/components/EstimateForm.tsx
+++ b/client/src/components/EstimateForm.tsx
@@ -191,7 +191,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
             render={({ field }) => (
               <ProjectSelector
                 value={field.value || ''}
-                onChange={field.onChange}
+                onChange={(projectId) => field.onChange(projectId || null)}
                 disabled={isSubmitting}
                 customerId={watch('CustomerId')}
               />
@@ -204,7 +204,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
             render={({ field }) => (
               <ClassSelector
                 value={field.value || ''}
-                onChange={field.onChange}
+                onChange={(classId) => field.onChange(classId || null)}
                 disabled={isSubmitting}
               />
             )}
@@ -339,7 +339,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                         render={({ field: pField }) => (
                           <ProjectSelector
                             value={pField.value || ''}
-                            onChange={pField.onChange}
+                            onChange={(projectId) => pField.onChange(projectId || null)}
                             disabled={isSubmitting}
                           />
                         )}
@@ -352,7 +352,7 @@ export default function EstimateForm({ initialValues, onSubmit, title, isSubmitt
                         render={({ field: cField }) => (
                           <ClassSelector
                             value={cField.value || ''}
-                            onChange={cField.onChange}
+                            onChange={(classId) => cField.onChange(classId || null)}
                             disabled={isSubmitting}
                           />
                         )}

--- a/client/src/components/InvoiceForm.tsx
+++ b/client/src/components/InvoiceForm.tsx
@@ -408,10 +408,9 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
             render={({ field }) => (
               <ProjectSelector
                 value={field.value || ''}
-                onChange={field.onChange}
+                onChange={(projectId) => field.onChange(projectId || null)}
                 disabled={isSubmitting}
                 customerId={watch('CustomerId')}
-                className=""
               />
             )}
           />
@@ -422,7 +421,7 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
             render={({ field }) => (
               <ClassSelector
                 value={field.value || ''}
-                onChange={field.onChange}
+                onChange={(classId) => field.onChange(classId || null)}
                 disabled={isSubmitting}
               />
             )}
@@ -581,7 +580,7 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
                         render={({ field: pField }) => (
                           <ProjectSelector
                             value={pField.value || ''}
-                            onChange={pField.onChange}
+                            onChange={(projectId) => pField.onChange(projectId || null)}
                             disabled={isSubmitting}
                             customerId={watch('CustomerId')}
                           />
@@ -595,7 +594,7 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
                         render={({ field: cField }) => (
                           <ClassSelector
                             value={cField.value || ''}
-                            onChange={cField.onChange}
+                            onChange={(classId) => cField.onChange(classId || null)}
                             disabled={isSubmitting}
                           />
                         )}


### PR DESCRIPTION
## Summary
- Fixes the Project and Class dropdown on the Invoice form (and Bill/Estimate forms) by converting empty strings to `null` in `onChange` handlers
- The `ProjectSelector` and `ClassSelector` components return `''` when cleared, but the Zod schema validates `ProjectId`/`ClassId` as `z.string().uuid().nullish()` which rejects empty strings, causing silent form validation failures
- Also removes unnecessary `className=""` prop from InvoiceForm's ProjectSelector

## Root Cause
When PR #490 added ProjectId/ClassId tracking to all transaction forms, the `onChange` handlers passed `field.onChange` directly to the selector components. The selectors return `''` (empty string) when cleared, but the Zod schema only accepts `null`, `undefined`, or valid UUID strings. This caused the form to silently fail validation whenever users interacted with the Project dropdown.

## Test plan
- [ ] Open Invoice form, select a project, then clear it, and verify the form still submits successfully
- [ ] Open Invoice form without selecting a project and verify the form submits (ProjectId should be `null`)
- [ ] Open Invoice form, select a project, and verify the form submits with the correct ProjectId
- [ ] Repeat the above for Class dropdown
- [ ] Repeat the above for line-level Project and Class dropdowns
- [ ] Verify Bill and Estimate forms also work correctly with the same fix

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)