### PR TITLE
fix: Batch fixes for #573, #574, #575, #577

### DIFF
--- a/chat-api/server.js
+++ b/chat-api/server.js
@@ -2009,7 +2009,7 @@ const tools = [
         type: 'function',
         function: {
             name: 'mark_transactions_personal',
-            description: 'Mark all bank transactions for a specific account/card as personal. Uses preview/confirm pattern. Can also create a BankRule to auto-mark future imports.',
+            description: 'Mark all bank transactions for a specific account/card as personal. Uses preview/confirm pattern. Can also create a TransactionRule to auto-mark future imports.',
             parameters: {
                 type: 'object',
                 properties: {
@@ -2028,7 +2028,7 @@ const tools = [
                     },
                     create_rule: {
                         type: 'boolean',
-                        description: 'If true (default), creates a BankRule to auto-mark future imports from this account as personal.',
+                        description: 'If true (default), creates a TransactionRule to auto-mark future imports from this account as personal.',
                         default: true
                     }
                 },
@@ -4858,11 +4858,11 @@ async function executeMarkTransactionsPersonal(params, authToken = null) {
             }
         }
 
-        // Create BankRule if requested
+        // Create TransactionRule if requested
         let ruleCreated = false;
         if (createRule && markedCount > 0) {
             const ruleName = `Personal — ${account.Name}`;
-            const ruleResult = await dab.create('bankrules', {
+            const ruleResult = await dab.create('transactionrules', {
                 Name: ruleName,
                 BankAccountId: account.Id,
                 MatchField: 'Description',
@@ -4871,10 +4871,11 @@ async function executeMarkTransactionsPersonal(params, authToken = null) {
                 AssignIsPersonal: true,
                 Priority: 100,
                 IsEnabled: true,
+                Source: 'manual',
             }, authToken);
             ruleCreated = ruleResult.success;
             if (!ruleResult.success) {
-                console.warn('Failed to create bank rule:', ruleResult.error);
+                console.warn('Failed to create transaction rule:', ruleResult.error);
             }
         }
 

--- a/client/src/components/MatchToInvoiceDialog.tsx
+++ b/client/src/components/MatchToInvoiceDialog.tsx
@@ -160,6 +160,8 @@ export default function MatchToInvoiceDialog({
       queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
       queryClient.invalidateQueries({ queryKey: ['payments'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       toast.success('Deposit matched to invoice successfully');
       onMatched();
       handleClose();

--- a/client/src/components/transactions/TransactionEditDrawer.tsx
+++ b/client/src/components/transactions/TransactionEditDrawer.tsx
@@ -35,6 +35,7 @@ interface TransactionEditDrawerProps {
   transaction: BankTransaction | null;
   accounts: Account[];
   onSave: (id: string, data: TransactionEditFormData) => void;
+  onSaveAndApprove?: (id: string, data: TransactionEditFormData) => void;
   onClose: () => void;
   isSaving?: boolean;
   isRecategorize?: boolean;
@@ -44,6 +45,7 @@ export default function TransactionEditDrawer({
   transaction,
   accounts,
   onSave,
+  onSaveAndApprove,
   onClose,
   isSaving = false,
   isRecategorize = false,
@@ -77,6 +79,11 @@ export default function TransactionEditDrawer({
   const handleSave = () => {
     if (!transaction) return;
     onSave(transaction.Id, form);
+  };
+
+  const handleSaveAndApprove = () => {
+    if (!transaction || !onSaveAndApprove) return;
+    onSaveAndApprove(transaction.Id, form);
   };
 
   const selectedAccount = accounts.find((a) => a.Id === form.accountId) ?? null;
@@ -292,6 +299,17 @@ export default function TransactionEditDrawer({
             >
               {isSaving ? 'Saving...' : isRecategorize ? 'Recategorize' : 'Save'}
             </Button>
+            {onSaveAndApprove && !isRecategorize && transaction?.Status === 'Pending' && (
+              <Button
+                variant="contained"
+                color="success"
+                onClick={handleSaveAndApprove}
+                disabled={isSaving || !form.accountId}
+                title={!form.accountId ? 'Select an account to approve' : ''}
+              >
+                {isSaving ? 'Saving...' : 'Save & Approve'}
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/client/src/pages/ApplyDeposit.tsx
+++ b/client/src/pages/ApplyDeposit.tsx
@@ -226,6 +226,8 @@ export default function ApplyDeposit() {
       queryClient.invalidateQueries({ queryKey: ['customerdeposits'] });
       queryClient.invalidateQueries({ queryKey: ['depositapplications'] });
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       navigate('/customer-deposits');
     },
     onError: (error) => {

--- a/client/src/pages/InvoiceView.tsx
+++ b/client/src/pages/InvoiceView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Printer, Edit, Building2, Mail, Trash2 } from 'lucide-react';
 import { useCompanySettings } from '../contexts/CompanySettingsContext';
 import { useCurrency } from '../contexts/CurrencyContext';
@@ -50,6 +50,7 @@ interface Customer {
 export default function InvoiceView() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { settings: company } = useCompanySettings();
   const { formatCurrency } = useCurrency();
   const { user, userRole } = useAuth();
@@ -163,6 +164,8 @@ export default function InvoiceView() {
       // Delete the invoice
       await api.delete(`/invoices_write/Id/${invoice.Id}`);
 
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       navigate('/invoices');
     } catch (error) {
       console.error('Failed to delete invoice:', error);

--- a/client/src/pages/NewCustomerDeposit.tsx
+++ b/client/src/pages/NewCustomerDeposit.tsx
@@ -111,6 +111,8 @@ export default function NewCustomerDeposit() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['customerdeposits'] });
       queryClient.invalidateQueries({ queryKey: ['accounts'] }); // Refresh account balances
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       navigate('/customer-deposits');
     },
     onError: (error) => {

--- a/client/src/pages/NewJournalEntry.tsx
+++ b/client/src/pages/NewJournalEntry.tsx
@@ -2,7 +2,7 @@ import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../lib/api';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { formatCurrencyStandalone } from '../contexts/CurrencyContext';
@@ -50,6 +50,7 @@ type JournalEntryFormData = z.infer<typeof journalEntrySchema>;
 
 export default function NewJournalEntry() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { register, control, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<JournalEntryFormData>({
     resolver: zodResolver(journalEntrySchema),
     defaultValues: {
@@ -107,6 +108,8 @@ export default function NewJournalEntry() {
         });
       }
 
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       navigate('/journal-entries');
     } catch (error: any) {
       console.error('Failed to create journal entry:', error);

--- a/client/src/pages/NewPayment.tsx
+++ b/client/src/pages/NewPayment.tsx
@@ -112,6 +112,8 @@ export default function NewPayment() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['payments'] });
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       navigate('/payments');
     },
     onError: (error) => {

--- a/client/src/pages/TransactionRules.tsx
+++ b/client/src/pages/TransactionRules.tsx
@@ -1,6 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Plus, Search, X, ArrowUpDown, Play, Pause, Trash2, Pencil, FlaskConical } from 'lucide-react';
 import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
 import api from '../lib/api';
 import { formatCurrencyStandalone } from '../contexts/CurrencyContext';
 import { useToast } from '../hooks/useToast';
@@ -120,6 +126,7 @@ export default function TransactionRules() {
     IsEnabled: true,
   });
   const [validationErrors, setValidationErrors] = useState<ValidationErrors>({});
+  const [showSaveConfirm, setShowSaveConfirm] = useState(false);
   const { showToast } = useToast();
 
   const queryClient = useQueryClient();
@@ -309,6 +316,12 @@ export default function TransactionRules() {
     if (!validateForm()) {
       return;
     }
+
+    setShowSaveConfirm(true);
+  };
+
+  const handleConfirmSave = () => {
+    setShowSaveConfirm(false);
 
     const submitData: TransactionRuleInput = {
       ...formData,
@@ -848,6 +861,20 @@ export default function TransactionRules() {
           </form>
         </div>
       )}
+
+      {/* Save Confirmation Dialog */}
+      <Dialog open={showSaveConfirm} onClose={() => setShowSaveConfirm(false)}>
+        <DialogTitle>{editingRule ? 'Update Rule' : 'Create Rule'}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to {editingRule ? 'update' : 'create'} the rule &quot;{formData.Name.trim()}&quot;?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowSaveConfirm(false)}>No</Button>
+          <Button onClick={handleConfirmSave} variant="contained" autoFocus>Yes</Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Test Dialog */}
       {showTestDialog && (

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -418,7 +418,7 @@ export default function UnifiedTransactions() {
       console.error('Approve failed:', err);
       toast.error('Failed to approve transaction');
     });
-  }, [transactions, accountMap, queryClient]);
+  }, [transactions, accountMap, queryClient, isSimpleMode]);
 
   const handleReject = useCallback((id: string) => {
     updateMutation.mutate({ id, data: { Status: 'Rejected' } });
@@ -461,37 +461,59 @@ export default function UnifiedTransactions() {
   }, [accounts, updateMutation, recategorizeMutation, drawerTransaction]);
 
   // Save edits and approve in one step
-  const handleSaveAndApprove = useCallback((id: string, formData: TransactionEditFormData) => {
-    if (!formData.accountId) {
-      toast.error('Select an account before approving');
-      return;
-    }
-    const selectedAccount = accounts.find(a => a.Id === formData.accountId);
-    const category = selectedAccount?.Name || null;
+  const saveAndApproveMutation = useMutation({
+    mutationFn: async ({ id, formData }: { id: string; formData: TransactionEditFormData }) => {
+      const selectedAccount = accounts.find(a => a.Id === formData.accountId);
+      const category = selectedAccount?.Name || null;
 
-    api.post(`/transactions/${id}/approve`, {
-      accountId: formData.accountId,
-      category,
-      memo: formData.memo || null,
-      vendorId: formData.vendorId || null,
-      customerId: formData.customerId || null,
-      classId: formData.classId || null,
-      projectId: formData.projectId || null,
-      payee: formData.payee || null,
-      isPersonal: formData.isPersonal,
-      autoPost: isSimpleMode,
-    }).then(() => {
+      // First, persist the edited transaction fields
+      await api.patch(`/api/banktransactions/Id/${id}`, {
+        SuggestedAccountId: formData.accountId || null,
+        SuggestedCategory: category,
+        SuggestedMemo: formData.memo || null,
+        IsPersonal: formData.isPersonal,
+        VendorId: formData.vendorId || null,
+        CustomerId: formData.customerId || null,
+        ClassId: formData.classId || null,
+        ProjectId: formData.projectId || null,
+        Payee: formData.payee || null,
+      }, { headers: { 'X-MS-API-ROLE': 'Accountant' } });
+
+      // Then approve
+      return api.post(`/transactions/${id}/approve`, {
+        accountId: formData.accountId,
+        category,
+        memo: formData.memo || null,
+        vendorId: formData.vendorId || null,
+        customerId: formData.customerId || null,
+        classId: formData.classId || null,
+        projectId: formData.projectId || null,
+        payee: formData.payee || null,
+        isPersonal: formData.isPersonal,
+        autoPost: isSimpleMode,
+      });
+    },
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
       queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       setDrawerTransaction(null);
       setSelectedIds({ type: 'include', ids: new Set() });
       toast.success(isSimpleMode ? 'Transaction approved and posted to GL' : 'Transaction approved');
-    }).catch((err) => {
+    },
+    onError: (err: unknown) => {
       console.error('Save & Approve failed:', err);
       toast.error('Failed to approve transaction');
-    });
-  }, [accounts, queryClient, isSimpleMode]);
+    },
+  });
+
+  const handleSaveAndApprove = useCallback((id: string, formData: TransactionEditFormData) => {
+    if (!formData.accountId) {
+      toast.error('Select an account before approving');
+      return;
+    }
+    saveAndApproveMutation.mutate({ id, formData });
+  }, [saveAndApproveMutation]);
 
   // Resolve selected IDs, handling both 'include' and 'include_all' selection types
   const getSelectedTransactions = useCallback(() => {
@@ -903,7 +925,7 @@ export default function UnifiedTransactions() {
         onSave={handleSaveEdit}
         onSaveAndApprove={handleSaveAndApprove}
         onClose={() => setDrawerTransaction(null)}
-        isSaving={updateMutation.isPending || recategorizeMutation.isPending}
+        isSaving={updateMutation.isPending || recategorizeMutation.isPending || saveAndApproveMutation.isPending}
         isRecategorize={drawerTransaction?.Status === 'Posted'}
       />
 

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -255,6 +255,8 @@ export default function UnifiedTransactions() {
     onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['transactionrules'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
 
       if (data.ruleConflict && data.existingRule) {
         // Show confirmation dialog for rule conflict
@@ -311,6 +313,8 @@ export default function UnifiedTransactions() {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       setSelectedIds({ type: 'include', ids: new Set() });
       if (data?.approved > 0) {
         const postedCount = data.posted || 0;
@@ -362,6 +366,8 @@ export default function UnifiedTransactions() {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       toast.success(`Successfully posted ${data.count} transactions to the journal!`, { id: 'post-transactions' });
       setShowPostConfirm(false);
     },
@@ -403,6 +409,8 @@ export default function UnifiedTransactions() {
       autoPost: isSimpleMode,
     }).then(() => {
       queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       setDrawerTransaction(null);
       setSelectedIds({ type: 'include', ids: new Set() });
       toast.success(isSimpleMode ? 'Transaction approved and posted to GL' : 'Transaction approved');
@@ -451,6 +459,39 @@ export default function UnifiedTransactions() {
       },
     });
   }, [accounts, updateMutation, recategorizeMutation, drawerTransaction]);
+
+  // Save edits and approve in one step
+  const handleSaveAndApprove = useCallback((id: string, formData: TransactionEditFormData) => {
+    if (!formData.accountId) {
+      toast.error('Select an account before approving');
+      return;
+    }
+    const selectedAccount = accounts.find(a => a.Id === formData.accountId);
+    const category = selectedAccount?.Name || null;
+
+    api.post(`/transactions/${id}/approve`, {
+      accountId: formData.accountId,
+      category,
+      memo: formData.memo || null,
+      vendorId: formData.vendorId || null,
+      customerId: formData.customerId || null,
+      classId: formData.classId || null,
+      projectId: formData.projectId || null,
+      payee: formData.payee || null,
+      isPersonal: formData.isPersonal,
+      autoPost: isSimpleMode,
+    }).then(() => {
+      queryClient.invalidateQueries({ queryKey: ['unified-transactions'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
+      setDrawerTransaction(null);
+      setSelectedIds({ type: 'include', ids: new Set() });
+      toast.success(isSimpleMode ? 'Transaction approved and posted to GL' : 'Transaction approved');
+    }).catch((err) => {
+      console.error('Save & Approve failed:', err);
+      toast.error('Failed to approve transaction');
+    });
+  }, [accounts, queryClient, isSimpleMode]);
 
   // Resolve selected IDs, handling both 'include' and 'include_all' selection types
   const getSelectedTransactions = useCallback(() => {
@@ -860,6 +901,7 @@ export default function UnifiedTransactions() {
         transaction={drawerTransaction}
         accounts={accounts}
         onSave={handleSaveEdit}
+        onSaveAndApprove={handleSaveAndApprove}
         onClose={() => setDrawerTransaction(null)}
         isSaving={updateMutation.isPending || recategorizeMutation.isPending}
         isRecategorize={drawerTransaction?.Status === 'Posted'}

--- a/client/src/pages/YearEndClose.tsx
+++ b/client/src/pages/YearEndClose.tsx
@@ -264,6 +264,7 @@ export default function YearEndClose() {
       queryClient.invalidateQueries({ queryKey: ['accounting-periods'] });
       queryClient.invalidateQueries({ queryKey: ['year-end-close-entries'] });
       queryClient.invalidateQueries({ queryKey: ['journal-entries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal-entry-lines'] });
       navigate('/accounting-periods');
     },
     onError: (err: any) => {

--- a/client/src/pages/reports/TransactionDetail.tsx
+++ b/client/src/pages/reports/TransactionDetail.tsx
@@ -76,6 +76,7 @@ export default function TransactionDetail() {
       const r = await api.get('/journalentries');
       return r.data.value as JournalEntry[];
     },
+    refetchOnMount: 'always',
   });
 
   const {
@@ -88,6 +89,7 @@ export default function TransactionDetail() {
       const r = await api.get('/journalentrylines');
       return r.data.value as JournalEntryLine[];
     },
+    refetchOnMount: 'always',
   });
 
   const isLoading = accountsLoading || journalEntriesLoading || linesLoading;

--- a/client/tests/bank-rules.spec.ts
+++ b/client/tests/bank-rules.spec.ts
@@ -6,7 +6,7 @@ test.describe('Bank Rules (Inline CRUD)', () => {
     const ruleName = `Test Rule ${timestamp}`;
 
     await page.goto('/bank-rules');
-    await expect(page.getByRole('heading', { name: /Bank Rules/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Transaction Rules/i })).toBeVisible();
 
     // Click New Rule button
     await page.getByRole('button', { name: /New Rule/i }).click();
@@ -22,12 +22,13 @@ test.describe('Bank Rules (Inline CRUD)', () => {
     await expect(accountSelect.locator('option')).not.toHaveCount(1, { timeout: 10000 });
     await accountSelect.selectOption({ index: 1 });
 
-    // Save
+    // Save — click Create Rule, then confirm in dialog
     const responsePromise = page.waitForResponse(
-      resp => resp.url().includes('/bankrules') && (resp.status() === 201 || resp.status() === 200),
+      resp => resp.url().includes('/transactionrules') && (resp.status() === 201 || resp.status() === 200),
       { timeout: 15000 }
     );
     await page.getByRole('button', { name: /Create Rule/i }).click();
+    await page.getByRole('button', { name: 'Yes' }).click();
     await responsePromise;
 
     // Verify rule appears in list
@@ -52,10 +53,11 @@ test.describe('Bank Rules (Inline CRUD)', () => {
     await accountSelect.selectOption({ index: 1 });
 
     const createPromise = page.waitForResponse(
-      resp => resp.url().includes('/bankrules') && (resp.status() === 201 || resp.status() === 200),
+      resp => resp.url().includes('/transactionrules') && (resp.status() === 201 || resp.status() === 200),
       { timeout: 15000 }
     );
     await page.getByRole('button', { name: /Create Rule/i }).click();
+    await page.getByRole('button', { name: 'Yes' }).click();
     await createPromise;
 
     await expect(page.getByText(ruleName)).toBeVisible();
@@ -70,7 +72,14 @@ test.describe('Bank Rules (Inline CRUD)', () => {
       await page.locator('#matchValue').clear();
       await page.locator('#matchValue').fill('AMAZON PRIME');
 
+      const updatePromise = page.waitForResponse(
+        resp => resp.url().includes('/transactionrules') && (resp.status() === 201 || resp.status() === 200),
+        { timeout: 15000 }
+      );
       await page.getByRole('button', { name: /Update Rule/i }).click();
+      await page.getByRole('button', { name: 'Yes' }).click();
+      await updatePromise;
+
       await expect(page.getByText('AMAZON PRIME')).toBeVisible();
     }
   });
@@ -93,10 +102,11 @@ test.describe('Bank Rules (Inline CRUD)', () => {
     await accountSelect.selectOption({ index: 1 });
 
     const createPromise = page.waitForResponse(
-      resp => resp.url().includes('/bankrules') && (resp.status() === 201 || resp.status() === 200),
+      resp => resp.url().includes('/transactionrules') && (resp.status() === 201 || resp.status() === 200),
       { timeout: 15000 }
     );
     await page.getByRole('button', { name: /Create Rule/i }).click();
+    await page.getByRole('button', { name: 'Yes' }).click();
     await createPromise;
 
     await expect(page.getByText(ruleName)).toBeVisible();

--- a/client/tests/transaction-edit-drawer.spec.ts
+++ b/client/tests/transaction-edit-drawer.spec.ts
@@ -105,7 +105,7 @@ test.describe('Transaction Edit Drawer', () => {
     await expect(page.getByText('Personal Transaction')).toBeVisible();
     // Buttons
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
   });
 
   test('Save persists changes via PATCH', async ({ page }) => {
@@ -136,7 +136,7 @@ test.describe('Transaction Edit Drawer', () => {
       { timeout: 15000 }
     );
 
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
     const patchResp = await patchPromise;
     expect(patchResp.status()).toBeLessThan(300);
 
@@ -201,7 +201,7 @@ test.describe('Transaction Edit Drawer', () => {
         resp.request().method() === 'PATCH',
       { timeout: 15000 }
     );
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
     const patchResp = await patchPromise;
     expect(patchResp.status()).toBeLessThan(300);
   });

--- a/database/Script.PostDeployment.sql
+++ b/database/Script.PostDeployment.sql
@@ -7,6 +7,50 @@ Uses IF NOT EXISTS guards for idempotent operations (safe to run multiple times)
 --------------------------------------------------------------------------------------
 */
 
+-- ============================================================================
+-- DATA MIGRATIONS (run in ALL environments, including production)
+-- These are operational data migrations, NOT seed data.
+-- ============================================================================
+
+-- Migration: BankRules -> TransactionRules
+-- Copy existing BankRules into the unified TransactionRules table
+-- (Idempotent: only runs if TransactionRules is empty and BankRules has data)
+IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'TransactionRules')
+   AND EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'BankRules')
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM [dbo].[TransactionRules])
+       AND EXISTS (SELECT 1 FROM [dbo].[BankRules])
+    BEGIN
+        PRINT 'Migrating BankRules to TransactionRules...'
+
+        INSERT INTO [dbo].[TransactionRules] (
+            [Id], [Name], [BankAccountId],
+            [MatchField], [MatchType], [MatchValue],
+            [MinAmount], [MaxAmount], [TransactionType],
+            [AssignAccountId], [AssignVendorId], [AssignCustomerId],
+            [AssignClassId], [AssignMemo], [AssignIsPersonal],
+            [Priority], [IsEnabled], [Source],
+            [CreatedAt], [UpdatedAt]
+        )
+        SELECT
+            [Id], [Name], [BankAccountId],
+            [MatchField], [MatchType], [MatchValue],
+            [MinAmount], [MaxAmount], [TransactionType],
+            [AssignAccountId], [AssignVendorId], [AssignCustomerId],
+            [AssignClassId], [AssignMemo], [AssignIsPersonal],
+            [Priority], [IsEnabled], 'manual',
+            [CreatedAt], [UpdatedAt]
+        FROM [dbo].[BankRules];
+
+        PRINT 'Migrated BankRules to TransactionRules: ' + CAST(@@ROWCOUNT AS VARCHAR) + ' rows';
+    END
+    ELSE
+    BEGIN
+        PRINT 'TransactionRules migration skipped (already has data or BankRules is empty).'
+    END
+END
+GO
+
 -- Gate: skip all seed data when SeedData=false (production deploys)
 IF '$(SeedData)' = 'false'
 BEGIN

--- a/database/Script.PostDeployment.sql
+++ b/database/Script.PostDeployment.sql
@@ -14,12 +14,11 @@ Uses IF NOT EXISTS guards for idempotent operations (safe to run multiple times)
 
 -- Migration: BankRules -> TransactionRules
 -- Copy existing BankRules into the unified TransactionRules table
--- (Idempotent: only runs if TransactionRules is empty and BankRules has data)
+-- (Idempotent per-row: only inserts BankRules whose Id is not already in TransactionRules)
 IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'TransactionRules')
    AND EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'BankRules')
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM [dbo].[TransactionRules])
-       AND EXISTS (SELECT 1 FROM [dbo].[BankRules])
+    IF EXISTS (SELECT 1 FROM [dbo].[BankRules] br WHERE NOT EXISTS (SELECT 1 FROM [dbo].[TransactionRules] tr WHERE tr.Id = br.Id))
     BEGIN
         PRINT 'Migrating BankRules to TransactionRules...'
 
@@ -33,20 +32,21 @@ BEGIN
             [CreatedAt], [UpdatedAt]
         )
         SELECT
-            [Id], [Name], [BankAccountId],
-            [MatchField], [MatchType], [MatchValue],
-            [MinAmount], [MaxAmount], [TransactionType],
-            [AssignAccountId], [AssignVendorId], [AssignCustomerId],
-            [AssignClassId], [AssignMemo], [AssignIsPersonal],
-            [Priority], [IsEnabled], 'manual',
-            [CreatedAt], [UpdatedAt]
-        FROM [dbo].[BankRules];
+            br.[Id], br.[Name], br.[BankAccountId],
+            br.[MatchField], br.[MatchType], br.[MatchValue],
+            br.[MinAmount], br.[MaxAmount], br.[TransactionType],
+            br.[AssignAccountId], br.[AssignVendorId], br.[AssignCustomerId],
+            br.[AssignClassId], br.[AssignMemo], br.[AssignIsPersonal],
+            br.[Priority], br.[IsEnabled], 'manual',
+            br.[CreatedAt], br.[UpdatedAt]
+        FROM [dbo].[BankRules] br
+        WHERE NOT EXISTS (SELECT 1 FROM [dbo].[TransactionRules] tr WHERE tr.Id = br.Id);
 
         PRINT 'Migrated BankRules to TransactionRules: ' + CAST(@@ROWCOUNT AS VARCHAR) + ' rows';
     END
     ELSE
     BEGIN
-        PRINT 'TransactionRules migration skipped (already has data or BankRules is empty).'
+        PRINT 'TransactionRules migration skipped (no unmigrated BankRules found).'
     END
 END
 GO

--- a/scripts/deploy-db.js
+++ b/scripts/deploy-db.js
@@ -214,6 +214,8 @@ const TABLE_ORDER = [
   'InventoryLocations',
   'PurchaseOrders',
   'PurchaseOrderLines',
+  'BankRules',
+  'TransactionRules',
 ];
 
 async function runBatches(pool, script, name) {


### PR DESCRIPTION
## Summary

- **#573 Missing bank rules**: BankRules→TransactionRules data migration wasn't running in SqlPackage mode (production). Added idempotent migration to `PostDeployment.sql`, fixed API still referencing old `bankrules` entity, added tables to `deploy-db.js` table list.
- **#574 Save confirmation**: Added MUI Yes/No confirmation dialog before creating or updating transaction rules.
- **#575 1-click edit/approve**: Added "Save & Approve" button to the transaction edit drawer — categorizes and approves in one action, reducing workflow from 3+ clicks to 2.
- **#577 Report not refreshing**: Transaction Detail report now uses `refetchOnMount: 'always'` and all mutation points (approve, post, recategorize, new JE, payments, deposits, invoice delete, year-end close) invalidate `journal-entries` and `journal-entry-lines` caches.

## Files changed (16)

| Area | Files | Change |
|------|-------|--------|
| Database | `Script.PostDeployment.sql`, `deploy-db.js` | BankRules→TransactionRules data migration |
| API | `chat-api/server.js` | Fix `bankrules` → `transactionrules` entity reference |
| Rules UI | `TransactionRules.tsx` | Save confirmation dialog |
| Transactions UI | `TransactionEditDrawer.tsx`, `UnifiedTransactions.tsx` | Save & Approve button + cache invalidation |
| Reports | `TransactionDetail.tsx` | `refetchOnMount: 'always'` |
| Cache invalidation | 6 additional pages | Invalidate journal entry queries on mutation |
| Tests | `bank-rules.spec.ts`, `transaction-edit-drawer.spec.ts` | Updated for new UI behavior |

## Test plan

- [x] `bank-rules.spec.ts` — 3/3 passed (create, edit, delete rules with confirmation dialog)
- [x] `transaction-edit-drawer.spec.ts` — 7/7 passed (Save vs Save & Approve button disambiguation)
- [x] `unified-transactions-datagrid.spec.ts` — all passed
- [x] `bank-transactions.spec.ts` — 14/14 passed
- [x] `journal-entries.spec.ts` — 8/8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)