### PR TITLE
feat: Unified Transaction Rules + recategorization rule updates

### DIFF
--- a/chat-api/plaid-sync.js
+++ b/chat-api/plaid-sync.js
@@ -272,13 +272,29 @@ class PlaidSync {
         let suggestedMemo = plaidTx.name;
         let confidenceScore = 0;
 
-        // STEP 1: Check learned categorization rules first (faster + higher accuracy)
-        const ruleMatch = await this.checkCategorizationRules(plaidTx.name, plaidTx.merchant_name);
+        // STEP 1: Check unified TransactionRules (replaces separate categorization + bank rules)
+        let isPersonal = false;
+        let assignedVendorId = null;
+        let assignedCustomerId = null;
+        let assignedClassId = null;
+        let assignedProjectId = null;
+        let assignedPayee = null;
+
+        const ruleMatch = await this.checkTransactionRules(sourceAccountId, plaidTx.name || '', plaidTx.merchant_name, amount);
         if (ruleMatch) {
-            suggestedAccountId = ruleMatch.AccountId;
-            suggestedCategory = ruleMatch.Category || suggestedCategory;
-            confidenceScore = 100;  // Rules are 100% confidence (user-verified)
-            console.log(`Rule match: "${plaidTx.name}" -> ${ruleMatch.Category}`);
+            if (ruleMatch.AssignAccountId) {
+                suggestedAccountId = ruleMatch.AssignAccountId;
+                confidenceScore = 100;  // Rules are 100% confidence (user-verified)
+            }
+            suggestedCategory = ruleMatch.AssignCategory || suggestedCategory;
+            if (ruleMatch.AssignMemo) suggestedMemo = ruleMatch.AssignMemo;
+            if (ruleMatch.AssignIsPersonal) isPersonal = true;
+            assignedVendorId = ruleMatch.AssignVendorId || null;
+            assignedCustomerId = ruleMatch.AssignCustomerId || null;
+            assignedClassId = ruleMatch.AssignClassId || null;
+            assignedProjectId = ruleMatch.AssignProjectId || null;
+            assignedPayee = ruleMatch.AssignPayee || null;
+            console.log(`TransactionRule match: "${ruleMatch.MatchValue}" for "${plaidTx.name}"`);
         }
         // STEP 2: Try AI categorization if no rule match and AI is available
         else if (openaiClient) {
@@ -306,20 +322,6 @@ class PlaidSync {
             }
         }
 
-        // STEP 3: Check BankRules for account-level assignments (e.g., mark as personal)
-        let isPersonal = false;
-        const bankRuleMatch = await this.checkBankRules(sourceAccountId, plaidTx.name || '', amount);
-        if (bankRuleMatch) {
-            if (bankRuleMatch.AssignIsPersonal) {
-                isPersonal = true;
-            }
-            if (bankRuleMatch.AssignAccountId && !suggestedAccountId) {
-                suggestedAccountId = bankRuleMatch.AssignAccountId;
-                confidenceScore = 100;
-            }
-            console.log(`BankRule match: "${bankRuleMatch.Name}" for "${plaidTx.name}"`);
-        }
-
         return {
             Id: crypto.randomUUID(),
             SourceType: sourceType,
@@ -339,6 +341,11 @@ class PlaidSync {
             SuggestedMemo: suggestedMemo,
             ConfidenceScore: confidenceScore,
             IsPersonal: isPersonal,
+            VendorId: assignedVendorId,
+            CustomerId: assignedCustomerId,
+            ClassId: assignedClassId,
+            ProjectId: assignedProjectId,
+            Payee: assignedPayee,
             Status: 'Pending',
         };
     }
@@ -416,79 +423,24 @@ Respond in JSON format:
     }
 
     /**
-     * Check categorization rules for a transaction
-     * Returns matching rule or null if no match
-     */
-    async checkCategorizationRules(description, merchant) {
-        try {
-            const headers = await getDabHeaders();
-            // Get active rules ordered by priority
-            const response = await axios.get(
-                `${DAB_API_URL}/categorizationrules?$filter=IsActive eq true&$orderby=Priority`,
-                { headers }
-            );
-            const rules = response.data?.value || [];
-
-            for (const rule of rules) {
-                const valueToCheck = rule.MatchField === 'Merchant' ? merchant : description;
-                if (!valueToCheck) continue;
-
-                let matches = false;
-                const lowerValue = valueToCheck.toLowerCase();
-                const lowerMatch = rule.MatchValue.toLowerCase();
-
-                switch (rule.MatchType) {
-                    case 'exact':
-                        matches = lowerValue === lowerMatch;
-                        break;
-                    case 'contains':
-                        matches = lowerValue.includes(lowerMatch);
-                        break;
-                    case 'startswith':
-                        matches = lowerValue.startsWith(lowerMatch);
-                        break;
-                    default:
-                        matches = lowerValue.includes(lowerMatch);
-                }
-
-                if (matches) {
-                    // Increment hit count (fire and forget)
-                    axios.patch(`${DAB_API_URL}/categorizationrules/Id/${rule.Id}`, {
-                        HitCount: (rule.HitCount || 0) + 1
-                    }, { headers }).catch(() => {});
-
-                    return rule;
-                }
-            }
-
-            return null;
-        } catch (error) {
-            // 404 means categorizationrules entity doesn't exist yet - that's OK
-            if (error.response?.status !== 404) {
-                console.warn('Rule check error:', error.message);
-            }
-            return null;
-        }
-    }
-
-    /**
-     * Check BankRules for a transaction
+     * Check unified TransactionRules for a transaction
+     * Replaces separate checkCategorizationRules + checkBankRules
      * Returns first matching rule or null
      */
