### PR TITLE
fix: OData date filters for Milton invoice/bill queries

### DIFF
--- a/chat-api/server.js
+++ b/chat-api/server.js
@@ -2675,8 +2675,8 @@ async function executeQueryInvoices(params) {
                 filters.push(`Status eq '${params.status}'`);
             }
         }
-        if (params.date_from) filters.push(`IssueDate ge ${params.date_from}`);
-        if (params.date_to) filters.push(`IssueDate le ${params.date_to}`);
+        if (params.date_from) filters.push(`IssueDate ge ${params.date_from}T00:00:00Z`);
+        if (params.date_to) filters.push(`IssueDate le ${params.date_to}T23:59:59Z`);
         if (params.min_amount) filters.push(`TotalAmount ge ${params.min_amount}`);
         if (params.max_amount) filters.push(`TotalAmount le ${params.max_amount}`);
         if (params.customer_name) {
@@ -2806,8 +2806,8 @@ async function executeQueryBills(params) {
                 filters.push(`Status eq '${params.status}'`);
             }
         }
-        if (params.date_from) filters.push(`BillDate ge ${params.date_from}`);
-        if (params.date_to) filters.push(`BillDate le ${params.date_to}`);
+        if (params.date_from) filters.push(`BillDate ge ${params.date_from}T00:00:00Z`);
+        if (params.date_to) filters.push(`BillDate le ${params.date_to}T23:59:59Z`);
         if (params.vendor_name) {
             filters.push(`contains(VendorName, '${params.vendor_name}')`);
         }


### PR DESCRIPTION
## Summary
- DAB exposes SQL `DATE` columns as `Edm.DateTimeOffset`, so bare `YYYY-MM-DD` values in OData `$filter` cause 500 errors
- `query_invoices` and `query_bills` now append `T00:00:00Z` / `T23:59:59Z` to `date_from` / `date_to` parameters
- Fixes Milton failing with "issue retrieving invoice data" on date-range questions like "what invoices for this month?"

## Test plan
- [ ] Ask Milton "what invoices for this month?" — should return March invoices instead of an error
- [ ] Ask Milton "show bills from last month" — should return February bills
- [ ] Verify `get_financial_summary` still works (already used ISO format, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)