### PR TITLE
fix: Resolve 413 Payload Too Large when saving company settings

### DIFF
--- a/chat-api/server.js
+++ b/chat-api/server.js
@@ -184,7 +184,7 @@ function validateExtractedIntent(intent) {
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '10mb' }));
 
 // ============================================================================
 // DAB (Data API Builder) Proxy

--- a/client/tests/company-settings.spec.ts
+++ b/client/tests/company-settings.spec.ts
@@ -42,35 +42,113 @@ test.describe('Company Settings', () => {
     await page.goto('/settings');
     await expect(page.getByRole('heading', { name: 'Company Settings' })).toBeVisible();
 
-    // Wait for settings to load
-    await page.waitForTimeout(1000);
+    // Wait for settings to load from the database
+    const nameInput = page.locator('input[name="name"]');
+    await expect(nameInput).toBeVisible();
+    await page.waitForFunction(
+      () => {
+        const input = document.querySelector('input[name="name"]') as HTMLInputElement;
+        return input && input.value.length > 0;
+      },
+      { timeout: 10000 }
+    );
 
-    // Update company name
-    const nameInput = page.locator('#name, input[name="name"]');
-    if (await nameInput.isVisible()) {
-      const currentName = await nameInput.inputValue();
-      await nameInput.clear();
-      await nameInput.fill(`Test Company ${timestamp}`);
+    const currentName = await nameInput.inputValue();
+    await nameInput.clear();
+    await nameInput.fill(`Test Company ${timestamp}`);
 
-      // Update address
-      const addressInput = page.locator('#address, input[name="address"]');
-      if (await addressInput.isVisible()) {
-        await addressInput.clear();
-        await addressInput.fill('456 Test Blvd');
-      }
+    // Update address
+    const addressInput = page.locator('input[name="address"]');
+    await expect(addressInput).toBeVisible();
+    await addressInput.clear();
+    await addressInput.fill('456 Test Blvd');
 
-      // Save (first button is the company info section save)
-      await page.getByRole('button', { name: /Save Settings/i }).first().click();
+    // Save and wait for the PATCH API response
+    const savePromise = page.waitForResponse(
+      resp => resp.url().includes('/api/companies') &&
+              (resp.status() === 200 || resp.status() === 201)
+    );
+    await page.getByRole('button', { name: /Save Settings/i }).first().click();
+    await savePromise;
 
-      // Verify save success message
-      await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: 10000 });
+    // Verify save success message
+    await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: 10000 });
 
-      // Restore original name
-      await nameInput.clear();
-      await nameInput.fill(currentName || 'Modern Accounting');
-      await page.getByRole('button', { name: /Save Settings/i }).first().click();
-      await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: 10000 });
-    }
+    // Restore original name
+    await nameInput.clear();
+    await nameInput.fill(currentName || 'Modern Accounting');
+    const restorePromise = page.waitForResponse(
+      resp => resp.url().includes('/api/companies') &&
+              (resp.status() === 200 || resp.status() === 201)
+    );
+    await page.getByRole('button', { name: /Save Settings/i }).first().click();
+    await restorePromise;
+    await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should persist company address after page reload', async ({ page }) => {
+    const testAddress = `${Date.now()} Persistence Ave`;
+
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: 'Company Settings' })).toBeVisible();
+
+    // Wait for settings to load from the database
+    const addressInput = page.locator('input[name="address"]');
+    await expect(addressInput).toBeVisible();
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('input[name="name"]') as HTMLInputElement;
+        return el && el.value.length > 0;
+      },
+      { timeout: 10000 }
+    );
+
+    // Remember original address for cleanup
+    const originalAddress = await addressInput.inputValue();
+
+    // Update address to a unique test value
+    await addressInput.clear();
+    await addressInput.fill(testAddress);
+
+    // Save and wait for the API response
+    const savePromise = page.waitForResponse(
+      resp => resp.url().includes('/api/companies') &&
+              (resp.status() === 200 || resp.status() === 201)
+    );
+    await page.getByRole('button', { name: /Save Settings/i }).first().click();
+    await savePromise;
+    await expect(page.getByText(/saved successfully/i)).toBeVisible({ timeout: 10000 });
+
+    // Clear localStorage so reload must fetch from DB, not cache
+    await page.evaluate(() => localStorage.removeItem('company-settings'));
+
+    // Reload the page
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Company Settings' })).toBeVisible();
+
+    // Wait for settings to load from the database again
+    const reloadedAddressInput = page.locator('input[name="address"]');
+    await expect(reloadedAddressInput).toBeVisible();
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector('input[name="name"]') as HTMLInputElement;
+        return el && el.value.length > 0;
+      },
+      { timeout: 10000 }
+    );
+
+    // Verify the address persisted
+    await expect(reloadedAddressInput).toHaveValue(testAddress);
+
+    // Cleanup: restore original address
+    await reloadedAddressInput.clear();
+    await reloadedAddressInput.fill(originalAddress || '');
+    const cleanupPromise = page.waitForResponse(
+      resp => resp.url().includes('/api/companies') &&
+              (resp.status() === 200 || resp.status() === 201)
+    );
+    await page.getByRole('button', { name: /Save Settings/i }).first().click();
+    await cleanupPromise;
   });
 
   test('should update tax information', async ({ page }) => {


### PR DESCRIPTION
## Summary
- **Increased Express JSON body parser limit** from the default 100kb to 10mb in `chat-api/server.js` to accommodate base64-encoded company logos in PATCH payloads
- **Added Playwright persistence test** that saves a company address, clears localStorage, reloads the page, and verifies the value was round-tripped through the database
- **Improved existing test** to use `waitForResponse` and `waitForFunction` instead of `waitForTimeout` anti-pattern

## Root Cause
The company settings form stores the company logo as a base64 data URL (up to 2MB image -> ~2.7MB base64 string). When saving settings via `PATCH /api/companies/Id/{id}`, the payload exceeded Express's default `express.json()` limit of 100kb, resulting in a `413 Payload Too Large` error. The database column (`LogoUrl NVARCHAR(MAX)`) already supports large values since commit e159938.

## Changes
| File | Change |
|------|--------|
| `chat-api/server.js` | `express.json()` -> `express.json({ limit: '10mb' })` |
| `client/tests/company-settings.spec.ts` | New persistence test + improved existing test patterns |

## Test plan
- [ ] Save company settings with a logo uploaded -- should succeed (no 413)
- [ ] Save company settings without a logo -- should still work as before
- [ ] Run `npx playwright test company-settings.spec.ts` -- all tests pass
- [ ] Verify the new persistence test clears localStorage and confirms DB round-trip

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)