-    async checkBankRules(sourceAccountId, description, amount) {
+    async checkTransactionRules(sourceAccountId, description, merchant, amount) {
         try {
             // Cache rules for 60 seconds to avoid N+1 queries during sync
             const now = Date.now();
-            if (!this._bankRulesCache || now - this._bankRulesCacheTime > 60000) {
+            if (!this._transactionRulesCache || now - this._transactionRulesCacheTime > 60000) {
                 const headers = await getDabHeaders();
                 const response = await axios.get(
-                    `${DAB_API_URL}/bankrules?$filter=IsEnabled eq true&$orderby=Priority desc`,
+                    `${DAB_API_URL}/transactionrules?$filter=IsEnabled eq true&$orderby=Priority desc`,
                     { headers }
                 );
-                this._bankRulesCache = response.data?.value || [];
-                this._bankRulesCacheTime = now;
+                this._transactionRulesCache = response.data?.value || [];
+                this._transactionRulesCacheTime = now;
             }
-            const rules = this._bankRulesCache;
+            const rules = this._transactionRulesCache;
 
             for (const rule of rules) {
                 // Check BankAccountId scope: null means all accounts, otherwise must match
@@ -496,37 +448,19 @@ Respond in JSON format:
                     continue;
                 }
 
-                // Check MatchField / MatchType / MatchValue
                 let matches = false;
                 const matchField = rule.MatchField || 'Description';
                 const matchType = rule.MatchType || 'Contains';
                 const matchValue = rule.MatchValue || '';
 
-                let descriptionMatches = false;
+                let textMatches = false;
                 let amountMatches = false;
 
-                if (matchField === 'Description' || matchField === 'Both') {
-                    const lowerDesc = (description || '').toLowerCase();
-                    const lowerMatch = matchValue.toLowerCase();
-
-                    switch (matchType) {
-                        case 'Contains':
-                            descriptionMatches = lowerDesc.includes(lowerMatch);
-                            break;
-                        case 'StartsWith':
-                            descriptionMatches = lowerDesc.startsWith(lowerMatch);
-                            break;
-                        case 'Equals':
-                            descriptionMatches = lowerDesc === lowerMatch;
-                            break;
-                        case 'Regex':
-                            try {
-                                descriptionMatches = new RegExp(matchValue, 'i').test(description || '');
-                            } catch {
-                                descriptionMatches = false;
-                            }
-                            break;
-                    }
+                // For Merchant field, check merchant name; for Description, check description
+                if (matchField === 'Merchant') {
+                    textMatches = this._matchText(merchant || '', matchValue, matchType);
+                } else if (matchField === 'Description' || matchField === 'Both') {
+                    textMatches = this._matchText(description || '', matchValue, matchType);
                 }
 
                 if (matchField === 'Amount' || matchField === 'Both') {
@@ -536,12 +470,12 @@ Respond in JSON format:
                     amountMatches = minOk && maxOk;
                 }
 
-                if (matchField === 'Description') {
-                    matches = descriptionMatches;
+                if (matchField === 'Description' || matchField === 'Merchant') {
+                    matches = textMatches;
                 } else if (matchField === 'Amount') {
                     matches = amountMatches;
                 } else if (matchField === 'Both') {
-                    matches = descriptionMatches && amountMatches;
+                    matches = textMatches && amountMatches;
                 }
 
                 // Check TransactionType if specified
@@ -552,6 +486,12 @@ Respond in JSON format:
                 }
 
                 if (matches) {
+                    // Increment hit count (fire and forget)
+                    const headers = await getDabHeaders();
+                    axios.patch(`${DAB_API_URL}/transactionrules/Id/${rule.Id}`, {
+                        HitCount: (rule.HitCount || 0) + 1
+                    }, { headers }).catch(() => {});
+
                     return rule;
                 }
             }
@@ -559,9 +499,38 @@ Respond in JSON format:
             return null;
         } catch (error) {
             if (error.response?.status !== 404) {
-                console.warn('BankRules check error:', error.message);
+                console.warn('TransactionRules check error:', error.message);
             }
             return null;
+        }
+    }
+
+    /**
+     * Match text against a pattern using the given match type
+     */
+    _matchText(text, matchValue, matchType) {
+        if (!text) return false;
+        const lowerText = text.toLowerCase();
+        const lowerMatch = matchValue.toLowerCase();
+
+        switch (matchType) {
+            case 'Contains':
+            case 'contains':
+                return lowerText.includes(lowerMatch);
+            case 'StartsWith':
+            case 'startswith':
+                return lowerText.startsWith(lowerMatch);
+            case 'Equals':
+            case 'exact':
+                return lowerText === lowerMatch;
+            case 'Regex':
+                try {
+                    return new RegExp(matchValue, 'i').test(text);
+                } catch {
+                    return false;
+                }
+            default:
+                return lowerText.includes(lowerMatch);
         }
     }
 

--- a/chat-api/server.js
+++ b/chat-api/server.js
@@ -7515,7 +7515,7 @@ function extractAuthToken(req) {
 app.post('/api/transactions/:id/approve', async (req, res) => {
     try {
         const { id } = req.params;
-        const { accountId, category, memo, autoPost = true } = req.body;
+        const { accountId, category, memo, vendorId, customerId, classId, projectId, payee, isPersonal, autoPost = true } = req.body;
         const authToken = extractAuthToken(req);
 
         if (!accountId) {
@@ -7551,8 +7551,9 @@ app.post('/api/transactions/:id/approve', async (req, res) => {
             return res.status(500).json({ error: updateResult.error || 'Failed to update transaction' });
         }
 
-        // Learn from the correction - create a rule if different from AI suggestion
+        // Learn from the correction - create/update a TransactionRule
         let ruleCreated = false;
+        let ruleUpdated = false;
         if (shouldLearn && transaction.Description) {
             // Extract a pattern from the description (use merchant if available, otherwise first significant word)
             const pattern = transaction.Merchant ||
@@ -7561,29 +7562,47 @@ app.post('/api/transactions/:id/approve', async (req, res) => {
 
             if (pattern) {
                 try {
-                    // Check if rule already exists using dab client
-                    const existingRulesResult = await dab.get('categorizationrules', {
+                    // Check if rule already exists
+                    const existingRulesResult = await dab.get('transactionrules', {
                         filter: `MatchValue eq '${pattern.replace(/'/g, "''")}'`
                     }, authToken);
 
-                    if (existingRulesResult.success && (!existingRulesResult.value || existingRulesResult.value.length === 0)) {
-                        // Create new rule using dab client
-                        const createResult = await dab.create('categorizationrules', {
-                            MatchType: 'contains',
-                            MatchField: 'Description',
-                            MatchValue: pattern,
-                            AccountId: accountId,
-                            Category: category || transaction.SuggestedCategory,
-                            Priority: 50,  // User-learned rules have higher priority
-                            CreatedBy: 'user-feedback'
-                        }, authToken);
+                    const ruleData = {
+                        MatchType: 'Contains',
+                        MatchField: transaction.Merchant ? 'Merchant' : 'Description',
+                        MatchValue: pattern,
+                        AssignAccountId: accountId,
+                        AssignCategory: category || transaction.SuggestedCategory || null,
+                        AssignVendorId: vendorId || null,
+                        AssignCustomerId: customerId || null,
+                        AssignClassId: classId || null,
+                        AssignProjectId: projectId || null,
+                        AssignMemo: memo || null,
+                        AssignPayee: payee || null,
+                        AssignIsPersonal: isPersonal || false,
+                        Priority: 50,
+                        IsEnabled: true,
+                        Source: 'auto-approve',
+                    };
+
+                    const existingRules = existingRulesResult.success ? (existingRulesResult.value || []) : [];
+                    if (existingRules.length > 0) {
+                        // Update existing rule
+                        const existingRule = existingRules[0];
+                        const { MatchType, MatchField, MatchValue, Source, ...updateFields } = ruleData;
+                        await dab.update('transactionrules', existingRule.Id, updateFields, authToken);
+                        ruleUpdated = true;
+                        console.log(`Learning: Updated rule for "${pattern}" -> ${category}`);
+                    } else {
+                        // Create new rule
+                        const createResult = await dab.create('transactionrules', ruleData, authToken);
                         if (createResult.success) {
                             ruleCreated = true;
                             console.log(`Learning: Created rule for "${pattern}" -> ${category}`);
                         }
                     }
                 } catch (ruleError) {
-                    console.warn('Failed to create learning rule:', ruleError.message);
+                    console.warn('Failed to create/update learning rule:', ruleError.message);
                 }
             }
         }
@@ -7597,12 +7616,12 @@ app.post('/api/transactions/:id/approve', async (req, res) => {
             req,
             source: 'API',
         });
-        if (ruleCreated) {
+        if (ruleCreated || ruleUpdated) {
             logAuditEvent({
-                action: 'Create',
-                entityType: 'CategorizationRule',
-                entityDescription: `Auto-created rule from transaction approval`,
-                newValues: { MatchValue: transaction.Merchant || transaction.Description?.substring(0, 50), AccountId: accountId },
+                action: ruleCreated ? 'Create' : 'Update',
+                entityType: 'TransactionRule',
+                entityDescription: `Auto-${ruleCreated ? 'created' : 'updated'} rule from transaction approval`,
+                newValues: { MatchValue: transaction.Merchant || transaction.Description?.substring(0, 50), AssignAccountId: accountId },
                 req,
                 source: 'API',
             });
@@ -7689,15 +7708,18 @@ app.post('/api/transactions/:id/approve', async (req, res) => {
             }
         }
 
+        const learned = ruleCreated || ruleUpdated;
         res.json({
             success: true,
             transactionId: id,
-            learned: ruleCreated,
+            learned,
+            ruleCreated,
+            ruleUpdated,
             posted,
             journalEntryId,
             message: posted
-                ? (ruleCreated ? 'Transaction approved, posted to GL, and rule learned' : 'Transaction approved and posted to GL')
-                : (ruleCreated ? 'Transaction approved and rule learned' : 'Transaction approved')
+                ? (learned ? 'Transaction approved, posted to GL, and rule learned' : 'Transaction approved and posted to GL')
+                : (learned ? 'Transaction approved and rule learned' : 'Transaction approved')
         });
     } catch (error) {
         console.error('Transaction approval error:', error.message);
@@ -8334,12 +8356,86 @@ app.post('/api/banktransactions/:id/recategorize', async (req, res) => {
         });
 
         console.log(`[Recategorize] Transaction ${id.substring(0, 8)}: ${oldAccName} -> ${newAccName}`);
+
+        // Create or update a TransactionRule so future transactions are categorized correctly
+        let ruleCreated = false;
+        let ruleUpdated = false;
+        let ruleConflict = false;
+        let existingRuleInfo = null;
+        try {
+            const pattern = txn.Merchant ||
+                (txn.Description || '').split(' ').filter(w => w.length > 3)[0] ||
+                (txn.Description || '').substring(0, 50);
+
+            if (pattern) {
+                const escapedPattern = pattern.replace(/'/g, "''");
+                const existingRulesResult = await dab.get('transactionrules', {
+                    filter: `MatchValue eq '${escapedPattern}'`
+                }, authToken);
+                const existingRules = existingRulesResult.success ? (existingRulesResult.value || []) : [];
+
+                const ruleData = {
+                    MatchType: 'Contains',
+                    MatchField: txn.Merchant ? 'Merchant' : 'Description',
+                    MatchValue: pattern,
+                    AssignAccountId: accountId,
+                    AssignCategory: newCategoryName || null,
+                    AssignVendorId: vendorId || null,
+                    AssignCustomerId: customerId || null,
+                    AssignClassId: classId || null,
+                    AssignProjectId: projectId || null,
+                    AssignMemo: memo || null,
+                    AssignPayee: payee || null,
+                    AssignIsPersonal: isPersonal || false,
+                    Priority: 50,
+                    IsEnabled: true,
+                    Source: 'auto-recategorize',
+                };
+
+                if (existingRules.length > 0) {
+                    const existingRule = existingRules[0];
+                    const existingAccountDiffers = existingRule.AssignAccountId &&
+                        existingRule.AssignAccountId.toLowerCase() !== accountId.toLowerCase();
+
+                    if (existingAccountDiffers && req.query.updateRule !== 'true') {
+                        // Conflict — return info so frontend can ask user
+                        ruleConflict = true;
+                        existingRuleInfo = {
+                            ruleId: existingRule.Id,
+                            matchValue: existingRule.MatchValue,
+                            existingAccountId: existingRule.AssignAccountId,
+                            existingCategory: existingRule.AssignCategory || null,
+                        };
+                    } else {
+                        // Update existing rule (same account, or user confirmed update)
+                        const { MatchType, MatchField, MatchValue, Source, ...updateFields } = ruleData;
+                        await dab.update('transactionrules', existingRule.Id, updateFields, authToken);
+                        ruleUpdated = true;
+                        console.log(`[Recategorize] Updated rule for "${pattern}" -> ${newAccName}`);
+                    }
+                } else {
+                    // No existing rule — create automatically
+                    const createResult = await dab.create('transactionrules', ruleData, authToken);
+                    if (createResult.success) {
+                        ruleCreated = true;
+                        console.log(`[Recategorize] Created rule for "${pattern}" -> ${newAccName}`);
+                    }
+                }
+            }
+        } catch (ruleError) {
+            console.warn('[Recategorize] Failed to create/update rule:', ruleError.message);
+        }
+
         res.json({
             success: true,
             recategorized: true,
             oldAccount: oldAccName,
             newAccount: newAccName,
             journalEntryId: txn.JournalEntryId,
+            ruleCreated,
+            ruleUpdated,
+            ruleConflict,
+            existingRule: existingRuleInfo,
         });
     } catch (error) {
         console.error('Recategorize error:', error.message);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -130,7 +130,7 @@ import TaxForms from './pages/TaxForms';
 import W2Forms from './pages/W2Forms';
 import Form1099NEC from './pages/Form1099NEC';
 import BankImportHistory from './pages/BankImportHistory';
-import BankRules from './pages/BankRules';
+import TransactionRules from './pages/TransactionRules';
 import VendorHierarchy from './pages/VendorHierarchy';
 import CustomerHierarchy from './pages/CustomerHierarchy';
 import CreditMemos from './pages/CreditMemos';
@@ -308,7 +308,8 @@ function AppContent() {
             <Route path="bank-import" element={<Navigate to="/import?tab=bank-import" replace />} />
             <Route path="bank-import/matches" element={<Navigate to="/import?tab=review-matches" replace />} />
             <Route path="bank-import/history" element={<BankImportHistory />} />
-            <Route path="bank-rules" element={<BankRules />} />
+            <Route path="transaction-rules" element={<TransactionRules />} />
+            <Route path="bank-rules" element={<TransactionRules />} />
             <Route path="email-reminders" element={<EmailReminders />} />
             <Route path="admin/audit-log" element={<AuditLog />} />
             <Route path="accounting-periods" element={<AccountingPeriods />} />

--- a/client/src/components/navigation/navConfig.ts
+++ b/client/src/components/navigation/navConfig.ts
@@ -126,7 +126,7 @@ export const navigationConfig: NavEntry[] = [
     items: [
       { id: 'banking', name: 'Bank Connections', href: '/plaid-connections', icon: Building2 },
       { id: 'import', name: 'Import', href: '/import', icon: Upload },
-      { id: 'bank-rules', name: 'Bank Rules', href: '/bank-rules', icon: ListFilter },
+      { id: 'transaction-rules', name: 'Transaction Rules', href: '/transaction-rules', icon: ListFilter },
     ],
   },
 

--- a/client/src/pages/TransactionRules.tsx
+++ b/client/src/pages/TransactionRules.tsx
@@ -5,24 +5,29 @@ import api from '../lib/api';
 import { formatCurrencyStandalone } from '../contexts/CurrencyContext';
 import { useToast } from '../hooks/useToast';
 
-interface BankRule {
+interface TransactionRule {
   Id: string;
   Name: string;
   BankAccountId: string | null;
-  MatchField: 'Description' | 'Amount' | 'Both';
+  MatchField: 'Description' | 'Merchant' | 'Amount' | 'Both';
   MatchType: 'Contains' | 'StartsWith' | 'Equals' | 'Regex';
   MatchValue: string;
   MinAmount: number | null;
   MaxAmount: number | null;
   TransactionType: 'Debit' | 'Credit' | null;
   AssignAccountId: string | null;
+  AssignCategory: string | null;
   AssignVendorId: string | null;
   AssignCustomerId: string | null;
   AssignClassId: string | null;
+  AssignProjectId: string | null;
   AssignMemo: string | null;
+  AssignPayee: string | null;
   AssignIsPersonal: boolean;
   Priority: number;
   IsEnabled: boolean;
+  HitCount: number;
+  Source: string;
   CreatedAt: string;
   UpdatedAt: string;
 }
@@ -49,20 +54,23 @@ interface ClassItem {
   Name: string;
 }
 
-interface BankRuleInput {
+interface TransactionRuleInput {
   Name: string;
   BankAccountId?: string | null;
-  MatchField: 'Description' | 'Amount' | 'Both';
+  MatchField: 'Description' | 'Merchant' | 'Amount' | 'Both';
   MatchType: 'Contains' | 'StartsWith' | 'Equals' | 'Regex';
   MatchValue: string;
   MinAmount?: number | null;
   MaxAmount?: number | null;
   TransactionType?: 'Debit' | 'Credit' | null;
   AssignAccountId?: string | null;
+  AssignCategory?: string | null;
   AssignVendorId?: string | null;
   AssignCustomerId?: string | null;
   AssignClassId?: string | null;
+  AssignProjectId?: string | null;
   AssignMemo?: string | null;
+  AssignPayee?: string | null;
   AssignIsPersonal?: boolean;
   Priority?: number;
   IsEnabled?: boolean;
@@ -86,14 +94,14 @@ interface ValidationErrors {
 const NAME_MAX_LENGTH = 100;
 const MATCH_VALUE_MAX_LENGTH = 255;
 
-export default function BankRules() {
+export default function TransactionRules() {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [showForm, setShowForm] = useState(false);
   const [showTestDialog, setShowTestDialog] = useState(false);
   const [testResults, setTestResults] = useState<BankTransaction[]>([]);
-  const [editingRule, setEditingRule] = useState<BankRule | null>(null);
-  const [formData, setFormData] = useState<BankRuleInput>({
+  const [editingRule, setEditingRule] = useState<TransactionRule | null>(null);
+  const [formData, setFormData] = useState<TransactionRuleInput>({
     Name: '',
     BankAccountId: null,
     MatchField: 'Description',
@@ -116,15 +124,15 @@ export default function BankRules() {
 
   const queryClient = useQueryClient();
 
-  // Fetch bank rules
+  // Fetch transaction rules
   const {
     data: bankRules,
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['bankrules'],
+    queryKey: ['transactionrules'],
     queryFn: async () => {
-      const response = await api.get<{ value: BankRule[] }>('/bankrules?$orderby=Priority desc,Name');
+      const response = await api.get<{ value: TransactionRule[] }>('/transactionrules?$orderby=Priority desc,Name');
       return response.data.value;
     },
   });
@@ -178,48 +186,48 @@ export default function BankRules() {
   });
 
   const createMutation = useMutation({
-    mutationFn: async (data: BankRuleInput) => {
-      const response = await api.post('/bankrules', data);
+    mutationFn: async (data: TransactionRuleInput) => {
+      const response = await api.post('/transactionrules', data);
       return response.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bankrules'] });
-      showToast('Bank rule created successfully', 'success');
+      queryClient.invalidateQueries({ queryKey: ['transactionrules'] });
+      showToast('Transaction rule created successfully', 'success');
       resetForm();
     },
     onError: (error) => {
-      console.error('Failed to create bank rule:', error);
-      showToast('Failed to create bank rule', 'error');
+      console.error('Failed to create transaction rule:', error);
+      showToast('Failed to create transaction rule', 'error');
     },
   });
 
   const updateMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: Partial<BankRuleInput> }) => {
-      const response = await api.patch(`/bankrules/Id/${id}`, data);
+    mutationFn: async ({ id, data }: { id: string; data: Partial<TransactionRuleInput> }) => {
+      const response = await api.patch(`/transactionrules/Id/${id}`, data);
       return response.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bankrules'] });
-      showToast('Bank rule updated successfully', 'success');
+      queryClient.invalidateQueries({ queryKey: ['transactionrules'] });
+      showToast('Transaction rule updated successfully', 'success');
       resetForm();
     },
     onError: (error) => {
-      console.error('Failed to update bank rule:', error);
-      showToast('Failed to update bank rule', 'error');
+      console.error('Failed to update transaction rule:', error);
+      showToast('Failed to update transaction rule', 'error');
     },
   });
 
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => {
-      await api.delete(`/bankrules/Id/${id}`);
+      await api.delete(`/transactionrules/Id/${id}`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['bankrules'] });
-      showToast('Bank rule deleted successfully', 'success');
+      queryClient.invalidateQueries({ queryKey: ['transactionrules'] });
+      showToast('Transaction rule deleted successfully', 'success');
     },
     onError: (error) => {
-      console.error('Failed to delete bank rule:', error);
-      showToast('Failed to delete bank rule', 'error');
+      console.error('Failed to delete transaction rule:', error);
+      showToast('Failed to delete transaction rule', 'error');
     },
   });
 
@@ -276,7 +284,7 @@ export default function BankRules() {
     }
 
     // Check amount range for Amount/Both match fields
-    if (formData.MatchField !== 'Description') {
+    if (formData.MatchField === 'Amount' || formData.MatchField === 'Both') {
       const minAmt = formData.MinAmount ?? null;
       const maxAmt = formData.MaxAmount ?? null;
       if (minAmt === null && maxAmt === null) {
@@ -302,7 +310,7 @@ export default function BankRules() {
       return;
     }
 
-    const submitData: BankRuleInput = {
+    const submitData: TransactionRuleInput = {
       ...formData,
       Name: formData.Name.trim(),
       MatchValue: formData.MatchValue.trim(),
@@ -316,7 +324,7 @@ export default function BankRules() {
     }
   };
 
-  const handleEdit = (rule: BankRule) => {
+  const handleEdit = (rule: TransactionRule) => {
     setEditingRule(rule);
     setFormData({
       Name: rule.Name,
@@ -346,10 +354,10 @@ export default function BankRules() {
     }
   };
 
-  const handleToggleEnabled = async (rule: BankRule) => {
+  const handleToggleEnabled = async (rule: TransactionRule) => {
     try {
-      await api.patch(`/bankrules/Id/${rule.Id}`, { IsEnabled: !rule.IsEnabled });
-      queryClient.invalidateQueries({ queryKey: ['bankrules'] });
+      await api.patch(`/transactionrules/Id/${rule.Id}`, { IsEnabled: !rule.IsEnabled });
+      queryClient.invalidateQueries({ queryKey: ['transactionrules'] });
       showToast(`Rule ${rule.IsEnabled ? 'disabled' : 'enabled'} successfully`, 'success');
     } catch (error) {
       console.error('Failed to toggle rule:', error);
@@ -472,7 +480,7 @@ export default function BankRules() {
     <div className="max-w-7xl mx-auto">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Bank Rules</h1>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Transaction Rules</h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Automatically categorize imported bank transactions based on configurable rules
           </p>
@@ -572,12 +580,13 @@ export default function BankRules() {
                   <select
                     id="matchField"
                     value={formData.MatchField}
-                    onChange={(e) => setFormData({ ...formData, MatchField: e.target.value as 'Description' | 'Amount' | 'Both' })}
+                    onChange={(e) => setFormData({ ...formData, MatchField: e.target.value as 'Description' | 'Merchant' | 'Amount' | 'Both' })}
                     className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm border p-2 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
                   >
                     <option value="Description">Description</option>
+                    <option value="Merchant">Merchant</option>
                     <option value="Amount">Amount</option>
-                    <option value="Both">Both</option>
+                    <option value="Both">Both (Description + Amount)</option>
                   </select>
                 </div>
                 <div>
@@ -961,6 +970,9 @@ export default function BankRules() {
                 Assigns To
               </th>
               <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                Source
+              </th>
+              <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                 Status
               </th>
               <th scope="col" className="relative px-4 py-3">
@@ -971,8 +983,8 @@ export default function BankRules() {
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {filteredRules?.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
-                  No bank rules found. Create your first rule to automatically categorize transactions.
+                <td colSpan={7} className="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
+                  No transaction rules found. Create your first rule to automatically categorize transactions.
                 </td>
               </tr>
             ) : (
@@ -991,9 +1003,9 @@ export default function BankRules() {
                   </td>
                   <td className="px-4 py-4 text-sm text-gray-900 dark:text-gray-100">
                     <div className="flex flex-col gap-1">
-                      {(rule.MatchField === 'Description' || rule.MatchField === 'Both') && (
+                      {(rule.MatchField === 'Description' || rule.MatchField === 'Merchant' || rule.MatchField === 'Both') && (
                         <span className="inline-flex items-center px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded">
-                          {rule.MatchType}: "{rule.MatchValue}"
+                          {rule.MatchField === 'Merchant' ? 'Merchant ' : ''}{rule.MatchType}: "{rule.MatchValue}"
                         </span>
                       )}
                       {(rule.MatchField === 'Amount' || rule.MatchField === 'Both') && (
@@ -1033,6 +1045,18 @@ export default function BankRules() {
                         <span title="Memo" className="text-xs italic truncate max-w-xs">Memo: {rule.AssignMemo}</span>
                       )}
                     </div>
+                  </td>
+                  <td className="px-4 py-4 whitespace-nowrap">
+                    <span className={`inline-flex px-2 py-0.5 text-xs rounded ${
+                      rule.Source === 'manual' ? 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300' :
+                      rule.Source === 'auto-approve' ? 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200' :
+                      rule.Source === 'auto-recategorize' ? 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200' :
+                      'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                    }`}>
+                      {rule.Source === 'auto-approve' ? 'Approve' :
+                       rule.Source === 'auto-recategorize' ? 'Recategorize' :
+                       rule.Source || 'Manual'}
+                    </span>
                   </td>
                   <td className="px-4 py-4 whitespace-nowrap">
                     <span
@@ -1086,7 +1110,7 @@ export default function BankRules() {
 
       <div className="mt-4 text-sm text-gray-500 dark:text-gray-400">
         <p>
-          Bank rules are applied automatically when transactions are imported. Rules are processed in priority order (highest first).
+          Transaction rules are applied automatically when transactions are imported. Rules are also created when you approve or recategorize transactions. Rules are processed in priority order (highest first).
           The first matching rule wins.
         </p>
       </div>

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -74,6 +74,13 @@ export default function UnifiedTransactions() {
   });
   const [showPostConfirm, setShowPostConfirm] = useState(false);
   const [matchingTransaction, setMatchingTransaction] = useState<BankTransaction | null>(null);
+  const [ruleConflict, setRuleConflict] = useState<{
+    transactionId: string;
+    data: TransactionEditFormData;
+    matchValue: string;
+    existingCategory: string | null;
+    newCategory: string | null;
+  } | null>(null);
 
   // Fetch transactions
   const { data: transactionsData, isLoading: transactionsLoading } = useQuery({
@@ -229,8 +236,11 @@ export default function UnifiedTransactions() {
 
   // Recategorize posted transaction mutation
   const recategorizeMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: TransactionEditFormData }) => {
-      const response = await api.post(`/banktransactions/${id}/recategorize`, {
+    mutationFn: async ({ id, data, updateRule }: { id: string; data: TransactionEditFormData; updateRule?: boolean }) => {
+      const url = updateRule
+        ? `/banktransactions/${id}/recategorize?updateRule=true`
+        : `/banktransactions/${id}/recategorize`;
+      const response = await api.post(url, {
         accountId: data.accountId || null,
         memo: data.memo || null,
         vendorId: data.vendorId || null,
@@ -242,12 +252,32 @@ export default function UnifiedTransactions() {
       });
       return response.data;
     },
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['transactionrules'] });
+
+      if (data.ruleConflict && data.existingRule) {
+        // Show confirmation dialog for rule conflict
+        const newAccountName = data.newAccount || 'new account';
+        setRuleConflict({
+          transactionId: variables.id,
+          data: variables.data,
+          matchValue: data.existingRule.matchValue,
+          existingCategory: data.existingRule.existingCategory,
+          newCategory: newAccountName,
+        });
+        // Still show success for the recategorization itself
+        if (data.recategorized) {
+          toast.success(`Recategorized: ${data.oldAccount} → ${data.newAccount}`);
+        }
+        return;
+      }
+
       setDrawerTransaction(null);
       setSelectedIds({ type: 'include', ids: new Set() });
       if (data.recategorized) {
-        toast.success(`Recategorized: ${data.oldAccount} → ${data.newAccount}`);
+        const ruleMsg = data.ruleCreated ? ' (rule created)' : data.ruleUpdated ? ' (rule updated)' : '';
+        toast.success(`Recategorized: ${data.oldAccount} → ${data.newAccount}${ruleMsg}`);
       } else {
         toast.success('Transaction updated');
       }
@@ -845,6 +875,35 @@ export default function UnifiedTransactions() {
         confirmText="Post Transactions"
         cancelText="Cancel"
         isLoading={postMutation.isPending}
+        variant="default"
+      />
+
+      {/* Rule Conflict Confirmation */}
+      <ConfirmModal
+        isOpen={!!ruleConflict}
+        onClose={() => {
+          setRuleConflict(null);
+          setDrawerTransaction(null);
+          setSelectedIds({ type: 'include', ids: new Set() });
+        }}
+        onConfirm={() => {
+          if (ruleConflict) {
+            recategorizeMutation.mutate({
+              id: ruleConflict.transactionId,
+              data: ruleConflict.data,
+              updateRule: true,
+            });
+            setRuleConflict(null);
+            setDrawerTransaction(null);
+            setSelectedIds({ type: 'include', ids: new Set() });
+          }
+        }}
+        title="Update Transaction Rule?"
+        message={ruleConflict
+          ? `An existing rule categorizes "${ruleConflict.matchValue}" as "${ruleConflict.existingCategory || 'unknown'}". Update it to "${ruleConflict.newCategory || 'new account'}"?`
+          : ''}
+        confirmText="Update Rule"
+        cancelText="Keep Existing Rule"
         variant="default"
       />
 

--- a/dab-config.json
+++ b/dab-config.json
@@ -142,6 +142,71 @@
                 "enabled": false
             }
         },
+        "transactionrules": {
+            "source": "dbo.TransactionRules",
+            "permissions": [
+                {
+                    "role": "authenticated",
+                    "actions": [
+                        "read"
+                    ]
+                },
+                {
+                    "role": "Admin",
+                    "actions": [
+                        "*"
+                    ]
+                },
+                {
+                    "role": "Accountant",
+                    "actions": [
+                        "create",
+                        "read",
+                        "update"
+                    ]
+                },
+                {
+                    "role": "Service",
+                    "actions": [
+                        "create",
+                        "read",
+                        "update"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "Name": "Name",
+                "BankAccountId": "BankAccountId",
+                "MatchField": "MatchField",
+                "MatchType": "MatchType",
+                "MatchValue": "MatchValue",
+                "MinAmount": "MinAmount",
+                "MaxAmount": "MaxAmount",
+                "TransactionType": "TransactionType",
+                "AssignAccountId": "AssignAccountId",
+                "AssignCategory": "AssignCategory",
+                "AssignVendorId": "AssignVendorId",
+                "AssignCustomerId": "AssignCustomerId",
+                "AssignClassId": "AssignClassId",
+                "AssignProjectId": "AssignProjectId",
+                "AssignMemo": "AssignMemo",
+                "AssignPayee": "AssignPayee",
+                "AssignIsPersonal": "AssignIsPersonal",
+                "Priority": "Priority",
+                "IsEnabled": "IsEnabled",
+                "HitCount": "HitCount",
+                "Source": "Source",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            },
+            "key-fields": [
+                "Id"
+            ],
+            "cache": {
+                "enabled": false
+            }
+        },
         "banktransactions": {
             "source": "dbo.BankTransactions",
             "permissions": [

--- a/dab-config.production.json
+++ b/dab-config.production.json
@@ -139,6 +139,71 @@
                 "enabled": false
             }
         },
+        "transactionrules": {
+            "source": "dbo.TransactionRules",
+            "permissions": [
+                {
+                    "role": "authenticated",
+                    "actions": [
+                        "read"
+                    ]
+                },
+                {
+                    "role": "Admin",
+                    "actions": [
+                        "*"
+                    ]
+                },
+                {
+                    "role": "Accountant",
+                    "actions": [
+                        "create",
+                        "read",
+                        "update"
+                    ]
+                },
+                {
+                    "role": "Service",
+                    "actions": [
+                        "create",
+                        "read",
+                        "update"
+                    ]
+                }
+            ],
+            "mappings": {
+                "Id": "Id",
+                "Name": "Name",
+                "BankAccountId": "BankAccountId",
+                "MatchField": "MatchField",
+                "MatchType": "MatchType",
+                "MatchValue": "MatchValue",
+                "MinAmount": "MinAmount",
+                "MaxAmount": "MaxAmount",
+                "TransactionType": "TransactionType",
+                "AssignAccountId": "AssignAccountId",
+                "AssignCategory": "AssignCategory",
+                "AssignVendorId": "AssignVendorId",
+                "AssignCustomerId": "AssignCustomerId",
+                "AssignClassId": "AssignClassId",
+                "AssignProjectId": "AssignProjectId",
+                "AssignMemo": "AssignMemo",
+                "AssignPayee": "AssignPayee",
+                "AssignIsPersonal": "AssignIsPersonal",
+                "Priority": "Priority",
+                "IsEnabled": "IsEnabled",
+                "HitCount": "HitCount",
+                "Source": "Source",
+                "CreatedAt": "CreatedAt",
+                "UpdatedAt": "UpdatedAt"
+            },
+            "key-fields": [
+                "Id"
+            ],
+            "cache": {
+                "enabled": false
+            }
+        },
         "banktransactions": {
             "source": "dbo.BankTransactions",
             "permissions": [

--- a/database/dbo/Tables/TransactionRules.sql
+++ b/database/dbo/Tables/TransactionRules.sql
@@ -1,0 +1,72 @@
+CREATE TABLE [dbo].[TransactionRules]
+(
+    [Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [Name] NVARCHAR(100) NULL,              -- optional, for user-created rules
+    [BankAccountId] UNIQUEIDENTIFIER NULL,   -- NULL = all accounts
+
+    -- Matching
+    [MatchField] NVARCHAR(50) NOT NULL,      -- 'Description', 'Merchant', 'Amount', 'Both'
+    [MatchType] NVARCHAR(50) NOT NULL,       -- 'Contains', 'StartsWith', 'Equals', 'Regex'
+    [MatchValue] NVARCHAR(255) NOT NULL,
+    [MinAmount] DECIMAL(19,4) NULL,
+    [MaxAmount] DECIMAL(19,4) NULL,
+    [TransactionType] NVARCHAR(20) NULL,     -- 'Debit', 'Credit', NULL=both
+
+    -- Assignments
+    [AssignAccountId] UNIQUEIDENTIFIER NULL,
+    [AssignCategory] NVARCHAR(200) NULL,     -- display name
+    [AssignVendorId] UNIQUEIDENTIFIER NULL,
+    [AssignCustomerId] UNIQUEIDENTIFIER NULL,
+    [AssignClassId] UNIQUEIDENTIFIER NULL,
+    [AssignProjectId] UNIQUEIDENTIFIER NULL,
+    [AssignMemo] NVARCHAR(500) NULL,
+    [AssignPayee] NVARCHAR(200) NULL,
+    [AssignIsPersonal] BIT NOT NULL DEFAULT 0,
+
+    -- Metadata
+    [Priority] INT NOT NULL DEFAULT 0,
+    [IsEnabled] BIT NOT NULL DEFAULT 1,
+    [HitCount] INT NOT NULL DEFAULT 0,
+    [Source] NVARCHAR(50) NOT NULL DEFAULT 'manual', -- 'manual', 'auto-approve', 'auto-recategorize'
+    [CreatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+    [UpdatedAt] DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
+
+    -- Temporal table columns (system-versioned)
+    [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+    [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+    PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]),
+
+    -- Foreign keys
+    CONSTRAINT [FK_TransactionRules_BankAccount] FOREIGN KEY ([BankAccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_TransactionRules_AssignAccount] FOREIGN KEY ([AssignAccountId]) REFERENCES [dbo].[Accounts]([Id]),
+    CONSTRAINT [FK_TransactionRules_AssignVendor] FOREIGN KEY ([AssignVendorId]) REFERENCES [dbo].[Vendors]([Id]),
+    CONSTRAINT [FK_TransactionRules_AssignCustomer] FOREIGN KEY ([AssignCustomerId]) REFERENCES [dbo].[Customers]([Id]),
+    CONSTRAINT [FK_TransactionRules_AssignClass] FOREIGN KEY ([AssignClassId]) REFERENCES [dbo].[Classes]([Id]),
+    CONSTRAINT [FK_TransactionRules_AssignProject] FOREIGN KEY ([AssignProjectId]) REFERENCES [dbo].[Projects]([Id]),
+
+    CONSTRAINT [CK_TransactionRules_MatchField] CHECK ([MatchField] IN ('Description', 'Merchant', 'Amount', 'Both')),
+    CONSTRAINT [CK_TransactionRules_MatchType] CHECK ([MatchType] IN ('Contains', 'StartsWith', 'Equals', 'Regex')),
+    CONSTRAINT [CK_TransactionRules_TransactionType] CHECK ([TransactionType] IS NULL OR [TransactionType] IN ('Debit', 'Credit'))
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[TransactionRules_History]))
+GO
+
+-- Enable change tracking
+ALTER TABLE [dbo].[TransactionRules] ENABLE CHANGE_TRACKING
+GO
+
+-- Create indexes for common queries
+CREATE INDEX [IX_TransactionRules_MatchValue] ON [dbo].[TransactionRules] ([MatchValue])
+GO
+
+CREATE INDEX [IX_TransactionRules_Priority] ON [dbo].[TransactionRules] ([Priority] DESC)
+GO
+
+CREATE INDEX [IX_TransactionRules_IsEnabled] ON [dbo].[TransactionRules] ([IsEnabled])
+GO
+
+CREATE INDEX [IX_TransactionRules_BankAccountId] ON [dbo].[TransactionRules] ([BankAccountId])
+GO
+
+CREATE INDEX [IX_TransactionRules_Source] ON [dbo].[TransactionRules] ([Source])
+GO

--- a/database/dbo/Triggers/TR_TransactionRules_UpdatedAt.sql
+++ b/database/dbo/Triggers/TR_TransactionRules_UpdatedAt.sql
@@ -1,0 +1,12 @@
+CREATE TRIGGER [dbo].[TR_TransactionRules_UpdatedAt] ON [dbo].[TransactionRules]
+AFTER UPDATE AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE t
+    SET UpdatedAt = SYSUTCDATETIME()
+    FROM [dbo].[TransactionRules] t
+    INNER JOIN inserted i ON t.Id = i.Id
+    INNER JOIN deleted d ON i.Id = d.Id
+    WHERE i.UpdatedAt = d.UpdatedAt;
+END
+GO

--- a/database/migrations/049_MigrateToTransactionRules.sql
+++ b/database/migrations/049_MigrateToTransactionRules.sql
@@ -1,0 +1,36 @@
+-- Migration: Copy existing BankRules data into TransactionRules (data-only)
+-- The TransactionRules table is created by the sqlproj schema file
+
+IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'TransactionRules')
+   AND EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'BankRules')
+BEGIN
+    -- Only migrate if TransactionRules is empty (idempotent)
+    IF NOT EXISTS (SELECT 1 FROM [dbo].[TransactionRules])
+    BEGIN
+        INSERT INTO [dbo].[TransactionRules] (
+            [Id], [Name], [BankAccountId],
+            [MatchField], [MatchType], [MatchValue],
+            [MinAmount], [MaxAmount], [TransactionType],
+            [AssignAccountId], [AssignVendorId], [AssignCustomerId],
+            [AssignClassId], [AssignMemo], [AssignIsPersonal],
+            [Priority], [IsEnabled], [Source],
+            [CreatedAt], [UpdatedAt]
+        )
+        SELECT
+            [Id], [Name], [BankAccountId],
+            [MatchField], [MatchType], [MatchValue],
+            [MinAmount], [MaxAmount], [TransactionType],
+            [AssignAccountId], [AssignVendorId], [AssignCustomerId],
+            [AssignClassId], [AssignMemo], [AssignIsPersonal],
+            [Priority], [IsEnabled], 'manual',
+            [CreatedAt], [UpdatedAt]
+        FROM [dbo].[BankRules];
+
+        PRINT 'Migrated ' + CAST(@@ROWCOUNT AS VARCHAR) + ' rules from BankRules to TransactionRules';
+    END
+    ELSE
+    BEGIN
+        PRINT 'TransactionRules already has data, skipping migration';
+    END
+END
+GO


### PR DESCRIPTION
## Summary
- **Unified TransactionRules table** replacing separate BankRules + (never-created) CategorizationRules, with data migration from BankRules
- **Approve endpoint** now stores all Assign* fields (VendorId, ClassId, ProjectId, Memo, Payee, IsPersonal) in TransactionRules and updates existing rules instead of skipping
- **Recategorize endpoint** automatically creates/updates rules with conflict detection — returns `ruleConflict` when an existing rule maps to a different account
- **plaid-sync** uses single `checkTransactionRules()` replacing two separate checks, applying all assignment fields from matched rules
- **Frontend** renamed Bank Rules → Transaction Rules with Source column, added rule conflict confirmation dialog on recategorize

Closes #565

## Test plan
- [ ] Deploy DB: `node scripts/deploy-db.js` — verify TransactionRules table created and BankRules data migrated
- [ ] Approve a pending transaction with a different account than suggested → verify rule created in TransactionRules with Source='auto-approve'
- [ ] Recategorize a posted transaction (no existing rule) → verify rule auto-created with Source='auto-recategorize'
- [ ] Recategorize same merchant to a different account → confirmation dialog appears asking to update the rule
- [ ] Confirm update → rule updated; Cancel → rule unchanged
- [ ] Visit /transaction-rules → page loads with Source column showing rule origins
- [ ] Old /bank-rules URL still works (redirects to TransactionRules component)
- [ ] Run Plaid sync → verify unified rule check works and applies all Assign* fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)