### PR TITLE
fix: Schema drift — sync sqlproj views, unify deploys on SqlPackage

### DIFF
--- a/.devcontainer/Dockerfile.db-init
+++ b/.devcontainer/Dockerfile.db-init
@@ -6,7 +6,9 @@ WORKDIR /src
 COPY database/ ./database/
 RUN dotnet build database/AccountingDB.sqlproj -c Release -o /dacpac
 
-# Runtime stage — slim image with SqlPackage + Node.js for migrations
+# Runtime stage — SDK image with SqlPackage + Node.js for migrations
+# (SDK is required because SqlPackage is installed as a dotnet tool and
+# the Node.js post-deploy script may invoke dotnet/sqlpackage directly.)
 FROM mcr.microsoft.com/dotnet/sdk:8.0-noble
 
 # Install Node.js 20 (needed for post-deploy migrations)

--- a/.devcontainer/Dockerfile.db-init
+++ b/.devcontainer/Dockerfile.db-init
@@ -1,15 +1,36 @@
-FROM node:20-slim
+FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
+
+WORKDIR /src
+
+# Copy sqlproj and build DACPAC
+COPY database/ ./database/
+RUN dotnet build database/AccountingDB.sqlproj -c Release -o /dacpac
+
+# Runtime stage — slim image with SqlPackage + Node.js for migrations
+FROM mcr.microsoft.com/dotnet/sdk:8.0-noble
+
+# Install Node.js 20 (needed for post-deploy migrations)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install SqlPackage
+RUN dotnet tool install -g microsoft.sqlpackage
+ENV PATH="$PATH:/root/.dotnet/tools"
 
 WORKDIR /app
 
-# Copy package files and install mssql
+# Copy DACPAC from build stage
+COPY --from=build /dacpac/ ./dacpac/
+
+# Copy package files and install mssql (for migrations)
 COPY package*.json ./
 RUN npm install mssql
 
-# Copy database project and deploy script
+# Copy database project (for migrations) and deploy script
 COPY database/ ./database/
 COPY scripts/deploy-db.js ./scripts/
 
-# Use Node.js mode explicitly since we're in a minimal container
-# SqlPackage mode requires .NET SDK which isn't installed here
-CMD ["node", "scripts/deploy-db.js", "--node"]
+# Deploy using SqlPackage (builds DACPAC in build stage, publishes here)
+# Falls through to run migrations via Node.js after SqlPackage publish
+CMD ["node", "scripts/deploy-db.js"]

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Validate DAB config
         run: node scripts/validate-dab-config.js
 
+      - name: Validate schema consistency
+        run: node scripts/validate-schema.js
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,12 +32,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Validate DAB config
-        run: node scripts/validate-dab-config.js
-
-      - name: Validate schema consistency
-        run: node scripts/validate-schema.js
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -46,6 +40,12 @@ jobs:
           cache-dependency-path: |
             client/package-lock.json
             chat-api/package-lock.json
+
+      - name: Validate DAB config
+        run: node scripts/validate-dab-config.js
+
+      - name: Validate schema consistency
+        run: node scripts/validate-schema.js
 
       - name: Install client dependencies
         working-directory: client

--- a/database/dbo/Views/v_BankTransactionsImport.sql
+++ b/database/dbo/Views/v_BankTransactionsImport.sql
@@ -1,0 +1,30 @@
+CREATE VIEW [dbo].[v_BankTransactionsImport] AS
+SELECT
+    bt.[Id],
+    bt.[SourceType],
+    bt.[SourceName],
+    bt.[SourceAccountId],
+    a.[Name] AS SourceAccountName,
+    bt.[TransactionDate],
+    bt.[PostDate],
+    bt.[Amount],
+    bt.[Description],
+    bt.[Merchant],
+    bt.[TransactionType],
+    bt.[CheckNumber],
+    bt.[ReferenceNumber],
+    bt.[BankTransactionId],
+    bt.[Status],
+    bt.[MatchConfidence],
+    bt.[MatchedPaymentId],
+    bt.[MatchedAt],
+    bt.[ImportId],
+    bi.[FileName] AS ImportFileName,
+    bi.[ImportDate],
+    bi.[ImportedBy],
+    bt.[CreatedDate]
+FROM
+    [dbo].[BankTransactions] bt
+    LEFT JOIN [dbo].[Accounts] a ON bt.[SourceAccountId] = a.[Id]
+    LEFT JOIN [dbo].[BankTransactionImports] bi ON bt.[ImportId] = bi.[Id];
+GO

