### PR TITLE
feat: Persist DataGrid column widths across sessions

### DIFF
--- a/client/src/components/RestDataGrid.tsx
+++ b/client/src/components/RestDataGrid.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import {
   DataGrid,
   GridColDef,
@@ -98,6 +98,12 @@ export default function RestDataGrid<T extends GridValidRowModel>({
   const setSortModel = gridKey ? persistedState.onSortModelChange : setLocalSortModel;
   const setFilterModel = gridKey ? persistedState.onFilterModelChange : setLocalFilterModel;
 
+  // Apply persisted column widths
+  const resolvedColumns = useMemo(
+    () => (gridKey ? persistedState.applyColumnWidths(columns) : columns),
+    [gridKey, persistedState.applyColumnWidths, columns],
+  );
+
   // Fetch data from REST API
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -165,7 +171,7 @@ export default function RestDataGrid<T extends GridValidRowModel>({
       <div ref={gridRef} style={{ height: resolvedHeight, width: '100%' }} className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-x-auto">
         <DataGrid
           rows={rows}
-          columns={columns}
+          columns={resolvedColumns}
           getRowId={getRowId}
           loading={loading}
           // Client-side pagination
@@ -178,6 +184,8 @@ export default function RestDataGrid<T extends GridValidRowModel>({
           // Client-side filtering
           filterModel={filterModel}
           onFilterModelChange={setFilterModel}
+          // Persist column widths
+          onColumnWidthChange={gridKey ? persistedState.onColumnWidthChange : undefined}
           // Row interaction
           onRowClick={handleRowClick}
           checkboxSelection={checkboxSelection}

--- a/client/src/components/ServerDataGrid.tsx
+++ b/client/src/components/ServerDataGrid.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import {
   DataGrid,
   GridColDef,
@@ -311,10 +311,16 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
     }
   }, [onRowClick, editPath, getRowId, navigate]);
 
+  // Apply persisted column widths
+  const widthAdjustedColumns = useMemo(
+    () => (gridKey ? persistedState.applyColumnWidths(columns) : columns),
+    [gridKey, persistedState.applyColumnWidths, columns],
+  );
+
   // Add actions column if renderActions is provided
   const columnsWithActions: GridColDef[] = renderActions
     ? [
-        ...columns,
+        ...widthAdjustedColumns,
         {
           field: 'actions',
           headerName: 'Actions',
@@ -324,7 +330,7 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
           renderCell: (params) => renderActions(params.row as T),
         },
       ]
-    : columns;
+    : widthAdjustedColumns;
 
   if (error) {
     return (
@@ -367,6 +373,8 @@ export default function ServerDataGrid<T extends GridValidRowModel>({
           filterMode="server"
           filterModel={filterModel}
           onFilterModelChange={handleFilterModelChange}
+          // Persist column widths
+          onColumnWidthChange={gridKey ? persistedState.onColumnWidthChange : undefined}
           // Row interaction
           onRowClick={handleRowClick}
           checkboxSelection={checkboxSelection}

--- a/client/src/hooks/useDataGridState.ts
+++ b/client/src/hooks/useDataGridState.ts
@@ -3,14 +3,20 @@ import type {
   GridSortModel,
   GridFilterModel,
   GridPaginationModel,
+  GridColDef,
+  GridColumnResizeParams,
 } from '@mui/x-data-grid';
 
 const STORAGE_PREFIX = 'datagrid-state:';
+
+/** Map of field name → pixel width */
+type ColumnWidthMap = Record<string, number>;
 
 interface PersistedState {
   sortModel?: GridSortModel;
   filterModel?: GridFilterModel;
   paginationModel?: GridPaginationModel;
+  columnWidths?: ColumnWidthMap;
 }
 
 function loadState(key: string): PersistedState {
@@ -49,6 +55,10 @@ interface UseDataGridStateReturn {
   onSortModelChange: (model: GridSortModel) => void;
   onFilterModelChange: (model: GridFilterModel) => void;
   onPaginationModelChange: (model: GridPaginationModel) => void;
+  /** Apply persisted column widths to a columns array */
+  applyColumnWidths: (columns: GridColDef[]) => GridColDef[];
+  /** Handler for DataGrid onColumnWidthChange */
+  onColumnWidthChange: (params: GridColumnResizeParams) => void;
 }
 
 /**
@@ -112,6 +122,34 @@ export default function useDataGridState({
     [gridKey],
   );
 
+  const [columnWidths, setColumnWidths] = useState<ColumnWidthMap>(
+    persisted.columnWidths ?? {},
+  );
+
+  const onColumnWidthChange = useCallback(
+    (params: GridColumnResizeParams) => {
+      setColumnWidths((prev) => {
+        const next = { ...prev, [params.colDef.field]: params.width };
+        const current = loadState(gridKey);
+        saveState(gridKey, { ...current, columnWidths: next });
+        return next;
+      });
+    },
+    [gridKey],
+  );
+
+  const applyColumnWidths = useCallback(
+    (columns: GridColDef[]): GridColDef[] => {
+      if (Object.keys(columnWidths).length === 0) return columns;
+      return columns.map((col) =>
+        columnWidths[col.field] != null
+          ? { ...col, width: columnWidths[col.field] }
+          : col,
+      );
+    },
+    [columnWidths],
+  );
+
   return {
     sortModel,
     filterModel,
@@ -119,5 +157,7 @@ export default function useDataGridState({
     onSortModelChange,
     onFilterModelChange,
     onPaginationModelChange,
+    applyColumnWidths,
+    onColumnWidthChange,
   };
 }

--- a/client/tests/column-widths.spec.ts
+++ b/client/tests/column-widths.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from './coverage.fixture';
+
+test.describe('DataGrid column width persistence', () => {
+  const GRID_KEY = 'customers-grid';
+  const STORAGE_KEY = `datagrid-state:${GRID_KEY}`;
+
+  test.beforeEach(async ({ page }) => {
+    // Clear any persisted state for this grid
+    await page.goto('http://localhost:5173');
+    await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  });
+
+  test('should persist column widths after resize and restore on reload', async ({ page }) => {
+    // Navigate to Customers page (uses RestDataGrid with gridKey="customers-grid")
+    await page.goto('http://localhost:5173/customers');
+
+    // Wait for the DataGrid to render with data or empty state
+    const grid = page.locator('.MuiDataGrid-root');
+    await expect(grid).toBeVisible({ timeout: 15000 });
+
+    // Wait for loading to finish
+    await expect(grid.locator('.MuiDataGrid-overlay')).toBeHidden({ timeout: 15000 }).catch(() => {});
+    // Small extra wait for rows to render
+    await page.waitForTimeout(1000);
+
+    // Get the first resizable column header separator
+    const columnHeaders = grid.locator('.MuiDataGrid-columnHeader');
+    const headerCount = await columnHeaders.count();
+    expect(headerCount).toBeGreaterThan(1);
+
+    // Get the field name of the second column (first non-checkbox column to resize)
+    const secondHeader = columnHeaders.nth(1);
+    const fieldName = await secondHeader.getAttribute('data-field');
+    expect(fieldName).toBeTruthy();
+
+    // Get the column separator for the second column
+    const separator = secondHeader.locator('.MuiDataGrid-columnSeparator');
+    await expect(separator).toBeVisible();
+
+    // Get initial column width
+    const initialBox = await secondHeader.boundingBox();
+    expect(initialBox).toBeTruthy();
+    const initialWidth = initialBox!.width;
+
+    // Drag the separator to resize the column (drag 100px to the right)
+    const sepBox = await separator.boundingBox();
+    expect(sepBox).toBeTruthy();
+    const startX = sepBox!.x + sepBox!.width / 2;
+    const startY = sepBox!.y + sepBox!.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 100, startY, { steps: 10 });
+    await page.mouse.up();
+
+    // Wait for the resize to settle
+    await page.waitForTimeout(500);
+
+    // Verify the column actually resized
+    const resizedBox = await secondHeader.boundingBox();
+    expect(resizedBox).toBeTruthy();
+    expect(resizedBox!.width).toBeGreaterThan(initialWidth + 50);
+
+    // Check localStorage was updated with the new width
+    const storedState = await page.evaluate((key) => {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, STORAGE_KEY);
+
+    expect(storedState).toBeTruthy();
+    expect(storedState.columnWidths).toBeTruthy();
+    expect(storedState.columnWidths[fieldName!]).toBeGreaterThan(initialWidth + 50);
+
+    const savedWidth = storedState.columnWidths[fieldName!];
+
+    // Reload the page to test persistence
+    await page.reload();
+    await expect(grid).toBeVisible({ timeout: 15000 });
+    await expect(grid.locator('.MuiDataGrid-overlay')).toBeHidden({ timeout: 15000 }).catch(() => {});
+    await page.waitForTimeout(1000);
+
+    // Check the column width is restored from localStorage
+    const restoredHeader = grid.locator(`.MuiDataGrid-columnHeader[data-field="${fieldName}"]`);
+    await expect(restoredHeader).toBeVisible();
+    const restoredBox = await restoredHeader.boundingBox();
+    expect(restoredBox).toBeTruthy();
+
+    // Width should be close to the saved width (within 5px tolerance for rendering)
+    expect(restoredBox!.width).toBeGreaterThan(savedWidth - 5);
+    expect(restoredBox!.width).toBeLessThan(savedWidth + 5);
+  });
+
+  test('should not interfere with other grids', async ({ page }) => {
+    const OTHER_KEY = 'datagrid-state:invoices-grid';
+    await page.evaluate((key) => localStorage.removeItem(key), OTHER_KEY);
+
+    // Navigate to Customers and resize a column
+    await page.goto('http://localhost:5173/customers');
+    const grid = page.locator('.MuiDataGrid-root');
+    await expect(grid).toBeVisible({ timeout: 15000 });
+    await expect(grid.locator('.MuiDataGrid-overlay')).toBeHidden({ timeout: 15000 }).catch(() => {});
+    await page.waitForTimeout(1000);
+
+    const secondHeader = grid.locator('.MuiDataGrid-columnHeader').nth(1);
+    const separator = secondHeader.locator('.MuiDataGrid-columnSeparator');
+    await expect(separator).toBeVisible();
+
+    const sepBox = await separator.boundingBox();
+    expect(sepBox).toBeTruthy();
+    const startX = sepBox!.x + sepBox!.width / 2;
+    const startY = sepBox!.y + sepBox!.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 80, startY, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(500);
+
+    // Verify customers grid has saved widths
+    const customersState = await page.evaluate((key) => {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, STORAGE_KEY);
+    expect(customersState?.columnWidths).toBeTruthy();
+
+    // Invoices grid should have no column widths saved
+    const invoicesState = await page.evaluate((key) => {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, OTHER_KEY);
+    expect(invoicesState?.columnWidths).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #553

- Extends `useDataGridState` hook to save/restore column widths in `localStorage` alongside existing sort/filter/pagination state
- Wires up `onColumnWidthChange` and `applyColumnWidths` in both `RestDataGrid` and `ServerDataGrid`, covering all 22+ grid pages automatically
- Adds Playwright test verifying resize → persist → reload → restore, plus grid isolation

## Test plan

- [x] Playwright tests pass (2/2): resize persists across reload, grids don't interfere with each other
- [ ] Manual: resize columns on Customers, navigate away, come back — widths retained
- [ ] Manual: verify Invoices grid widths are independent from Customers grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)