### PR TITLE
feat: Search transactions by amount (#591)

### DIFF
--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -172,14 +172,24 @@ export default function UnifiedTransactions() {
     // Apply search filter client-side
     if (filters.search) {
       const searchLower = filters.search.toLowerCase();
+      const searchNumeric = filters.search.replace(/[$,\s]/g, '');
+      const isAmountSearch =
+        searchNumeric !== '' && /^-?\d*\.?\d+$/.test(searchNumeric);
       data = data.filter(txn => {
         // Resolve category to account name for search
         const resolvedCategory = resolveCategory(txn, accountMap);
-        return (
+        if (
           txn.Description?.toLowerCase().includes(searchLower) ||
           txn.Merchant?.toLowerCase().includes(searchLower) ||
           resolvedCategory?.toLowerCase().includes(searchLower)
-        );
+        ) {
+          return true;
+        }
+        if (isAmountSearch && typeof txn.Amount === 'number') {
+          const absAmount = Math.abs(txn.Amount).toFixed(2);
+          return absAmount.includes(searchNumeric);
+        }
+        return false;
       });
     }
 

--- a/client/src/pages/UnifiedTransactions.tsx
+++ b/client/src/pages/UnifiedTransactions.tsx
@@ -187,7 +187,8 @@ export default function UnifiedTransactions() {
         }
         if (isAmountSearch && typeof txn.Amount === 'number') {
           const absAmount = Math.abs(txn.Amount).toFixed(2);
-          return absAmount.includes(searchNumeric);
+          const searchAbs = searchNumeric.replace(/^-/, '');
+          return absAmount.includes(searchAbs);
         }
         return false;
       });


### PR DESCRIPTION
Closes #591

## Summary
- `/transactions` search now matches the Amount column in addition to Description, Merchant, and Category.
- The input is stripped of `$`, `,`, and whitespace. If what remains is numeric, it's matched as a substring against `Math.abs(Amount).toFixed(2)`.
- So all of `$12,716.67`, `$12716.67`, `12,716.67`, `12716.67`, and `12716` find a transaction with `Amount = -12716.67` or `12716.67`.

## Behavior notes
- Matching is sign-agnostic by design (`Math.abs`) — searching `12716.67` finds both debits and credits of that size.
- Matching is substring-based on the 2-decimal form, so `12716` matches `12716.67` but also `127160.00` — consistent with how the existing text search works.
- Non-numeric searches behave exactly as before.

## Test plan
- [x] `npm run build` in `client/` passes
- [ ] In `/transactions`, enter `$12,716.67` — finds the expected row
- [ ] Enter `12716` — finds amounts starting with `12716`
- [ ] Enter a merchant name — still matches as before