### PR TITLE
fix: Resolve client-side bugs #498, #500, #501

### DIFF
--- a/client/src/components/EmailSettingsForm.tsx
+++ b/client/src/components/EmailSettingsForm.tsx
@@ -249,6 +249,7 @@ export default function EmailSettingsForm() {
               value={field.value ?? ''}
               label={hasExistingPassword ? 'Password (leave blank to keep current)' : 'Password'}
               type={showPassword ? 'text' : 'password'}
+              autoComplete="current-password"
               placeholder={hasExistingPassword ? '........' : 'Enter password'}
               error={!!fieldState.error}
               helperText={fieldState.error?.message}

--- a/client/src/components/InvoiceForm.tsx
+++ b/client/src/components/InvoiceForm.tsx
@@ -174,7 +174,7 @@ export default function InvoiceForm({ initialValues, onSubmit, title, isSubmitti
         ...(customer.City && { city: customer.City }),
       });
 
-      const taxResponse = await api.get(`/api/tax/rate?${params}`);
+      const taxResponse = await api.get(`/tax/rate?${params}`);
       const taxData = taxResponse.data;
 
       if (taxData.rate !== undefined) {

--- a/client/src/pages/EditSubmission.tsx
+++ b/client/src/pages/EditSubmission.tsx
@@ -77,6 +77,16 @@ export default function EditSubmission() {
 
   const { handleSubmit, watch, reset, control } = useForm<SubmissionFormData>({
     resolver: zodResolver(submissionSchema),
+    defaultValues: {
+      Title: '',
+      Type: 'Bug',
+      Priority: 'Medium',
+      Status: 'Open',
+      Description: '',
+      StepsToReproduce: '',
+      ExpectedBehavior: '',
+      ActualBehavior: '',
+    },
   });
 
   const submissionType = watch('Type');


### PR DESCRIPTION
## Summary
- **#498**: Remove double `/api` prefix on tax rate API call in InvoiceForm — `api.get('/api/tax/rate')` → `api.get('/tax/rate')` (axios baseURL already includes `/api`)
- **#500**: Add `defaultValues` to EditSubmission `useForm` call to prevent React uncontrolled-to-controlled warning on mount
- **#501**: Add `autoComplete="current-password"` to SMTP password TextField in EmailSettingsForm

## Test plan
- [ ] Create/edit an invoice with a customer that has an address — verify no 404 on tax rate lookup
- [ ] Navigate to edit a submission — verify no React console warning
- [ ] Navigate to Settings → Email — verify no DOM console warning about autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)