--- a/database/dbo/Views/v_Employees.sql
+++ b/database/dbo/Views/v_Employees.sql
@@ -24,6 +24,19 @@ SELECT
     e.[State],
     e.[ZipCode],
     e.[Status],
+    -- Bank info (masked account number)
+    e.[BankRoutingNumber],
+    CASE WHEN e.[BankAccountNumber] IS NOT NULL
+         THEN '****' + RIGHT(e.[BankAccountNumber], 4)
+         ELSE NULL
+    END AS [BankAccountNumberMasked],
+    e.[BankAccountType],
+    -- Plaid verification fields
+    e.[PlaidItemId],
+    e.[PlaidAccountId],
+    e.[BankVerificationStatus],
+    e.[BankVerifiedAt],
+    e.[BankInstitutionName],
     e.[CreatedAt],
     e.[UpdatedAt]
 FROM [dbo].[Employees] e

--- a/database/dbo/Views/v_OverdueInvoicesForReminder.sql
+++ b/database/dbo/Views/v_OverdueInvoicesForReminder.sql
@@ -2,7 +2,7 @@ CREATE VIEW [dbo].[v_OverdueInvoicesForReminder] AS
 WITH PaymentTotals AS (
     -- Pre-aggregate payment totals per invoice
     SELECT InvoiceId, SUM(AmountApplied) AS TotalPaid
-    FROM PaymentApplications
+    FROM [dbo].[PaymentApplications]
     GROUP BY InvoiceId
 ),
 ReminderStats AS (
@@ -11,7 +11,7 @@ ReminderStats AS (
         EntityId,
         COUNT(*) AS RemindersSent,
         MAX(CreatedAt) AS LastReminderDate
-    FROM EmailLog
+    FROM [dbo].[EmailLog]
     WHERE IsAutomatic = 1
     GROUP BY EntityId
 )
@@ -25,17 +25,17 @@ SELECT
     i.DueDate,
     i.TotalAmount,
     i.TotalAmount - ISNULL(pt.TotalPaid, 0) AS AmountDue,
-    DATEDIFF(DAY, i.DueDate, GETDATE()) AS DaysOverdue,
+    DATEDIFF(DAY, i.DueDate, CAST(GETDATE() AS DATE)) AS DaysOverdue,
     i.Status,
     ISNULL(rs.RemindersSent, 0) AS RemindersSent,
     rs.LastReminderDate
-FROM Invoices i
-INNER JOIN Customers c ON i.CustomerId = c.Id
+FROM [dbo].[Invoices] i
+INNER JOIN [dbo].[Customers] c ON i.CustomerId = c.Id
 LEFT JOIN PaymentTotals pt ON pt.InvoiceId = i.Id
 LEFT JOIN ReminderStats rs ON rs.EntityId = i.Id
 WHERE
     i.Status IN ('Sent', 'Overdue')
-    AND i.DueDate < GETDATE()
+    AND i.DueDate < CAST(GETDATE() AS DATE)
     AND c.Email IS NOT NULL
     AND c.Email != '';
 GO

--- a/database/dbo/Views/v_OverdueInvoicesForReminder.sql
+++ b/database/dbo/Views/v_OverdueInvoicesForReminder.sql
@@ -1,0 +1,41 @@
+CREATE VIEW [dbo].[v_OverdueInvoicesForReminder] AS
+WITH PaymentTotals AS (
+    -- Pre-aggregate payment totals per invoice
+    SELECT InvoiceId, SUM(AmountApplied) AS TotalPaid
+    FROM PaymentApplications
+    GROUP BY InvoiceId
+),
+ReminderStats AS (
+    -- Pre-aggregate reminder statistics per entity
+    SELECT
+        EntityId,
+        COUNT(*) AS RemindersSent,
+        MAX(CreatedAt) AS LastReminderDate
+    FROM EmailLog
+    WHERE IsAutomatic = 1
+    GROUP BY EntityId
+)
+SELECT
+    i.Id AS InvoiceId,
+    i.InvoiceNumber,
+    i.CustomerId,
+    c.Name AS CustomerName,
+    c.Email AS CustomerEmail,
+    i.IssueDate,
+    i.DueDate,
+    i.TotalAmount,
+    i.TotalAmount - ISNULL(pt.TotalPaid, 0) AS AmountDue,
+    DATEDIFF(DAY, i.DueDate, GETDATE()) AS DaysOverdue,
+    i.Status,
+    ISNULL(rs.RemindersSent, 0) AS RemindersSent,
+    rs.LastReminderDate
+FROM Invoices i
+INNER JOIN Customers c ON i.CustomerId = c.Id
+LEFT JOIN PaymentTotals pt ON pt.InvoiceId = i.Id
+LEFT JOIN ReminderStats rs ON rs.EntityId = i.Id
+WHERE
+    i.Status IN ('Sent', 'Overdue')
+    AND i.DueDate < GETDATE()
+    AND c.Email IS NOT NULL
+    AND c.Email != '';
+GO

--- a/scripts/deploy-db.js
+++ b/scripts/deploy-db.js
@@ -15,9 +15,8 @@
  *    - Handles table ordering and foreign key dependencies
  *
  * Usage:
- *   node deploy-db.js                 # Auto-detect best mode
- *   node deploy-db.js --sqlpackage    # Force SqlPackage mode
- *   node deploy-db.js --node          # Force Node.js mode
+ *   node deploy-db.js                 # Default: SqlPackage (errors if missing)
+ *   node deploy-db.js --node          # Force Node.js mode (migrations only, no view updates)
  *   node deploy-db.js --script-only   # Generate deployment script only (SqlPackage)
  *
  * Environment Variables:
@@ -57,7 +56,6 @@ const dacpacPath = path.join(outputDir, 'AccountingDB.dacpac');
 
 // Parse command line arguments
 const args = process.argv.slice(2);
-const forceSqlPackage = args.includes('--sqlpackage');
 const forceNode = args.includes('--node');
 const scriptOnly = args.includes('--script-only');
 
@@ -77,22 +75,36 @@ function log(message, type = 'info') {
 }
 
 function findSqlPackage() {
-  // Check if SqlPackage is in PATH
-  try {
-    const result = spawnSync('where', ['SqlPackage'], { encoding: 'utf8', shell: true });
-    if (result.status === 0 && result.stdout.trim()) {
-      return result.stdout.trim().split('\n')[0].trim();
-    }
-  } catch (e) {}
+  const isWindows = process.platform === 'win32';
+  const lookupCmd = isWindows ? 'where' : 'which';
+
+  // Check if SqlPackage is in PATH (try both casings for Linux/macOS)
+  const names = isWindows ? ['SqlPackage'] : ['sqlpackage', 'SqlPackage'];
+  for (const name of names) {
+    try {
+      const result = spawnSync(lookupCmd, [name], { encoding: 'utf8', shell: true });
+      if (result.status === 0 && result.stdout.trim()) {
+        return result.stdout.trim().split('\n')[0].trim();
+      }
+    } catch (e) {}
+  }
 
   // Check common installation paths
-  const possiblePaths = [
-    path.join(process.env.USERPROFILE || '', '.dotnet', 'tools', 'SqlPackage.exe'),
-    'C:\\Program Files\\Microsoft SQL Server\\160\\DAC\\bin\\SqlPackage.exe',
-    'C:\\Program Files\\Microsoft SQL Server\\150\\DAC\\bin\\SqlPackage.exe',
-    'C:\\Program Files (x86)\\Microsoft SQL Server\\160\\DAC\\bin\\SqlPackage.exe',
-    'C:\\Program Files (x86)\\Microsoft SQL Server\\150\\DAC\\bin\\SqlPackage.exe',
-  ];
+  const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+  const possiblePaths = isWindows
+    ? [
+        path.join(homeDir, '.dotnet', 'tools', 'SqlPackage.exe'),
+        'C:\\Program Files\\Microsoft SQL Server\\160\\DAC\\bin\\SqlPackage.exe',
+        'C:\\Program Files\\Microsoft SQL Server\\150\\DAC\\bin\\SqlPackage.exe',
+        'C:\\Program Files (x86)\\Microsoft SQL Server\\160\\DAC\\bin\\SqlPackage.exe',
+        'C:\\Program Files (x86)\\Microsoft SQL Server\\150\\DAC\\bin\\SqlPackage.exe',
+      ]
+    : [
+        path.join(homeDir, '.dotnet', 'tools', 'sqlpackage'),
+        '/usr/local/bin/sqlpackage',
+        '/usr/local/bin/SqlPackage',
+        '/root/.dotnet/tools/sqlpackage',
+      ];
 
   for (const p of possiblePaths) {
     if (fs.existsSync(p)) {
@@ -175,6 +187,10 @@ async function deployWithSqlPackage() {
 
   // Step 4: Deploy or generate script
   if (scriptOnly) {
+    // Ensure output dir exists (may not when using pre-built DACPAC)
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
     const scriptPath = path.join(outputDir, 'deploy-script.sql');
     log('Generating deployment script...', 'step');
     execSync(

--- a/scripts/deploy-db.js
+++ b/scripts/deploy-db.js
@@ -124,35 +124,44 @@ function canBuildSqlProj() {
 async function deployWithSqlPackage() {
   log('Starting SqlPackage deployment mode', 'step');
 
-  // Step 1: Build the SQL project
-  log('Building SQL project...', 'step');
-  console.log(`  Project: ${sqlProjFile}`);
+  // Step 1: Find or build the DACPAC
+  // Check for pre-built DACPAC (e.g., from Docker build stage)
+  const prebuiltDacpac = path.join(projectDir, 'dacpac', 'AccountingDB.dacpac');
+  let activeDacpacPath = dacpacPath;
 
-  try {
-    // Try dotnet build first (requires Microsoft.Build.Sql SDK project)
-    execSync(`dotnet build "${sqlProjFile}" -c Debug`, {
-      stdio: 'inherit',
-      cwd: databaseDir,
-    });
-  } catch (e) {
-    // If dotnet build fails, try MSBuild
-    log('dotnet build failed, trying MSBuild...', 'warn');
+  if (fs.existsSync(prebuiltDacpac)) {
+    log(`Using pre-built DACPAC: ${prebuiltDacpac}`, 'success');
+    activeDacpacPath = prebuiltDacpac;
+  } else {
+    log('Building SQL project...', 'step');
+    console.log(`  Project: ${sqlProjFile}`);
+
     try {
-      execSync(`msbuild "${sqlProjFile}" /p:Configuration=Debug /t:Build`, {
+      // Try dotnet build first (requires Microsoft.Build.Sql SDK project)
+      execSync(`dotnet build "${sqlProjFile}" -c Debug`, {
         stdio: 'inherit',
         cwd: databaseDir,
       });
-    } catch (e2) {
-      throw new Error(
-        'Failed to build SQL project. Ensure Visual Studio with SSDT or Microsoft.Build.Sql is installed.'
-      );
+    } catch (e) {
+      // If dotnet build fails, try MSBuild
+      log('dotnet build failed, trying MSBuild...', 'warn');
+      try {
+        execSync(`msbuild "${sqlProjFile}" /p:Configuration=Debug /t:Build`, {
+          stdio: 'inherit',
+          cwd: databaseDir,
+        });
+      } catch (e2) {
+        throw new Error(
+          'Failed to build SQL project. Ensure Visual Studio with SSDT or Microsoft.Build.Sql is installed.'
+        );
+      }
     }
-  }
 
-  if (!fs.existsSync(dacpacPath)) {
-    throw new Error(`DACPAC not found at: ${dacpacPath}`);
+    if (!fs.existsSync(dacpacPath)) {
+      throw new Error(`DACPAC not found at: ${dacpacPath}`);
+    }
+    log(`Build successful: ${dacpacPath}`, 'success');
   }
-  log(`Build successful: ${dacpacPath}`, 'success');
 
   // Step 2: Find SqlPackage
   const sqlPackage = findSqlPackage();
@@ -169,14 +178,14 @@ async function deployWithSqlPackage() {
     const scriptPath = path.join(outputDir, 'deploy-script.sql');
     log('Generating deployment script...', 'step');
     execSync(
-      `"${sqlPackage}" /Action:Script /SourceFile:"${dacpacPath}" /TargetConnectionString:"${connectionString}" /OutputPath:"${scriptPath}"`,
+      `"${sqlPackage}" /Action:Script /SourceFile:"${activeDacpacPath}" /TargetConnectionString:"${connectionString}" /OutputPath:"${scriptPath}"`,
       { stdio: 'inherit' }
     );
     log(`Script saved to: ${scriptPath}`, 'success');
   } else {
     log(`Deploying to ${config.server}:${config.port}/${config.database}...`, 'step');
     execSync(
-      `"${sqlPackage}" /Action:Publish /SourceFile:"${dacpacPath}" /TargetConnectionString:"${connectionString}" /p:BlockOnPossibleDataLoss=false /p:GenerateSmartDefaults=true`,
+      `"${sqlPackage}" /Action:Publish /SourceFile:"${activeDacpacPath}" /TargetConnectionString:"${connectionString}" /p:BlockOnPossibleDataLoss=false /p:GenerateSmartDefaults=true`,
       { stdio: 'inherit' }
     );
     log('Deployment completed successfully!', 'success');
@@ -397,18 +406,16 @@ async function main() {
     const sqlPackageAvailable = findSqlPackage() !== null;
     canBuildSqlProj(); // Check if sqlproj can be built (logs warning if not)
 
-    if (forceSqlPackage) {
-      if (!sqlPackageAvailable) {
-        log('SqlPackage not found. Install via: dotnet tool install -g microsoft.sqlpackage', 'error');
-        process.exit(1);
-      }
+    if (forceNode) {
+      log('Using Node.js mode (explicit --node flag)', 'warn');
+      await deployWithNode();
+    } else if (sqlPackageAvailable) {
       await deployWithSqlPackage();
-    } else if (forceNode) {
-      await deployWithNode();
     } else {
-      // Default to Node.js mode (more reliable across environments)
-      // SqlPackage mode requires Visual Studio SSDT or specific SDK setup
-      await deployWithNode();
+      log('SqlPackage not found. Schema objects (views, triggers, stored procs) will NOT be updated.', 'error');
+      log('Install SqlPackage: dotnet tool install -g microsoft.sqlpackage', 'error');
+      log('Or use --node flag to force Node.js mode (migrations only, no view updates).', 'error');
+      process.exit(1);
     }
 
     console.log('');

--- a/scripts/validate-schema.js
+++ b/scripts/validate-schema.js
@@ -23,7 +23,12 @@ const path = require('path');
 const projectDir = path.join(__dirname, '..');
 const viewsDir = path.join(projectDir, 'database', 'dbo', 'Views');
 const migrationsDir = path.join(projectDir, 'database', 'migrations');
-const dabConfigPath = path.join(projectDir, 'dab-config.json');
+
+// Validate all dab-config*.json variants (main, development, production)
+const dabConfigPaths = fs
+  .readdirSync(projectDir)
+  .filter(f => /^dab-config.*\.json$/.test(f))
+  .map(f => path.join(projectDir, f));
 
 let errors = [];
 let warnings = [];
@@ -50,42 +55,50 @@ for (const file of viewFiles) {
 console.log(`Found ${sqlprojViews.size} views in sqlproj (database/dbo/Views/)`);
 
 // ============================================================================
-// Step 2: Check DAB config — every view-backed entity needs a sqlproj file
+// Step 2: Check DAB configs — every view-backed entity needs a sqlproj file
 // ============================================================================
 
-try {
-  const dabConfig = JSON.parse(fs.readFileSync(dabConfigPath, 'utf8'));
+if (dabConfigPaths.length === 0) {
+  warnings.push('No dab-config*.json files found, skipping DAB cross-reference');
+} else {
+  for (const configPath of dabConfigPaths) {
+    const configName = path.basename(configPath);
+    try {
+      const dabConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
-  if (dabConfig.entities) {
-    let viewEntityCount = 0;
+      if (!dabConfig.entities) continue;
 
-    for (const [entityName, entity] of Object.entries(dabConfig.entities)) {
-      if (!entity.source || !entity.source.object) continue;
+      let viewEntityCount = 0;
 
-      const sourceObj = entity.source.object;
-      // Check if this entity is backed by a view (dbo.v_*)
-      const viewMatch = sourceObj.match(/^dbo\.(v_\w+)$/i);
-      if (!viewMatch) continue;
+      for (const [entityName, entity] of Object.entries(dabConfig.entities)) {
+        if (!entity.source || !entity.source.object) continue;
 
-      viewEntityCount++;
-      const viewName = viewMatch[1].toLowerCase();
+        // Prefer source.type === "view" (robust); fall back to v_ name pattern
+        const isView =
+          (entity.source.type && entity.source.type.toLowerCase() === 'view') ||
+          /^dbo\.v_\w+$/i.test(entity.source.object);
+        if (!isView) continue;
 
-      if (!sqlprojViews.has(viewName)) {
-        errors.push(
-          `DAB entity "${entityName}" references view "dbo.${viewMatch[1]}" ` +
-          `but no file exists in database/dbo/Views/. ` +
-          `SqlPackage deployments will not create or update this view.`
-        );
+        // Extract object name (strip schema prefix if present)
+        const objectMatch = entity.source.object.match(/^(?:\[?dbo\]?\.)?\[?(\w+)\]?$/i);
+        if (!objectMatch) continue;
+
+        viewEntityCount++;
+        const viewName = objectMatch[1].toLowerCase();
+
+        if (!sqlprojViews.has(viewName)) {
+          errors.push(
+            `${configName}: entity "${entityName}" references view "${entity.source.object}" ` +
+            `but no file exists in database/dbo/Views/. ` +
+            `SqlPackage deployments will not create or update this view.`
+          );
+        }
       }
-    }
 
-    console.log(`Checked ${viewEntityCount} view-backed DAB entities`);
-  }
-} catch (e) {
-  if (e.code === 'ENOENT') {
-    warnings.push('dab-config.json not found, skipping DAB cross-reference');
-  } else {
-    warnings.push(`Error reading dab-config.json: ${e.message}`);
+      console.log(`Checked ${viewEntityCount} view-backed entities in ${configName}`);
+    } catch (e) {
+      warnings.push(`Error reading ${configName}: ${e.message}`);
+    }
   }
 }
 

--- a/scripts/validate-schema.js
+++ b/scripts/validate-schema.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Schema Consistency Validator
+ *
+ * Ensures the sqlproj (source of truth) stays in sync with:
+ * - DAB config: every view-backed entity must have a sqlproj .sql file
+ * - Migrations: views created in migrations must also exist in sqlproj
+ *
+ * This prevents schema drift where views exist in the database but not
+ * in the sqlproj, causing SqlPackage deployments to miss updates.
+ *
+ * Usage:
+ *   node scripts/validate-schema.js
+ *
+ * Exit codes:
+ *   0 - All checks passed
+ *   1 - Errors found
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const projectDir = path.join(__dirname, '..');
+const viewsDir = path.join(projectDir, 'database', 'dbo', 'Views');
+const migrationsDir = path.join(projectDir, 'database', 'migrations');
+const dabConfigPath = path.join(projectDir, 'dab-config.json');
+
+let errors = [];
+let warnings = [];
+
+console.log('Validating schema consistency...');
+console.log('');
+
+// ============================================================================
+// Step 1: Inventory all sqlproj view files
+// ============================================================================
+
+const viewFiles = fs.readdirSync(viewsDir).filter(f => f.endsWith('.sql'));
+const sqlprojViews = new Map();
+
+for (const file of viewFiles) {
+  const content = fs.readFileSync(path.join(viewsDir, file), 'utf8');
+  // Extract view name from CREATE VIEW [dbo].[viewName] or CREATE VIEW dbo.viewName
+  const match = content.match(/CREATE\s+VIEW\s+\[?dbo\]?\.\[?(\w+)\]?/i);
+  if (match) {
+    sqlprojViews.set(match[1].toLowerCase(), file);
+  }
+}
+
+console.log(`Found ${sqlprojViews.size} views in sqlproj (database/dbo/Views/)`);
+
+// ============================================================================
+// Step 2: Check DAB config — every view-backed entity needs a sqlproj file
+// ============================================================================
+
+try {
+  const dabConfig = JSON.parse(fs.readFileSync(dabConfigPath, 'utf8'));
+
+  if (dabConfig.entities) {
+    let viewEntityCount = 0;
+
+    for (const [entityName, entity] of Object.entries(dabConfig.entities)) {
+      if (!entity.source || !entity.source.object) continue;
+
+      const sourceObj = entity.source.object;
+      // Check if this entity is backed by a view (dbo.v_*)
+      const viewMatch = sourceObj.match(/^dbo\.(v_\w+)$/i);
+      if (!viewMatch) continue;
+
+      viewEntityCount++;
+      const viewName = viewMatch[1].toLowerCase();
+
+      if (!sqlprojViews.has(viewName)) {
+        errors.push(
+          `DAB entity "${entityName}" references view "dbo.${viewMatch[1]}" ` +
+          `but no file exists in database/dbo/Views/. ` +
+          `SqlPackage deployments will not create or update this view.`
+        );
+      }
+    }
+
+    console.log(`Checked ${viewEntityCount} view-backed DAB entities`);
+  }
+} catch (e) {
+  if (e.code === 'ENOENT') {
+    warnings.push('dab-config.json not found, skipping DAB cross-reference');
+  } else {
+    warnings.push(`Error reading dab-config.json: ${e.message}`);
+  }
+}
+
+// ============================================================================
+// Step 3: Check migrations — views created in migrations need sqlproj files
+// ============================================================================
+
+if (fs.existsSync(migrationsDir)) {
+  const migrationFiles = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.sql'));
+
+  for (const file of migrationFiles) {
+    const content = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    // Find CREATE VIEW or CREATE OR ALTER VIEW statements
+    const viewCreates = content.matchAll(/CREATE\s+(?:OR\s+ALTER\s+)?VIEW\s+\[?dbo\]?\.\[?(\w+)\]?/gi);
+
+    for (const match of viewCreates) {
+      const viewName = match[1].toLowerCase();
+      if (!sqlprojViews.has(viewName)) {
+        errors.push(
+          `Migration "${file}" creates view "dbo.${match[1]}" ` +
+          `but no file exists in database/dbo/Views/. ` +
+          `The sqlproj must be the single source of truth for all schema objects.`
+        );
+      }
+    }
+  }
+
+  console.log(`Scanned ${migrationFiles.length} migration files`);
+}
+
+// ============================================================================
+// Output results
+// ============================================================================
+
+console.log('');
+
+if (errors.length > 0) {
+  console.log('\x1b[31m=== ERRORS ===\x1b[0m');
+  errors.forEach(e => console.log('\x1b[31m  \u2717\x1b[0m', e));
+  console.log('');
+}
+
+if (warnings.length > 0) {
+  console.log('\x1b[33m=== WARNINGS ===\x1b[0m');
+  warnings.forEach(w => console.log('\x1b[33m  \u26a0\x1b[0m', w));
+  console.log('');
+}
+
+if (errors.length === 0 && warnings.length === 0) {
+  console.log('\x1b[32m\u2713 Schema consistency checks passed\x1b[0m');
+  process.exit(0);
+} else if (errors.length > 0) {
+  console.log(`\x1b[31m\u2717 ${errors.length} error(s), ${warnings.length} warning(s)\x1b[0m`);
+  process.exit(1);
+} else {
+  console.log(`\x1b[32m\u2713 Passed with ${warnings.length} warning(s)\x1b[0m`);
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

- **5 prod views were stale** for 2-3 months (missing IsPersonal, ProjectId, ClassId, TermId, ReferenceNumber columns) because the Node.js deploy fallback can't update existing views
- **3 views had no sqlproj file** — created only in migrations, violating the single-source-of-truth rule
- **Root cause:** dev deployments used Node.js mode by default, which behaves differently from prod's SqlPackage mode

## Changes

### Fix stale sqlproj files
- `v_Employees.sql` — add 8 bank/Plaid verification columns (from migration 032)
- `v_OverdueInvoicesForReminder.sql` — **new file** (was only in migration 035)
- `v_BankTransactionsImport.sql` — **new file** (was only in migration 032)

### Unify deployment on SqlPackage (dev = prod)
- `deploy-db.js` — default to SqlPackage, error if missing instead of silent Node.js fallback
- `Dockerfile.db-init` — install .NET SDK + SqlPackage, build DACPAC, publish (replaces Node.js migration runner)

### CI drift prevention
- `validate-schema.js` — **new script** checks that every view in DAB config and every view created in migrations has a corresponding sqlproj `.sql` file
- `pr-check.yml` — runs schema validation on every PR

## After merge

Run the `deploy-database.yml` workflow to push the updated views to prod:
1. Dry-run first to review the diff
2. Publish to apply

## Test plan

- [x] `node scripts/validate-schema.js` passes (33 views, 27 DAB entities, 45 migrations scanned)
- [x] `dotnet build database/AccountingDB.sqlproj` succeeds (0 errors)
- [x] 141 unit tests pass
- [ ] Docker `db-init` builds and deploys via SqlPackage (test with `docker compose up`)
- [ ] Prod dry-run shows expected view updates only

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)