### PR TITLE
chore: add .mcp.json.example template for fresh checkouts

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "workiq": {
+      "type": "stdio",
+      "command": "npx.cmd",
+      "args": [
+        "-y",
+        "@microsoft/workiq@latest",
+        "mcp"
+      ]
+    },
+    "mssql": {
+      "command": "<path-to>/mssql_mcp_server.exe",
+      "env": {
+        "MSSQL_HOST": "localhost,14330",
+        "MSSQL_DATABASE": "AccountingDB",
+        "MSSQL_USER": "sa",
+        "MSSQL_PASSWORD": "StrongPassword123"
+      }
+    },
+    "qbo": {
+      "type": "http",
+      "url": "http://localhost:8001/mcp"
+    }
+  }
+}

--- a/docs/claude-mcp.md
+++ b/docs/claude-mcp.md
@@ -13,6 +13,20 @@ Configuration lives in `.mcp.json` (gitignored — safe to contain credentials).
 
 ---
 
+## First-Time Setup
+
+`.mcp.json` is gitignored. On a fresh checkout, bootstrap it from the committed template:
+
+```bash
+cp .mcp.json.example .mcp.json
+# Update the MSSQL `command` path to your local mssql_mcp_server.exe
+node scripts/switch-mcp.js prod   # or: local
+```
+
+The switch script fills in prod creds from Key Vault on each run, so the template ships with local/sandbox defaults.
+
+---
+
 ## Quick Start: Switching Environments
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `.mcp.json.example` committed to the repo so new checkouts can bootstrap MCP config
- Adds a First-Time Setup section to `docs/claude-mcp.md` pointing at the template
- `.mcp.json` stays gitignored — template has local/sandbox defaults only; `switch-mcp.js prod` fills in real creds from Key Vault

## Why
Ran into this today: `.mcp.json` is gitignored, and `switch-mcp.js` only reads/writes an existing file. Fresh checkouts with no `.mcp.json` fail immediately. Template eliminates the "where do I get this file" step.

## Test plan
- [x] `.mcp.json.example` contains no real credentials (only local Docker sandbox defaults already in `docker-compose.yml`)
- [ ] `cp .mcp.json.example .mcp.json && node scripts/switch-mcp.js prod` works on a fresh checkout
- [ ] `node scripts/switch-mcp.js local` works from the same template

🤖 Generated with [Claude Code](https://claude.com/claude-code)