### PR TITLE
fix(#487): Align Edit Submission form fields with New Submission form

### DIFF
--- a/client/src/pages/EditSubmission.tsx
+++ b/client/src/pages/EditSubmission.tsx
@@ -298,6 +298,7 @@ export default function EditSubmission() {
               label="Description"
               multiline
               rows={4}
+              placeholder="Provide a detailed description..."
               error={!!fieldState.error}
               helperText={fieldState.error?.message}
               size="small"
@@ -319,6 +320,7 @@ export default function EditSubmission() {
                   label="Steps to Reproduce"
                   multiline
                   rows={4}
+                  placeholder={"1. Go to...\n2. Click on...\n3. See error..."}
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
                   size="small"
@@ -338,6 +340,7 @@ export default function EditSubmission() {
                     label="Expected Behavior"
                     multiline
                     rows={3}
+                    placeholder="What should happen..."
                     error={!!fieldState.error}
                     helperText={fieldState.error?.message}
                     size="small"
@@ -356,6 +359,7 @@ export default function EditSubmission() {
                     label="Actual Behavior"
                     multiline
                     rows={3}
+                    placeholder="What actually happens..."
                     error={!!fieldState.error}
                     helperText={fieldState.error?.message}
                     size="small"


### PR DESCRIPTION
## Summary

Closes #487.

Investigation found that the New Submission form **already has** the bug-specific fields (Steps to Reproduce, Expected Behavior, Actual Behavior) conditionally shown when Type = "Bug". These fields have been present since the initial implementation in commit `84a7b56` (feat: Add bug and enhancement submission system #66).

The original issue was likely caused by dark mode rendering raw HTML `<input>`/`<textarea>` elements as invisible (white text on white background), which was fixed by PR #475 converting all form controls to MUI components.

This PR completes the field parity by:
- Adding matching placeholder text to the Edit form's Description field (`"Provide a detailed description..."`)
- Adding matching placeholder text to the Edit form's Steps to Reproduce field (`"1. Go to...\n2. Click on...\n3. See error..."`)
- Adding matching placeholder text to the Edit form's Expected Behavior field (`"What should happen..."`)
- Adding matching placeholder text to the Edit form's Actual Behavior field (`"What actually happens..."`)

Status is intentionally **not** added to the New form -- new submissions should default to "Open" server-side.

## Test plan
- [ ] Navigate to `/submissions/new`, select Type = "Bug", and verify Steps to Reproduce, Expected Behavior, and Actual Behavior fields appear with placeholder text
- [ ] Navigate to `/submissions/:id/edit` for a Bug submission and verify the same placeholder text appears in Description and bug-specific fields
- [ ] Verify both forms render correctly in light and dark mode
- [ ] Submit a new Bug with all fields filled and verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)